### PR TITLE
[chore] Jacoco Test Coverage 새로운 모듈 감지 자동화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,4 +110,13 @@ project(':support:jacoco'){
 						})
 		)
 	}
+
+	var allProjectsExcludeJacoco = allProjects.stream()
+			.filter(p -> !p.getDisplayName().contains('jacoco')
+					&& !p.getDisplayName().contains('root project'))
+			.collect(Collectors.toList())
+
+	dependencies {
+		implementation allProjectsExcludeJacoco
+	}
 }

--- a/support/jacoco/build.gradle
+++ b/support/jacoco/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'jacoco-report-aggregation'
     id 'org.springframework.boot' version '2.7.11' apply false
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
@@ -19,8 +18,6 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation project(':api:acceptance-test')
-
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
새로운 모듈을 만들면, support/jacoco/build.gradle에 `implementation project('새로운 모듈')` 이런 방식으로 등록해줘야 하는 불편함을 없애기 위해, 새로운 모듈을 자동으로 감지해서 Test coverage를 측정하도록 수정했습니다.

## 어떻게 해결했나요?
- [x] Jacoco 모듈이 `jacoco` 와 `root porject`를 제외한 모든 모듈을 implementation 받도록 gradle 스크립트를 구성했습니다.
- [x] 기존의 Jacoco 모듈에서 implementation 받던 api모듈과 없앴습니다 jacoco-aggregation-plugin을 (중복 버그)

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

## 참고자료
