### PR TITLE
[fix] `id-generator-core` 에 대한 의존성 전이

### DIFF
--- a/core/id-generator/id-generator-starter/src/main/java/module-info.java
+++ b/core/id-generator/id-generator-starter/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module luffy.core.id.generator.id.generator.starter.main {
-	requires luffy.core.id.generator.id.core.main;
+	requires transitive luffy.core.id.generator.id.core.main;
 	requires luffy.core.id.generator.mock.id.generator.main;
 
 	requires spring.boot;


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
id-generator-core에 대한 의존성이, 사용자에게 전이 되도록 수정했습니다.

## 어떻게 해결했나요?
- [x] id-generator-starter 의 module-info에 transitive를 추가했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
[jigsaw project](https://www.baeldung.com/java-9-modularity)