### PR TITLE
[feat] : 인증 테스트 더블 `auth:mock` 모듈 추가

### DIFF
--- a/auth/mock/build.gradle
+++ b/auth/mock/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+}

--- a/auth/mock/src/main/java/me/nalab/auth/mock/api/MockUserRegisterEvent.java
+++ b/auth/mock/src/main/java/me/nalab/auth/mock/api/MockUserRegisterEvent.java
@@ -1,0 +1,18 @@
+package me.nalab.auth.mock.api;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 인증이 필요한 API를 테스트 할때, 이 Event를 Publish하면,
+ * expectedToken이 Authorization 헤더로 주어졌을때, expectedId를
+ * Controller의 @RequestAttribute("logined") 로 받을 수 있습니다.
+ */
+@Builder
+@Getter
+public class MockUserRegisterEvent {
+
+	private final Long expectedId;
+	private final String expectedToken;
+
+}

--- a/auth/mock/src/main/java/me/nalab/auth/mock/config/MockAuthConfigurer.java
+++ b/auth/mock/src/main/java/me/nalab/auth/mock/config/MockAuthConfigurer.java
@@ -1,0 +1,34 @@
+package me.nalab.auth.mock.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import me.nalab.auth.mock.interceptor.MockAuthInterceptor;
+
+@Configuration
+public class MockAuthConfigurer implements WebMvcConfigurer {
+
+	private static final String[] INTERCEPTOR_URLS = {
+		"/v1/surveys",
+		"/v1/users",
+		"/v1/surveys-id",
+		"/v1/questions",
+		"/v1/feedbacks/*",
+		"/v1/feedbacks",
+	};
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(mockAuthInterceptor())
+			.addPathPatterns(INTERCEPTOR_URLS);
+	}
+
+	@Bean
+	HandlerInterceptor mockAuthInterceptor() {
+		return new MockAuthInterceptor();
+	}
+
+}

--- a/auth/mock/src/main/java/me/nalab/auth/mock/interceptor/CannotValidMockTokenException.java
+++ b/auth/mock/src/main/java/me/nalab/auth/mock/interceptor/CannotValidMockTokenException.java
@@ -1,0 +1,4 @@
+package me.nalab.auth.mock.interceptor;
+
+public class CannotValidMockTokenException extends RuntimeException {
+}

--- a/auth/mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
+++ b/auth/mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
@@ -1,0 +1,36 @@
+package me.nalab.auth.mock.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+
+public class MockAuthInterceptor implements HandlerInterceptor {
+
+	private String expectedToken = null;
+	private Long expectedId = null;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		String token = request.getHeader("Authorization");
+		throwIfCannotValidToken(token);
+		request.setAttribute("logined", expectedId);
+		return true;
+	}
+
+	private void throwIfCannotValidToken(String token) {
+		if(expectedToken == null || expectedId == null || !expectedToken.equals(token)) {
+			throw new CannotValidMockTokenException();
+		}
+	}
+
+	@EventListener(MockUserRegisterEvent.class)
+	void mockUserRegister(MockUserRegisterEvent mockUserRegisterEvent) {
+		expectedToken = mockUserRegisterEvent.getExpectedToken();
+		expectedId = mockUserRegisterEvent.getExpectedId();
+	}
+
+}

--- a/auth/mock/src/main/java/module-info.java
+++ b/auth/mock/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module luffy.auth.mock.main {
+
+	requires spring.context;
+	requires spring.webmvc;
+	requires org.apache.tomcat.embed.core;
+	requires lombok;
+
+	exports me.nalab.auth.mock.api;
+	exports me.nalab.auth.mock.config;
+
+}

--- a/auth/mock/src/test/java/me/nalab/auth/mock/interceptor/AbstractMockAuthTest.java
+++ b/auth/mock/src/test/java/me/nalab/auth/mock/interceptor/AbstractMockAuthTest.java
@@ -1,0 +1,53 @@
+package me.nalab.auth.mock.interceptor;
+
+import java.io.UnsupportedEncodingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+abstract class AbstractMockAuthTest {
+
+	@Autowired
+	MockMvc mvc;
+
+	Long call(HttpMethod httpMethod, String url, String token) throws Exception {
+		if(httpMethod == HttpMethod.GET) {
+			return get(url, token);
+		}
+		if(httpMethod == HttpMethod.POST) {
+			return post(url, token);
+		}
+		throw new IllegalStateException("Cannot find correct test method for \"" + httpMethod.name() + "\"");
+	}
+
+	private Long get(String url, String token) throws Exception {
+		ResultActions resultActions = mvc.perform(MockMvcRequestBuilders
+			.get(url)
+			.header("Authorization", token)
+			.accept(MediaType.ALL)
+		);
+
+		return extractLoginId(resultActions);
+	}
+
+	private Long post(String url, String token) throws Exception {
+		ResultActions resultActions = mvc.perform(MockMvcRequestBuilders
+			.post(url)
+			.header("Authorization", token)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content("{\"mock\" : 1}")
+			.accept(MediaType.ALL)
+		);
+
+		return extractLoginId(resultActions);
+	}
+
+	private Long extractLoginId(ResultActions resultActions) throws UnsupportedEncodingException {
+		return Long.valueOf(resultActions.andReturn().getResponse().getContentAsString());
+	}
+
+}

