### PR TITLE
[feat] `Survey` domain model

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ include 'support'
 include 'support:jacoco'
 
 include 'survey'
+include 'survey:domain'
 
 include 'auth'
 

--- a/survey/domain/.gitignore
+++ b/survey/domain/.gitignore
@@ -1,0 +1,42 @@
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
@@ -1,0 +1,14 @@
+package me.nalab.survey.domain.survey;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Choice {
+
+	private final Long id;
+	private final String content;
+	private final Integer order;
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
@@ -11,4 +11,12 @@ public class Choice {
 	private final String content;
 	private final Integer order;
 
+	@Override
+	public String toString() {
+		return "Choice{" +
+			"id=" + id +
+			", content='" + content + '\'' +
+			", order=" + order +
+			'}';
+	}
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
@@ -1,5 +1,7 @@
 package me.nalab.survey.domain.survey;
 
+import java.util.Objects;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,4 +22,18 @@ public class Choice {
 			'}';
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if(this == o)
+			return true;
+		if(o == null || getClass() != o.getClass())
+			return false;
+		Choice choice = (Choice)o;
+		return id.equals(choice.id) && content.equals(choice.content) && order.equals(choice.order);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, content, order);
+	}
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
@@ -19,4 +19,5 @@ public class Choice {
 			", order=" + order +
 			'}';
 	}
+
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -27,4 +27,5 @@ public class ChoiceFormQuestion extends FormQuestionable {
 			", questionType=" + questionType +
 			'}';
 	}
+
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -1,6 +1,7 @@
 package me.nalab.survey.domain.survey;
 
 import java.util.List;
+import java.util.Objects;
 
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -26,6 +27,25 @@ public class ChoiceFormQuestion extends FormQuestionable {
 			", order=" + order +
 			", questionType=" + questionType +
 			'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if(this == o)
+			return true;
+		if(!(o instanceof FormQuestionable))
+			return false;
+		ChoiceFormQuestion that = (ChoiceFormQuestion)o;
+		return choiceList.equals(that.choiceList) && maxSelectionCount.equals(that.maxSelectionCount)
+			&& choiceFormQuestionType == that.choiceFormQuestionType && id.equals(that.id) && title.equals(that.title)
+			&& createdAt.equals(that.createdAt) && updatedAt.equals(
+			that.updatedAt) && order.equals(that.order) && questionType == that.questionType;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(choiceList, maxSelectionCount, choiceFormQuestionType, id, title, createdAt, updatedAt,
+			order, questionType);
 	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -13,4 +13,18 @@ public class ChoiceFormQuestion extends FormQuestionable {
 	private final Integer maxSelectionCount;
 	private final ChoiceFormQuestionType choiceFormQuestionType;
 
+	@Override
+	public String toString() {
+		return "ChoiceFormQuestion{" +
+			"choiceList=" + choiceList +
+			", maxSelectionCount=" + maxSelectionCount +
+			", choiceFormQuestionType=" + choiceFormQuestionType +
+			", id=" + id +
+			", title='" + title + '\'' +
+			", createdAt=" + createdAt +
+			", updatedAt=" + updatedAt +
+			", order=" + order +
+			", questionType=" + questionType +
+			'}';
+	}
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -1,0 +1,16 @@
+package me.nalab.survey.domain.survey;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+public class ChoiceFormQuestion extends FormQuestionable {
+
+	private final List<Choice> choiceList;
+	private final Integer maxSelectionCount;
+	private final ChoiceFormQuestionType choiceFormQuestionType;
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestionType.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestionType.java
@@ -1,0 +1,25 @@
+package me.nalab.survey.domain.survey;
+
+/**
+ * 객관식 질문의 타입들
+ */
+public enum ChoiceFormQuestionType {
+
+	/**
+	 * 기본타입 `나와의 협업 경험 유무`
+	 */
+	COLLABORATION_EXPERIENCE,
+	/**
+	 * 기본타입 `리뷰어의 직군`
+	 */
+	POSITION,
+	/**
+	 * 기본타입 `나의 성향`
+	 */
+	TENDENCY,
+	/**
+	 * 커스텀 타입 `타겟이 생성한 객관식 질문`
+	 */
+	CUSTOM,
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.domain.survey;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+public abstract class FormQuestionable {
+
+	protected final Long id;
+	protected final String title;
+	protected final LocalDateTime createdAt;
+	protected final LocalDateTime updatedAt;
+	protected final Integer order;
+	protected final QuestionType questionType;
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
@@ -1,6 +1,7 @@
 package me.nalab.survey.domain.survey;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/QuestionType.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/QuestionType.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.domain.survey;
+
+/**
+ * 질문의 유형들
+ */
+public enum QuestionType {
+
+	/**
+	 * 객관식 질문
+	 */
+	CHOICE,
+	/**
+	 * 주관식 질문
+	 */
+	SHORT,
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
@@ -9,4 +9,16 @@ public class ShortFormQuestion extends FormQuestionable {
 
 	private final ShortFormQuestionType shortFormQuestionType;
 
+	@Override
+	public String toString() {
+		return "ShortFormQuestion{" +
+			"shortFormQuestionType=" + shortFormQuestionType +
+			", id=" + id +
+			", title='" + title + '\'' +
+			", createdAt=" + createdAt +
+			", updatedAt=" + updatedAt +
+			", order=" + order +
+			", questionType=" + questionType +
+			'}';
+	}
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
@@ -1,5 +1,7 @@
 package me.nalab.survey.domain.survey;
 
+import java.util.Objects;
+
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -20,6 +22,23 @@ public class ShortFormQuestion extends FormQuestionable {
 			", order=" + order +
 			", questionType=" + questionType +
 			'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if(this == o)
+			return true;
+		if(!(o instanceof FormQuestionable))
+			return false;
+		ShortFormQuestion that = (ShortFormQuestion)o;
+		return shortFormQuestionType == that.shortFormQuestionType && id.equals(that.id) && title.equals(that.title)
+			&& createdAt.equals(that.createdAt) && updatedAt.equals(
+			that.updatedAt) && order.equals(that.order) && questionType == that.questionType;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(shortFormQuestionType, id, title, createdAt, updatedAt, order, questionType);
 	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
@@ -1,0 +1,12 @@
+package me.nalab.survey.domain.survey;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+public class ShortFormQuestion extends FormQuestionable {
+
+	private final ShortFormQuestionType shortFormQuestionType;
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
@@ -21,4 +21,5 @@ public class ShortFormQuestion extends FormQuestionable {
 			", questionType=" + questionType +
 			'}';
 	}
+
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestionType.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestionType.java
@@ -1,0 +1,21 @@
+package me.nalab.survey.domain.survey;
+
+/**
+ * 주관식 질문의 타입들
+ */
+public enum ShortFormQuestionType {
+
+	/**
+	 * 기본타입 `나의 강점`
+	 */
+	STRENGTH,
+	/**
+	 * 기본타입 `나의 약점`
+	 */
+	WEAKNESS,
+	/**
+	 * 커스텀 타입 `타겟이 생성한 주관식 질문`
+	 */
+	CUSTOM,
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -2,6 +2,7 @@ package me.nalab.survey.domain.survey;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +24,22 @@ public class Survey {
 			", updatedAt=" + updatedAt +
 			", formQuestionableList=" + formQuestionableList +
 			'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if(this == o)
+			return true;
+		if(!(o instanceof Survey))
+			return false;
+		Survey survey = (Survey)o;
+		return id.equals(survey.id) && createdAt.equals(survey.createdAt) && updatedAt.equals(survey.updatedAt)
+			&& formQuestionableList.equals(survey.formQuestionableList);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, createdAt, updatedAt, formQuestionableList);
 	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -15,4 +15,13 @@ public class Survey {
 	private final LocalDateTime updatedAt;
 	private final List<FormQuestionable> formQuestionableList;
 
+	@Override
+	public String toString() {
+		return "Survey{" +
+			"id=" + id +
+			", createdAt=" + createdAt +
+			", updatedAt=" + updatedAt +
+			", formQuestionableList=" + formQuestionableList +
+			'}';
+	}
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -1,0 +1,18 @@
+package me.nalab.survey.domain.survey;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Survey {
+
+	private final Long id;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+	private final List<FormQuestionable> formQuestionableList;
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -24,4 +24,5 @@ public class Survey {
 			", formQuestionableList=" + formQuestionableList +
 			'}';
 	}
+
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -22,4 +22,5 @@ public class Target {
 			", nickname='" + nickname + '\'' +
 			'}';
 	}
+
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -1,6 +1,7 @@
 package me.nalab.survey.domain.target;
 
 import java.util.List;
+import java.util.Objects;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +22,21 @@ public class Target {
 			", surveyList=" + surveyList +
 			", nickname='" + nickname + '\'' +
 			'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if(this == o)
+			return true;
+		if(!(o instanceof Target))
+			return false;
+		Target target = (Target)o;
+		return id.equals(target.id) && surveyList.equals(target.surveyList) && nickname.equals(target.nickname);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, surveyList, nickname);
 	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.domain.target;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import me.nalab.survey.domain.survey.Survey;
+
+@Builder
+@Getter
+public class Target {
+
+	private final Long id;
+	private final List<Survey> surveyList;
+	private final String nickname;
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -14,4 +14,12 @@ public class Target {
 	private final List<Survey> surveyList;
 	private final String nickname;
 
+	@Override
+	public String toString() {
+		return "Target{" +
+			"id=" + id +
+			", surveyList=" + surveyList +
+			", nickname='" + nickname + '\'' +
+			'}';
+	}
 }

--- a/survey/domain/src/main/java/module-info.java
+++ b/survey/domain/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module luffy.survey.domain.main {
+
+	exports me.nalab.survey.domain.survey;
+	exports me.nalab.survey.domain.target;
+
+	requires lombok;
+
+}

--- a/survey/domain/src/test/java/me/nalab/survey/domain/AbstractSurveySources.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/AbstractSurveySources.java
@@ -1,0 +1,84 @@
+package me.nalab.survey.domain;
+
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+import me.nalab.survey.domain.survey.Choice;
+import me.nalab.survey.domain.survey.ChoiceFormQuestion;
+import me.nalab.survey.domain.survey.ChoiceFormQuestionType;
+import me.nalab.survey.domain.survey.FormQuestionable;
+import me.nalab.survey.domain.survey.QuestionType;
+import me.nalab.survey.domain.survey.ShortFormQuestion;
+import me.nalab.survey.domain.survey.ShortFormQuestionType;
+import me.nalab.survey.domain.survey.Survey;
+
+public abstract class AbstractSurveySources {
+
+	protected static Stream<Arguments> surveyCreateSuccessSources() {
+		return Stream.of(
+			of(
+				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now())
+				, (Supplier<List<FormQuestionable>>)() -> List.of(
+					choiceFormQuestion(2L, "choice-form1", LocalDateTime.now(), LocalDateTime.now(), 1,
+						List.of(choice(3L, 1, "choice1"), choice(4L, 2, "choice2")))
+					, shortFormQuestion(5L, "short-form2", LocalDateTime.now(), LocalDateTime.now(), 2
+					)
+				)
+			)
+		);
+	}
+
+	static Function<Supplier<List<FormQuestionable>>, Survey> surveyFunction(Long id, LocalDateTime createAt,
+		LocalDateTime updatedAt) {
+		return T -> Survey.builder()
+			.id(id)
+			.createdAt(createAt)
+			.updatedAt(updatedAt)
+			.formQuestionableList(T.get())
+			.build();
+	}
+
+	static FormQuestionable choiceFormQuestion(Long id, String title, LocalDateTime createdAt, LocalDateTime updatedAt,
+		Integer order, List<Choice> choiceList) {
+		return ChoiceFormQuestion.builder()
+			.id(id)
+			.title(title)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.order(order)
+			.questionType(QuestionType.CHOICE)
+			.choiceFormQuestionType(ChoiceFormQuestionType.CUSTOM)
+			.choiceList(choiceList)
+			.build();
+	}
+
+	static FormQuestionable shortFormQuestion(Long id, String title, LocalDateTime createdAt, LocalDateTime updatedAt,
+		Integer order) {
+		return ShortFormQuestion.builder()
+			.id(id)
+			.title(title)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.order(order)
+			.questionType(QuestionType.SHORT)
+			.shortFormQuestionType(ShortFormQuestionType.CUSTOM)
+			.build();
+	}
+
+	static Choice choice(Long id, Integer order, String content) {
+		return Choice.builder()
+			.id(id)
+			.order(order)
+			.content(content)
+			.build();
+	}
+
+
+}

--- a/survey/domain/src/test/java/me/nalab/survey/domain/AbstractTargetSources.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/AbstractTargetSources.java
@@ -1,0 +1,43 @@
+package me.nalab.survey.domain;
+
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+import me.nalab.survey.domain.survey.FormQuestionable;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.domain.target.Target;
+
+public abstract class AbstractTargetSources extends AbstractSurveySources {
+
+	protected static Stream<Arguments> targetCreateSuccessSources() {
+		return Stream.of(
+			of(
+				targetFunction(10L, "mike"),
+				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now())
+				, (Supplier<List<FormQuestionable>>)() -> List.of(
+					choiceFormQuestion(2L, "choice-form1", LocalDateTime.now(), LocalDateTime.now(), 1,
+						List.of(choice(3L, 1, "choice1"), choice(4L, 2, "choice2")))
+					, shortFormQuestion(5L, "short-form2", LocalDateTime.now(), LocalDateTime.now(), 2
+					)
+				)
+			)
+		);
+	}
+
+	static Function<List<Survey>, Target> targetFunction(Long id,
+		String nickname) {
+		return T -> Target.builder()
+			.id(id)
+			.nickname(nickname)
+			.surveyList(T)
+			.build();
+	}
+
+}

--- a/survey/domain/src/test/java/me/nalab/survey/domain/survey/AbstractSurveyDomainTest.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/survey/AbstractSurveyDomainTest.java
@@ -1,0 +1,38 @@
+package me.nalab.survey.domain.survey;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import me.nalab.survey.domain.AbstractSurveySources;
+
+class AbstractSurveyDomainTest extends AbstractSurveySources {
+
+	private static final Logger LOGGER = Logger.getLogger(AbstractSurveyDomainTest.class.getSimpleName());
+
+	@ParameterizedTest
+	@MethodSource("surveyCreateSuccessSources")
+	void SURVEY_CREATE_SUCCESS(Function<Supplier<List<FormQuestionable>>, Survey> surveyCreate,
+		Supplier<List<FormQuestionable>> formQuestionSupplier) {
+
+		assertDoesNotThrow(() -> surveyCreate.apply(formQuestionSupplier));
+	}
+
+	@ParameterizedTest
+	@MethodSource("surveyCreateSuccessSources")
+	void SURVEY_TO_STRING_LOGGING_SUCCESS(Function<Supplier<List<FormQuestionable>>, Survey> surveyCreate,
+		Supplier<List<FormQuestionable>> formQuestionSupplier) {
+
+		Survey survey = surveyCreate.apply(formQuestionSupplier);
+		assertNotNull(survey);
+		LOGGER.info(survey.toString());
+	}
+
+}

--- a/survey/domain/src/test/java/me/nalab/survey/domain/target/TargetDomainTest.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/target/TargetDomainTest.java
@@ -1,0 +1,51 @@
+package me.nalab.survey.domain.target;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import me.nalab.survey.domain.AbstractTargetSources;
+import me.nalab.survey.domain.survey.FormQuestionable;
+import me.nalab.survey.domain.survey.Survey;
+
+class TargetDomainTest extends AbstractTargetSources {
+
+	private static final Logger LOGGER = Logger.getLogger(TargetDomainTest.class.getSimpleName());
+
+	@ParameterizedTest
+	@MethodSource("targetCreateSuccessSources")
+	void CREATE_TARGET_SUCCESS(Function<List<Survey>, Target> targetCreate,
+		Function<Supplier<List<FormQuestionable>>, Survey> surveyCreate,
+		Supplier<List<FormQuestionable>> formQuestionSupplier) {
+
+		assertDoesNotThrow(() -> targetCreate.apply(
+				List.of(
+					surveyCreate.apply(formQuestionSupplier)
+				)
+			)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("targetCreateSuccessSources")
+	void TARGET_TO_STRING_LOGGING_SUCCESS(Function<List<Survey>, Target> targetCreate,
+		Function<Supplier<List<FormQuestionable>>, Survey> surveyCreate,
+		Supplier<List<FormQuestionable>> formQuestionSupplier) {
+
+		Target target = targetCreate.apply(
+			List.of(
+				surveyCreate.apply(formQuestionSupplier)
+			)
+		);
+		assertNotNull(target);
+		LOGGER.info(target.toString());
+	}
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Survey domain의 model을 추가했습니다.

## 어떻게 해결했나요?
- [x] `survey` 도메인과 관련된 모듈들을 추가했습니다.
- [x] `module-info`에 `survey`도메인 관련 정보를 exports시켰습니다.  
- [x] `survey` , `target` domain의 생성 및 로깅 테스트 추가 afeae01d8f0ebb297c3e8932e84b1fb803ff878d
 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
