### PR TITLE
[chore] Jacoco branch rule 70%

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,13 @@ subprojects {
 					value = 'COVEREDRATIO'
 					minimum = 0.70
 				}
+
+				limit {
+					counter = 'BRANCH'
+					value = 'COVEREDRATIO'
+					minimum = 0.70
+				}
+
 			}
 
 		}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Jacoco test code coverage check에 `branch` rule을 추가 했습니다. 

## 어떻게 해결했나요?
- [x] Class 단위로 체크하고, `branch` rule이 70%를 넘지 못하면 test가 실패하도록 구성했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
[NOTION 기술문서](https://www.notion.so/depromeet/Test-Coverage-BRANCH-Counter-9862797c6e0441a894248683988bc0d1?pvs=4)
[Jacoco Coverage Counter 공식 문서](https://www.eclemma.org/jacoco/trunk/doc/counters.html)