### PR TITLE
[feat] `Method` 단위 coverage exclude 

### DIFF
--- a/core/meta/src/main/java/me/nalab/core/meta/coverage/Generated.java
+++ b/core/meta/src/main/java/me/nalab/core/meta/coverage/Generated.java
@@ -1,0 +1,13 @@
+package me.nalab.core.meta.coverage;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface Generated {
+}

--- a/core/meta/src/main/java/module-info.java
+++ b/core/meta/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module luffy.core.meta.main {
+
+	exports me.nalab.core.meta.coverage;
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ rootProject.name = 'luffy'
 
 include 'core'
 include 'core:data'
+include 'core:meta'
 
 include 'api'
 include 'api:acceptance-test'

--- a/survey/domain/build.gradle
+++ b/survey/domain/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(':core:meta')
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import lombok.Builder;
 import lombok.Getter;
+import me.nalab.core.meta.coverage.Generated;
 
 @Builder
 @Getter
@@ -23,6 +24,7 @@ public class Choice {
 	}
 
 	@Override
+	@Generated
 	public boolean equals(Object o) {
 		if(this == o)
 			return true;
@@ -33,6 +35,7 @@ public class Choice {
 	}
 
 	@Override
+	@Generated
 	public int hashCode() {
 		return Objects.hash(id, content, order);
 	}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
+import me.nalab.core.meta.coverage.Generated;
 
 @SuperBuilder
 @Getter
@@ -30,6 +31,7 @@ public class ChoiceFormQuestion extends FormQuestionable {
 	}
 
 	@Override
+	@Generated
 	public boolean equals(Object o) {
 		if(this == o)
 			return true;
@@ -43,6 +45,7 @@ public class ChoiceFormQuestion extends FormQuestionable {
 	}
 
 	@Override
+	@Generated
 	public int hashCode() {
 		return Objects.hash(choiceList, maxSelectionCount, choiceFormQuestionType, id, title, createdAt, updatedAt,
 			order, questionType);

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
+import me.nalab.core.meta.coverage.Generated;
 
 @SuperBuilder
 @Getter
@@ -25,6 +26,7 @@ public class ShortFormQuestion extends FormQuestionable {
 	}
 
 	@Override
+	@Generated
 	public boolean equals(Object o) {
 		if(this == o)
 			return true;
@@ -37,6 +39,7 @@ public class ShortFormQuestion extends FormQuestionable {
 	}
 
 	@Override
+	@Generated
 	public int hashCode() {
 		return Objects.hash(shortFormQuestionType, id, title, createdAt, updatedAt, order, questionType);
 	}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import lombok.Builder;
 import lombok.Getter;
+import me.nalab.core.meta.coverage.Generated;
 
 @Builder
 @Getter
@@ -27,6 +28,7 @@ public class Survey {
 	}
 
 	@Override
+	@Generated
 	public boolean equals(Object o) {
 		if(this == o)
 			return true;
@@ -38,6 +40,7 @@ public class Survey {
 	}
 
 	@Override
+	@Generated
 	public int hashCode() {
 		return Objects.hash(id, createdAt, updatedAt, formQuestionableList);
 	}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 
 import lombok.Builder;
 import lombok.Getter;
+import me.nalab.core.meta.coverage.Generated;
 import me.nalab.survey.domain.survey.Survey;
 
 @Builder
@@ -25,6 +26,7 @@ public class Target {
 	}
 
 	@Override
+	@Generated
 	public boolean equals(Object o) {
 		if(this == o)
 			return true;
@@ -35,6 +37,7 @@ public class Target {
 	}
 
 	@Override
+	@Generated
 	public int hashCode() {
 		return Objects.hash(id, surveyList, nickname);
 	}

--- a/survey/domain/src/main/java/module-info.java
+++ b/survey/domain/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module luffy.survey.domain.main {
 	exports me.nalab.survey.domain.survey;
 	exports me.nalab.survey.domain.target;
 
+	requires luffy.core.meta.main;
 	requires lombok;
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Method단위로 jacoco coverage에서 제외하는 기능을 추가했습니다.

## 어떻게 해결했나요?
- [x] `core:meta` 모듈에 `@Generated` 어노테이션을 추가 했습니다.
- [x] `survey:domain` 모듈의 domain에 `equals` , `hashcode` 메소드를 테스트 커버리지 측정에서 제외 했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
