### PR TITLE
[feat] : `Survey create` 정책 domain에 추가

### DIFF
--- a/survey/domain/build.gradle
+++ b/survey/domain/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(':core:id-generator:id-generator-starter')
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -1,11 +1,15 @@
 package me.nalab.survey.domain.survey;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+import me.nalab.survey.domain.survey.valid.ChoiceFormQuestionValidator;
 
 @SuperBuilder
 @Getter
@@ -16,5 +20,35 @@ public class ChoiceFormQuestion extends FormQuestionable {
 	private final List<Choice> choiceList;
 	private final Integer maxSelectionCount;
 	private final ChoiceFormQuestionType choiceFormQuestionType;
+
+	ChoiceFormQuestion(ChoiceFormQuestionBuilder<?, ?> builder) {
+		super(builder);
+		choiceList = builder.choiceList;
+		maxSelectionCount = builder.maxSelectionCount;
+		choiceFormQuestionType = builder.choiceFormQuestionType;
+		ChoiceFormQuestionValidator.validSelf(this);
+	}
+
+	static List<ChoiceFormQuestion> getDefaultChoiceFormQuestion(IdGenerator idGenerator) {
+		return Stream.of(ChoiceFormQuestionType.values())
+			.filter(cf -> cf != ChoiceFormQuestionType.CUSTOM)
+			.map(cf -> cf.getChoiceFormQuestion(idGenerator))
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	FormQuestionable ofIncreaseOrder(int defaultOrderSize) {
+		return builder()
+			.id(id)
+			.title(title)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.order(defaultOrderSize + order)
+			.questionType(questionType)
+			.choiceList(choiceList)
+			.maxSelectionCount(maxSelectionCount)
+			.choiceFormQuestionType(choiceFormQuestionType)
+			.build();
+	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestionType.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestionType.java
@@ -1,5 +1,11 @@
 package me.nalab.survey.domain.survey;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Function;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+
 /**
  * 객관식 질문의 타입들
  */
@@ -8,18 +14,91 @@ public enum ChoiceFormQuestionType {
 	/**
 	 * 기본타입 `나와의 협업 경험 유무`
 	 */
-	COLLABORATION_EXPERIENCE,
+	COLLABORATION_EXPERIENCE(t -> ChoiceFormQuestion.builder()
+		.id(t.generate())
+		.title("협업 경험")
+		.order(1)
+		.choiceFormQuestionType(SelfReferenceSupporter.COLLABORATION_EXPERIENCE)
+		.questionType(QuestionType.CHOICE)
+		.createdAt(LocalDateTime.now())
+		.updatedAt(LocalDateTime.now())
+		.maxSelectionCount(1)
+		.choiceList(
+			List.of(
+				Choice.builder().id(t.generate()).content("네, 있어요").order(1).build()
+				, Choice.builder().id(t.generate()).content("없어요").order(2).build()
+			)
+		).build()
+	),
 	/**
 	 * 기본타입 `리뷰어의 직군`
 	 */
-	POSITION,
+	POSITION(t -> ChoiceFormQuestion.builder()
+		.id(t.generate())
+		.title("포지션")
+		.order(2)
+		.choiceFormQuestionType(SelfReferenceSupporter.POSITION)
+		.questionType(QuestionType.CHOICE)
+		.createdAt(LocalDateTime.now())
+		.updatedAt(LocalDateTime.now())
+		.maxSelectionCount(1)
+		.choiceList(
+			List.of(
+				Choice.builder().id(t.generate()).content("기획자").order(1).build()
+				, Choice.builder().id(t.generate()).content("디자이너").order(2).build()
+				, Choice.builder().id(t.generate()).content("개발자").order(3).build()
+				, Choice.builder().id(t.generate()).content("해당 없음").order(4).build()
+			)
+		).build()),
 	/**
 	 * 기본타입 `나의 성향`
 	 */
-	TENDENCY,
+	TENDENCY(t -> ChoiceFormQuestion.builder()
+		.id(t.generate())
+		.title("나의 성향")
+		.order(3)
+		.choiceFormQuestionType(SelfReferenceSupporter.TENDENCY)
+		.questionType(QuestionType.CHOICE)
+		.createdAt(LocalDateTime.now())
+		.updatedAt(LocalDateTime.now())
+		.maxSelectionCount(5)
+		.choiceList(
+			List.of(
+				Choice.builder().id(t.generate()).content("꼼꼼한").order(1).build()
+				, Choice.builder().id(t.generate()).content("리더십 있는").order(2).build()
+				, Choice.builder().id(t.generate()).content("공감을 잘하는").order(3).build()
+				, Choice.builder().id(t.generate()).content("도전적인").order(4).build()
+				, Choice.builder().id(t.generate()).content("논리적인").order(5).build()
+				, Choice.builder().id(t.generate()).content("섬세한").order(6).build()
+				, Choice.builder().id(t.generate()).content("창의적인").order(7).build()
+			)
+		).build()),
 	/**
 	 * 커스텀 타입 `타겟이 생성한 객관식 질문`
 	 */
-	CUSTOM,
+	CUSTOM(t -> {
+		throw new UnsupportedOperationException(
+			"Un supported operation \"ChoiceFormQuestionType.CUSTOM.getChoiceFormQuestion()\""
+		);
+	}),
+	;
+
+	private final Function<IdGenerator, ChoiceFormQuestion> choiceFormQuestionFunction;
+
+	ChoiceFormQuestionType(Function<IdGenerator, ChoiceFormQuestion> choiceFormQuestionFunction) {
+		this.choiceFormQuestionFunction = choiceFormQuestionFunction;
+	}
+
+	ChoiceFormQuestion getChoiceFormQuestion(IdGenerator idGenerator) {
+		return choiceFormQuestionFunction.apply(idGenerator);
+	}
+
+	private static final class SelfReferenceSupporter {
+
+		private static final ChoiceFormQuestionType COLLABORATION_EXPERIENCE = ChoiceFormQuestionType.COLLABORATION_EXPERIENCE;
+		private static final ChoiceFormQuestionType POSITION = ChoiceFormQuestionType.POSITION;
+		private static final ChoiceFormQuestionType TENDENCY = ChoiceFormQuestionType.TENDENCY;
+
+	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
@@ -18,4 +18,6 @@ public abstract class FormQuestionable {
 	protected final Integer order;
 	protected final QuestionType questionType;
 
+	abstract FormQuestionable ofIncreaseOrder(int defaultOrderSize);
+
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestion.java
@@ -1,9 +1,14 @@
 package me.nalab.survey.domain.survey;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import me.nalab.core.idgenerator.idcore.IdGenerator;
 
 @SuperBuilder
 @Getter
@@ -12,5 +17,25 @@ import lombok.experimental.SuperBuilder;
 public class ShortFormQuestion extends FormQuestionable {
 
 	private final ShortFormQuestionType shortFormQuestionType;
+
+	static List<ShortFormQuestion> getDefaultShortFormQuestion(IdGenerator idGenerator) {
+		return Stream.of(ShortFormQuestionType.values())
+			.filter(sf -> sf != ShortFormQuestionType.CUSTOM)
+			.map(sf -> sf.getShortFormQuestion(idGenerator))
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	FormQuestionable ofIncreaseOrder(int defaultOrderSize) {
+		return builder()
+			.id(id)
+			.title(title)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.order(defaultOrderSize + order)
+			.questionType(questionType)
+			.shortFormQuestionType(shortFormQuestionType)
+			.build();
+	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestionType.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ShortFormQuestionType.java
@@ -1,5 +1,10 @@
 package me.nalab.survey.domain.survey;
 
+import java.time.LocalDateTime;
+import java.util.function.Function;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+
 /**
  * 주관식 질문의 타입들
  */
@@ -8,14 +13,52 @@ public enum ShortFormQuestionType {
 	/**
 	 * 기본타입 `나의 강점`
 	 */
-	STRENGTH,
+	STRENGTH(t -> ShortFormQuestion.builder()
+		.id(t.generate())
+		.questionType(QuestionType.SHORT)
+		.title("나의 직무적 강점은 무엇인가요?")
+		.shortFormQuestionType(SelfReferenceSupporter.STRENGTH)
+		.order(4)
+		.createdAt(LocalDateTime.now())
+		.updatedAt(LocalDateTime.now())
+		.build()),
 	/**
 	 * 기본타입 `나의 약점`
 	 */
-	WEAKNESS,
+	WEAKNESS(t -> ShortFormQuestion.builder()
+		.id(t.generate())
+		.questionType(QuestionType.SHORT)
+		.title("나의 직무적 약점은 무엇인가요?")
+		.shortFormQuestionType(SelfReferenceSupporter.WEAKNESS)
+		.order(5)
+		.createdAt(LocalDateTime.now())
+		.updatedAt(LocalDateTime.now())
+		.build()),
 	/**
 	 * 커스텀 타입 `타겟이 생성한 주관식 질문`
 	 */
-	CUSTOM,
+	CUSTOM(t -> {
+		throw new UnsupportedOperationException(
+			"Un supported operation \"ShortFormQuestionType.CUSTOM.getShortFormQuestion()\""
+		);
+	}),
+	;
+
+	private final Function<IdGenerator, ShortFormQuestion> shortFormQuestionFunction;
+
+	ShortFormQuestionType(Function<IdGenerator, ShortFormQuestion> shortFormQuestionFunction) {
+		this.shortFormQuestionFunction = shortFormQuestionFunction;
+	}
+
+	ShortFormQuestion getShortFormQuestion(IdGenerator idGenerator) {
+		return shortFormQuestionFunction.apply(idGenerator);
+	}
+
+	private static final class SelfReferenceSupporter {
+
+		private static final ShortFormQuestionType STRENGTH = ShortFormQuestionType.STRENGTH;
+		private static final ShortFormQuestionType WEAKNESS = ShortFormQuestionType.WEAKNESS;
+
+	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -1,12 +1,16 @@
 package me.nalab.survey.domain.survey;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+import me.nalab.survey.domain.survey.valid.SurveyValidator;
 
 @Builder
 @Getter
@@ -18,5 +22,34 @@ public class Survey {
 	private final LocalDateTime createdAt;
 	private final LocalDateTime updatedAt;
 	private final List<FormQuestionable> formQuestionableList;
+
+	Survey(Long id, LocalDateTime createdAt, LocalDateTime updatedAt,
+		List<FormQuestionable> formQuestionableList) {
+		this.id = id;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+		this.formQuestionableList = formQuestionableList;
+		SurveyValidator.validSelf(this);
+	}
+
+	public Survey createDefaultFormQuestions(IdGenerator idGenerator) {
+		return builder()
+			.id(id)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.formQuestionableList(getDefaultFormQuestionableList(idGenerator))
+			.build();
+	}
+
+	private List<FormQuestionable> getDefaultFormQuestionableList(IdGenerator idGenerator) {
+		List<FormQuestionable> mergedFormQuestionList = new ArrayList<>();
+		mergedFormQuestionList.addAll(ChoiceFormQuestion.getDefaultChoiceFormQuestion(idGenerator));
+		mergedFormQuestionList.addAll(ShortFormQuestion.getDefaultShortFormQuestion(idGenerator));
+		List<FormQuestionable> ordinaryFormQuestionableList = formQuestionableList.stream()
+			.map(fq -> fq.ofIncreaseOrder(mergedFormQuestionList.size()))
+			.collect(Collectors.toList());
+		mergedFormQuestionList.addAll(ordinaryFormQuestionableList);
+		return mergedFormQuestionList;
+	}
 
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/valid/ChoiceFormQuestionValidator.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/valid/ChoiceFormQuestionValidator.java
@@ -1,0 +1,32 @@
+package me.nalab.survey.domain.survey.valid;
+
+import java.util.HashSet;
+import java.util.List;
+
+import me.nalab.survey.domain.survey.Choice;
+import me.nalab.survey.domain.survey.ChoiceFormQuestion;
+
+public class ChoiceFormQuestionValidator {
+
+	private ChoiceFormQuestionValidator() {
+		throw new UnsupportedOperationException("Unsupported Operation \"ChoiceFormQuestionValidator()\"");
+	}
+
+	public static void validSelf(ChoiceFormQuestion choice) {
+		validNoDuplicatedChoiceOrder(choice.getChoiceList());
+	}
+
+	private static void validNoDuplicatedChoiceOrder(List<Choice> choiceList) {
+		HashSet<Integer> orders = new HashSet<>();
+		choiceList.forEach(
+			c -> {
+				Integer order = c.getOrder();
+				if(orders.contains(order)) {
+					throw new DuplicatedOrderException(order, orders);
+				}
+				orders.add(order);
+			}
+		);
+	}
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/valid/DuplicatedOrderException.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/valid/DuplicatedOrderException.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.domain.survey.valid;
+
+import java.util.HashSet;
+
+public class DuplicatedOrderException extends RuntimeException {
+
+	DuplicatedOrderException(Integer duplicated, HashSet<Integer> orders) {
+		super("Duplicated order detected duplicated \"" + duplicated + "\" ordinary \"" + orders.toString() + "\"");
+	}
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/valid/SurveyValidator.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/valid/SurveyValidator.java
@@ -1,0 +1,32 @@
+package me.nalab.survey.domain.survey.valid;
+
+import java.util.HashSet;
+import java.util.List;
+
+import me.nalab.survey.domain.survey.FormQuestionable;
+import me.nalab.survey.domain.survey.Survey;
+
+public class SurveyValidator {
+
+	private SurveyValidator() {
+		throw new UnsupportedOperationException("Unsupported Operation \"SurveyValidator()\"");
+	}
+
+	public static void validSelf(Survey survey) {
+		validNoDuplicatedFormOrder(survey.getFormQuestionableList());
+	}
+
+	private static void validNoDuplicatedFormOrder(List<FormQuestionable> formQuestionableList) {
+		HashSet<Integer> orders = new HashSet<>();
+		formQuestionableList.forEach(
+			fq -> {
+				Integer order = fq.getOrder();
+				if(orders.contains(order)) {
+					throw new DuplicatedOrderException(order, orders);
+				}
+				orders.add(order);
+			}
+		);
+	}
+
+}

--- a/survey/domain/src/main/java/module-info.java
+++ b/survey/domain/src/main/java/module-info.java
@@ -2,6 +2,9 @@ module luffy.survey.domain.main {
 
 	exports me.nalab.survey.domain.survey;
 	exports me.nalab.survey.domain.target;
+	exports me.nalab.survey.domain.survey.valid;
+
+	requires luffy.core.id.generator.id.generator.starter.main;
 
 	requires lombok;
 

--- a/survey/domain/src/test/java/me/nalab/survey/domain/AbstractSurveySources.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/AbstractSurveySources.java
@@ -35,6 +35,31 @@ public abstract class AbstractSurveySources {
 		);
 	}
 
+	protected static Stream<Arguments> surveyCreateFailOrderSources() {
+		return Stream.of(
+			of(
+				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now())
+				, (Supplier<List<FormQuestionable>>)() -> List.of(
+					choiceFormQuestion(2L, "choice-form-fail1", LocalDateTime.now(), LocalDateTime.now(), 1
+						, List.of(choice(3L, 1, "choice1"), choice(4L, 2, "choice2")))
+					, shortFormQuestion(11L, "short-form-fail", LocalDateTime.now(), LocalDateTime.now(), 1)
+				)
+			)
+			, of(
+				surveyFunction(6L, LocalDateTime.now(), LocalDateTime.now())
+				, (Supplier<List<FormQuestionable>>)() -> List.of(
+					choiceFormQuestion(7L, "choice-form-fail3", LocalDateTime.now(), LocalDateTime.now(), 1
+						, List.of(
+							choice(8L, 2, "choice3")
+							, choice(4L, 2, "choice4")
+							, choice(4L, 2, "choice4")
+						)
+					)
+				)
+			)
+		);
+	}
+
 	static Function<Supplier<List<FormQuestionable>>, Survey> surveyFunction(Long id, LocalDateTime createAt,
 		LocalDateTime updatedAt) {
 		return T -> Survey.builder()
@@ -55,6 +80,7 @@ public abstract class AbstractSurveySources {
 			.order(order)
 			.questionType(QuestionType.CHOICE)
 			.choiceFormQuestionType(ChoiceFormQuestionType.CUSTOM)
+			.maxSelectionCount(choiceList.size())
 			.choiceList(choiceList)
 			.build();
 	}
@@ -79,6 +105,5 @@ public abstract class AbstractSurveySources {
 			.content(content)
 			.build();
 	}
-
 
 }

--- a/survey/domain/src/test/java/me/nalab/survey/domain/survey/AbstractSurveyDomainTest.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/survey/AbstractSurveyDomainTest.java
@@ -2,16 +2,20 @@ package me.nalab.survey.domain.survey;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import me.nalab.core.idgenerator.idcore.IdGenerator;
 import me.nalab.survey.domain.AbstractSurveySources;
+import me.nalab.survey.domain.survey.valid.DuplicatedOrderException;
 
 class AbstractSurveyDomainTest extends AbstractSurveySources {
 
@@ -33,6 +37,43 @@ class AbstractSurveyDomainTest extends AbstractSurveySources {
 		Survey survey = surveyCreate.apply(formQuestionSupplier);
 		assertNotNull(survey);
 		LOGGER.info(survey.toString());
+	}
+
+	@ParameterizedTest
+	@MethodSource("surveyCreateSuccessSources")
+	@DisplayName("기본 질문을 갖고있는 Survey 생성 성공 테스트")
+	void SURVEY_WITH_DEFAULT_QUESTION_FORM_SUCCESS(Function<Supplier<List<FormQuestionable>>, Survey> surveyCreate
+		, Supplier<List<FormQuestionable>> formQuestionSupplier
+	) {
+		// given
+		Survey survey = surveyCreate.apply(formQuestionSupplier);
+
+		// when & then
+		assertDoesNotThrow(() -> survey.createDefaultFormQuestions(getLinearIdGenerator(10000000L)));
+	}
+
+	@ParameterizedTest
+	@MethodSource("surveyCreateFailOrderSources")
+	@DisplayName("Survey 생성 실패 테스트 - 중복 Order")
+	void SURVEY_WITH_DEFAULT_QUESTION_FORM_FAIL_DUPLICATED_ID(
+		Function<Supplier<List<FormQuestionable>>, Survey> surveyCreate
+		, Supplier<List<FormQuestionable>> formQuestionSupplier
+	) {
+		assertThrows(DuplicatedOrderException.class, () -> surveyCreate.apply(formQuestionSupplier));
+	}
+
+	private IdGenerator getLinearIdGenerator(Long startPoint) {
+		return new IdGenerator() {
+
+			private Long linerId = startPoint;
+
+			@Override
+			public long generate() {
+				linerId++;
+				return linerId;
+			}
+
+		};
 	}
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Survey 생성 유즈 케이스 중, Default Survey 생성 코드와 생성 관련 validation을 도메인에 추가했습니다.

## 어떻게 해결했나요?
- [x] 기본으로 생성되어야 하는 질문폼들을 생성하는 로직을 Survey 도메인 안에 넣었습니다.
- [x] 질문폼 생성시, 질문폼 간의 중복 order가 발생하는 경우를 처리하는 validation 로직을 domain 모듈에 넣었습니다.
- [x] 관련 테스트 케이스를 추가했습니다. 

## 어떤 부분에 집중하여 리뷰해야 할까요?
- [ ] 기본으로 생성되는 질문폼 목록과 (객관식이면 선택지)을 `클라이언트`가 아니라 `서버`에서 들고있어야 할거 같습니다. 
		들고있지 않으면, 악의적인 리뷰어가, 기본 질문폼에서 선택할 수 없는 선택지를 우리에게 날렸을 경우, validation 해줄 수 없을거 같아요.
		예를 들어, `나의 성향` 질문폼에서 `1, 2, 3` 번의 선택지가 있는데, `4` 번이 API를 타고 우리에게 왔을때, 서버에서는 이 선택지가 잘못 되었다는걸 알 수 없다고 생각합니다..!

- [ ] `기본 선택지` 생성 코드는 `정책` 이라서 유즈케이스가 아닌, 도메인에 있어야 한다고 생각합니다..! 
		이유는.. `질문 폼` 에 항상 `기본 선택지` 가 들어 있고, `생성`, `조회`, `응답` 등 대부분의 기능에서 `기본 선택지` 가 필요하기 때문입니다.

## 참고자료