--- a/auth/mock/src/test/java/me/nalab/auth/mock/interceptor/MockAuthInterceptorTest.java
+++ b/auth/mock/src/test/java/me/nalab/auth/mock/interceptor/MockAuthInterceptorTest.java
@@ -1,0 +1,87 @@
+package me.nalab.auth.mock.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.ContextConfiguration;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.auth.mock.config.MockAuthConfigurer;
+
+@WebMvcTest
+@ContextConfiguration(classes = {MockAuthConfigurer.class, MockAuthInterceptorTestController.class})
+class MockAuthInterceptorTest extends AbstractMockAuthTest {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@ParameterizedTest
+	@MethodSource("successSources")
+	@DisplayName("Mock 로그인 성공 테스트")
+	void SUCCESS_LOGIN(HttpMethod httpMethod, String url, String expectedToken, Long expectedId) throws
+		Exception {
+		// given
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedId(expectedId)
+			.expectedToken(expectedToken)
+			.build()
+		);
+
+		// when
+		Long id = call(httpMethod, url, expectedToken);
+
+		// then
+		assertEquals(expectedId, id);
+	}
+
+	@ParameterizedTest
+	@MethodSource("failSources")
+	@DisplayName("Mock 로그인 실패 테스트")
+	void FAIL_LOGIN(HttpMethod httpMethod, String url, String requestToken, String expectedToken,
+		Long expectedId) {
+		// given
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedId(expectedId)
+			.expectedToken(expectedToken)
+			.build()
+		);
+
+		// when & then
+		assertThrows(Exception.class, () -> call(httpMethod, url, requestToken));
+	}
+
+	static Stream<Arguments> successSources() {
+		return Stream.of(
+			of(HttpMethod.POST, "/v1/surveys", "token1", 1L)
+			, of(HttpMethod.GET, "/v1/users", "token2", 2L)
+			, of(HttpMethod.GET, "/v1/surveys-id", "token3", 3L)
+			, of(HttpMethod.GET, "/v1/questions?survey-id=4", "token4", 4L)
+			, of(HttpMethod.GET, "/v1/feedbacks?survey-id=5", "token5", 5L)
+			, of(HttpMethod.GET, "/v1/feedbacks/6", "token6", 6L)
+			, of(HttpMethod.GET, "/v1/feedbacks/summary?survey-id=7", "token7", 7L)
+			, of(HttpMethod.GET, "/v1/feedbacks?question-id=8", "token8", 8L)
+		);
+	}
+
+	static Stream<Arguments> failSources() {
+		return Stream.of(
+			of(HttpMethod.POST, "/v1/surveys", null, null, null)
+			, of(HttpMethod.GET, "/v1/users", null, "token2", 2L)
+			, of(HttpMethod.GET, "/v1/users", "token3", null, 3L)
+			, of(HttpMethod.GET, "/v1/users", "token4", "4nekot", 4L)
+			, of(HttpMethod.GET, "/v1/users", "token4", "token4", null)
+		);
+	}
+
+}

--- a/auth/mock/src/test/java/me/nalab/auth/mock/interceptor/MockAuthInterceptorTestController.java
+++ b/auth/mock/src/test/java/me/nalab/auth/mock/interceptor/MockAuthInterceptorTestController.java
@@ -1,0 +1,39 @@
+package me.nalab.auth.mock.interceptor;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class MockAuthInterceptorTestController {
+
+	@GetMapping(path = {
+		"/v1/users",
+		"/v1/surveys-id",
+		"/v1/questions",
+		"/v1/feedbacks",
+		"/v1/feedbacks/{feedback-id}",
+		"/v1/feedbacks/summary",
+		"/v1/feedbacks?question-id",
+	})
+	Long returnLoginId(@RequestAttribute("logined") Long loginId,
+		@RequestParam(name = "survey-id", required = false) Long surveyId,
+		@RequestParam(name = "question-id", required = false) Long questionId,
+		@PathVariable(name = "feedback-id", required = false) Long feedbackId) {
+		return loginId;
+	}
+
+	@PostMapping(path = {
+		"/v1/surveys",
+	})
+	Long returnLoginId(@RequestAttribute("logined") Long loginId,
+		@RequestBody Map<String, Object> someBody) {
+		return loginId;
+	}
+}

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -9,7 +9,7 @@ file('coverage-exclude.luffy').withInputStream(){
             .collect(Collectors.toList()))
 }
 
-subprojects {
+allprojects {
     apply plugin: 'java-library'
     apply plugin: 'jacoco'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,7 @@ include 'support:jacoco'
 include 'survey'
 
 include 'auth'
+include 'auth:mock'
 
 include 'core:id-generator'
 include 'core:id-generator:id-core'


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
인수테스트에서, 인증 기능이 구현되기 전까지, 테스트에 사용가능한 데스트 더블 모듈을 추가했습니다.

## 어떻게 해결했나요?
- [x] `Spring Event Publisher` 를 이용해 자신이 지정한 토큰과 Header의 `Authorization` 의 value가 같다면, 지정한 유저 id가 컨트롤러의 `@RequestAttribute("logined")` 로 들어가게 만들었습니다.
- [x] 테스트 더블용 [`인증 인터셉터`](auth/mock/src/main/java/me/nalab/auth/mock/api/MockUserRegisterEvent.java) 를 추가했습니다.
- [x] 인증이 필요한 모든 url에 [`인증 인터셉터`](auth/mock/src/main/java/me/nalab/auth/mock/api/MockUserRegisterEvent.java) 를 등록하는 [`설정 파일`](auth/mock/src/main/java/me/nalab/auth/mock/config/MockAuthConfigurer.java) 을 추가했습니다.
- [x] 관련 테스트 코드를 작성했습니다. 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
