### PR TITLE
[fix] gradle build task 동작 안하는 버그 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,6 @@ import java.util.stream.Collectors
 
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '2.7.11'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id "org.sonarqube" version "4.0.0.2929"
 }
 


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`./gradlew build` 동작에서 spring configured를 찾을 수 없다는 버그를 해결했습니다

## 어떻게 해결했나요?
- [x] 이미, api/build.gradle이 다른 모듈을 통합하는 기능이 있으므로, build.gradle 파일에 spring관련 plugin을 삭제 했습니다. 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

## 참고자료
[Spring docs create multi module project](https://spring.io/guides/gs/multi-module/)