### PR TITLE
[chore] api / acceptance-test dependency 수정

### DIFF
--- a/api/acceptance-test/build.gradle
+++ b/api/acceptance-test/build.gradle
@@ -18,6 +18,7 @@ dependencyManagement {
 }
 
 dependencies {
+    implementation project(':api')
 
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -12,8 +12,6 @@ repositories {
 }
 
 dependencies {
-    implementation project(':api:acceptance-test')
-
     implementation 'org.springframework.boot:spring-boot-starter'
 
     testImplementation platform('org.junit:junit-bom:5.9.1')


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
기존의 `api -> acceptance-test` 로 가던 dependency를 `api <- acceptance-test` 로 수정했습니다.

## 어떻게 해결했나요?
- [x] api/build.gradle의 `implementation project(':api:acceptance-test')` 를 삭제하고, api/acceptance-test/build.gradle에 `implementation project(':api')` 를 추가했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
[NOTION의 아키텍처 결정사항](https://www.notion.so/depromeet/207940cf46124f7ba2e58ef4d8a1eabd?pvs=4)