### PR TITLE
[fix] : `Survey` domain `equals` `hashCode` `toString` lombok 적용

### DIFF
--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
@@ -3,10 +3,12 @@ package me.nalab.survey.domain.survey;
 import java.util.Objects;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode
 public class Choice {
 
 	private final Long id;
@@ -22,18 +24,4 @@ public class Choice {
 			'}';
 	}
 
-	@Override
-	public boolean equals(Object o) {
-		if(this == o)
-			return true;
-		if(o == null || getClass() != o.getClass())
-			return false;
-		Choice choice = (Choice)o;
-		return id.equals(choice.id) && content.equals(choice.content) && order.equals(choice.order);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(id, content, order);
-	}
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
@@ -1,27 +1,18 @@
 package me.nalab.survey.domain.survey;
 
-import java.util.Objects;
-
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 @Builder
 @Getter
 @EqualsAndHashCode
+@ToString
 public class Choice {
 
 	private final Long id;
 	private final String content;
 	private final Integer order;
-
-	@Override
-	public String toString() {
-		return "Choice{" +
-			"id=" + id +
-			", content='" + content + '\'' +
-			", order=" + order +
-			'}';
-	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -1,13 +1,14 @@
 package me.nalab.survey.domain.survey;
 
 import java.util.List;
-import java.util.Objects;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class ChoiceFormQuestion extends FormQuestionable {
 
 	private final List<Choice> choiceList;
@@ -27,25 +28,6 @@ public class ChoiceFormQuestion extends FormQuestionable {
 			", order=" + order +
 			", questionType=" + questionType +
 			'}';
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if(this == o)
-			return true;
-		if(!(o instanceof FormQuestionable))
-			return false;
-		ChoiceFormQuestion that = (ChoiceFormQuestion)o;
-		return choiceList.equals(that.choiceList) && maxSelectionCount.equals(that.maxSelectionCount)
-			&& choiceFormQuestionType == that.choiceFormQuestionType && id.equals(that.id) && title.equals(that.title)
-			&& createdAt.equals(that.createdAt) && updatedAt.equals(
-			that.updatedAt) && order.equals(that.order) && questionType == that.questionType;
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(choiceList, maxSelectionCount, choiceFormQuestionType, id, title, createdAt, updatedAt,
-			order, questionType);
 	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -4,30 +4,17 @@ import java.util.List;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class ChoiceFormQuestion extends FormQuestionable {
 
 	private final List<Choice> choiceList;
 	private final Integer maxSelectionCount;
 	private final ChoiceFormQuestionType choiceFormQuestionType;
-
-	@Override
-	public String toString() {
-		return "ChoiceFormQuestion{" +
-			"choiceList=" + choiceList +
-			", maxSelectionCount=" + maxSelectionCount +
-			", choiceFormQuestionType=" + choiceFormQuestionType +
-			", id=" + id +
-			", title='" + title + '\'' +
-			", createdAt=" + createdAt +
-			", updatedAt=" + updatedAt +
-			", order=" + order +
-			", questionType=" + questionType +
-			'}';
-	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
@@ -1,7 +1,6 @@
 package me.nalab.survey.domain.survey;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
@@ -3,10 +3,12 @@ package me.nalab.survey.domain.survey;
 import java.time.LocalDateTime;
 
 import lombok.Getter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
 @Getter
+@ToString
 public abstract class FormQuestionable {
 
 	protected final Long id;

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
@@ -1,12 +1,12 @@
 package me.nalab.survey.domain.survey;
 
-import java.util.Objects;
-
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class ShortFormQuestion extends FormQuestionable {
 
 	private final ShortFormQuestionType shortFormQuestionType;
@@ -22,23 +22,6 @@ public class ShortFormQuestion extends FormQuestionable {
 			", order=" + order +
 			", questionType=" + questionType +
 			'}';
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if(this == o)
-			return true;
-		if(!(o instanceof FormQuestionable))
-			return false;
-		ShortFormQuestion that = (ShortFormQuestion)o;
-		return shortFormQuestionType == that.shortFormQuestionType && id.equals(that.id) && title.equals(that.title)
-			&& createdAt.equals(that.createdAt) && updatedAt.equals(
-			that.updatedAt) && order.equals(that.order) && questionType == that.questionType;
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(shortFormQuestionType, id, title, createdAt, updatedAt, order, questionType);
 	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
@@ -2,26 +2,15 @@ package me.nalab.survey.domain.survey;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
 @Getter
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class ShortFormQuestion extends FormQuestionable {
 
 	private final ShortFormQuestionType shortFormQuestionType;
-
-	@Override
-	public String toString() {
-		return "ShortFormQuestion{" +
-			"shortFormQuestionType=" + shortFormQuestionType +
-			", id=" + id +
-			", title='" + title + '\'' +
-			", createdAt=" + createdAt +
-			", updatedAt=" + updatedAt +
-			", order=" + order +
-			", questionType=" + questionType +
-			'}';
-	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -2,13 +2,14 @@ package me.nalab.survey.domain.survey;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode
 public class Survey {
 
 	private final Long id;
@@ -24,22 +25,6 @@ public class Survey {
 			", updatedAt=" + updatedAt +
 			", formQuestionableList=" + formQuestionableList +
 			'}';
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if(this == o)
-			return true;
-		if(!(o instanceof Survey))
-			return false;
-		Survey survey = (Survey)o;
-		return id.equals(survey.id) && createdAt.equals(survey.createdAt) && updatedAt.equals(survey.updatedAt)
-			&& formQuestionableList.equals(survey.formQuestionableList);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(id, createdAt, updatedAt, formQuestionableList);
 	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -6,25 +6,17 @@ import java.util.List;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 @Builder
 @Getter
 @EqualsAndHashCode
+@ToString
 public class Survey {
 
 	private final Long id;
 	private final LocalDateTime createdAt;
 	private final LocalDateTime updatedAt;
 	private final List<FormQuestionable> formQuestionableList;
-
-	@Override
-	public String toString() {
-		return "Survey{" +
-			"id=" + id +
-			", createdAt=" + createdAt +
-			", updatedAt=" + updatedAt +
-			", formQuestionableList=" + formQuestionableList +
-			'}';
-	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -1,14 +1,15 @@
 package me.nalab.survey.domain.target;
 
 import java.util.List;
-import java.util.Objects;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import me.nalab.survey.domain.survey.Survey;
 
 @Builder
 @Getter
+@EqualsAndHashCode
 public class Target {
 
 	private final Long id;
@@ -22,21 +23,6 @@ public class Target {
 			", surveyList=" + surveyList +
 			", nickname='" + nickname + '\'' +
 			'}';
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if(this == o)
-			return true;
-		if(!(o instanceof Target))
-			return false;
-		Target target = (Target)o;
-		return id.equals(target.id) && surveyList.equals(target.surveyList) && nickname.equals(target.nickname);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(id, surveyList, nickname);
 	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -5,24 +5,17 @@ import java.util.List;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import me.nalab.survey.domain.survey.Survey;
 
 @Builder
 @Getter
 @EqualsAndHashCode
+@ToString
 public class Target {
 
 	private final Long id;
 	private final List<Survey> surveyList;
 	private final String nickname;
-
-	@Override
-	public String toString() {
-		return "Target{" +
-			"id=" + id +
-			", surveyList=" + surveyList +
-			", nickname='" + nickname + '\'' +
-			'}';
-	}
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`Survey` 도메인의 `equals` `hashCode` `toString` 메소드를 구현에서 lombok으로 적용했습니다.

## 어떻게 해결했나요?
- [x] 기존의 Objects 기반의 equals와 hashcode 구현을 삭제하고, `@EqualsAndHashcode` 적용
- [x] 기존의 toString 구현을 삭제하고, `@ToString` 적용

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
