### PR TITLE
[Set up]  jacoco-reports CI 버전 업그레이드

### DIFF
--- a/.github/workflows/jacoco-reports.yml
+++ b/.github/workflows/jacoco-reports.yml
@@ -7,10 +7,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Run Coverage
         run: chmod +x gradlew && ./gradlew test && ./gradlew testCodeCoverageReport

--- a/api/acceptance-test/src/test/java/me/nalab/api/acceptancetest/jacoco/JacocoTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/api/acceptancetest/jacoco/JacocoTest.java
@@ -7,7 +7,11 @@ class JacocoTest {
 
 	@Test
 	void JACOCO_GRADLE_SET_UP(){
-		assertEquals(1, 1);
+		assertNotEquals("hello", getWorld());
+	}
+
+	private String getWorld(){
+		return "world";
 	}
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
jacoco-reports.yml 의 버전을 업그레이드 했습니다.

## 어떻게 해결했나요?
- [x] checkout의 버전을 v2 -> v3으로 업그레이드 했습니다.   
- [x] setup-java의 버전을 v1 -> v3으로 업그레이드 했습니다.    
- [x] setup-java의 jdk 벤더를 zulu(openjdk)로 변경했습니다.   
- [x] sonarcloud 설정 전에 넣은 jacoco용 테스트 코드로 인해서, main브랜치에서 sonarcloud scan 버그가 발생하는걸 해결했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
[actions/checkout](https://github.com/actions/checkout)   
[actions/setup-java](https://github.com/actions/setup-java#supported-distributions)