### PR TITLE
[feat] : IdGenerator 생성

### DIFF
--- a/core/id-generator/build.gradle
+++ b/core/id-generator/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+}
+
+group 'me.nalab'
+version '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/core/id-generator/id-core/build.gradle
+++ b/core/id-generator/id-core/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '2.7.11' apply false
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+}
+
+group = 'me.nalab'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.9.1')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+    }
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/core/id-generator/id-core/src/main/java/me/nalab/core/idgenerator/idcore/IdGenerator.java
+++ b/core/id-generator/id-core/src/main/java/me/nalab/core/idgenerator/idcore/IdGenerator.java
@@ -1,0 +1,7 @@
+package me.nalab.core.idgenerator.idcore;
+
+public interface IdGenerator {
+
+	long generate();
+
+}

--- a/core/id-generator/id-generator-starter/build.gradle
+++ b/core/id-generator/id-generator-starter/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '2.7.11' apply false
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+}
+
+group = 'me.nalab'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':core:id-generator:id-core')
+    implementation project(':core:id-generator:mock-id-generator')
+
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    testImplementation platform('org.junit:junit-bom:5.9.1')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+    }
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/core/id-generator/id-generator-starter/src/main/java/me/nalab/core/idgenerator/starter/IdGeneratorConfigurer.java
+++ b/core/id-generator/id-generator-starter/src/main/java/me/nalab/core/idgenerator/starter/IdGeneratorConfigurer.java
@@ -1,0 +1,17 @@
+package me.nalab.core.idgenerator.starter;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+import me.nalab.core.idgenerator.mock.MockIdGenerator;
+
+@Configuration
+class IdGeneratorConfigurer {
+
+	@Bean
+	IdGenerator randomIdGenerator(){
+		return new MockIdGenerator();
+	}
+
+}

--- a/core/id-generator/id-generator-starter/src/test/java/me/nalab/core/idgenerator/starter/IdGeneratorConfigurerTest.java
+++ b/core/id-generator/id-generator-starter/src/test/java/me/nalab/core/idgenerator/starter/IdGeneratorConfigurerTest.java
@@ -1,0 +1,27 @@
+package me.nalab.core.idgenerator.starter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IdGeneratorConfigurer.class)
+class IdGeneratorConfigurerTest {
+
+	@Autowired
+	private IdGenerator idGenerator;
+
+	@Test
+	@DisplayName("IdGenerator 등록 유무 성공 테스트")
+	void ID_GENERATOR_REGISTERED_SUCCESS(){
+		assertNotNull(idGenerator);
+	}
+
+}

--- a/core/id-generator/mock-id-generator/build.gradle
+++ b/core/id-generator/mock-id-generator/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '2.7.11' apply false
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+}
+
+group = 'me.nalab'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':core:id-generator:id-core')
+
+    testImplementation platform('org.junit:junit-bom:5.9.1')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+    }
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/core/id-generator/mock-id-generator/src/main/java/me/nalab/core/idgenerator/mock/MockIdGenerator.java
+++ b/core/id-generator/mock-id-generator/src/main/java/me/nalab/core/idgenerator/mock/MockIdGenerator.java
@@ -1,0 +1,16 @@
+package me.nalab.core.idgenerator.mock;
+
+import java.util.Random;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+
+public class MockIdGenerator implements IdGenerator {
+
+	private static final Random RANDOM = new Random();
+
+	@Override
+	public long generate() {
+		return RANDOM.nextLong();
+	}
+
+}

--- a/core/id-generator/mock-id-generator/src/test/java/me/nalab/core/idgenerator/mock/MockIdGeneratorTest.java
+++ b/core/id-generator/mock-id-generator/src/test/java/me/nalab/core/idgenerator/mock/MockIdGeneratorTest.java
@@ -1,0 +1,24 @@
+package me.nalab.core.idgenerator.mock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+
+class MockIdGeneratorTest {
+
+	private final IdGenerator mockIdGenerator;
+
+	public MockIdGeneratorTest() {
+		this.mockIdGenerator = new MockIdGenerator();
+	}
+
+	@Test
+	@DisplayName("Id 생성 성공 테스트")
+	void CREATE_ID_SUCCESS(){
+		assertInstanceOf(Long.class, mockIdGenerator.generate());
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,3 +13,8 @@ include 'survey'
 
 include 'auth'
 
+include 'core:id-generator'
+include 'core:id-generator:id-core'
+include 'core:id-generator:mock-id-generator'
+include 'core:id-generator:id-generator-starter'
+


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
ID generator 기능을 개발했습니다.

`core:id-generator:id-generator-starter` 를 주입받고, `IdGenerator` 의 `.generate()` 메소드를 사용해서, ID를 생성하면 됩니다.

## 어떻게 해결했나요?
- [x] Id generator 인터페이스를 `core:id-generator:id-core` 에 생성했습니다.
- [x] `core:id-generator:id-core`의 Id generator 인터페이스를 구현하는 클래스 `MockIdGenerator` 를 `core:id-generator:mock-id-generator` 에 생성했습니다.
- [x] `core:id-generator:id-core`의 구현체를 spring bean으로 등록하는 모듈 `id-generator-starter` 를 생성했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
