### PR TITLE
[feat] : Survey create usecase `port`

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,7 @@ include 'support:jacoco'
 
 include 'survey'
 include 'survey:domain'
+include 'survey:application'
 
 include 'auth'
 include 'auth:mock'

--- a/survey/application/build.gradle
+++ b/survey/application/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    implementation project(':survey:domain')
+    testImplementation project(':survey:domain')
+
+    implementation project(':core:id-generator:id-generator-starter')
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/create/CreateSurveyUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/create/CreateSurveyUseCase.java
@@ -1,0 +1,16 @@
+package me.nalab.survey.application.port.in.create;
+
+import me.nalab.survey.application.port.in.create.request.CreateSurveyRequest;
+
+/**
+ * 새로운 Survey를 생성하는 Usecase 이 인터페이스를 이용해서 새로운 Survey를 생성할 수 있음.
+ */
+public interface CreateSurveyUseCase {
+
+	/**
+	 * targetId에 해당하는 target에 새로운 Survey를 생성함.
+	 * @param createSurveyRequest CreateSurveyRequest 생성될 Survey의 정보들
+	 */
+	void createSurvey(Long targetId, CreateSurveyRequest createSurveyRequest);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateChoice.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateChoice.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.application.port.in.create.request;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CreateChoice {
+
+	private final String content;
+	private final Integer order;
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateChoiceQuestion.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateChoiceQuestion.java
@@ -1,0 +1,51 @@
+package me.nalab.survey.application.port.in.create.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+import me.nalab.survey.domain.survey.Choice;
+import me.nalab.survey.domain.survey.ChoiceFormQuestion;
+import me.nalab.survey.domain.survey.ChoiceFormQuestionType;
+import me.nalab.survey.domain.survey.QuestionType;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CreateChoiceQuestion implements CreateQuestionable<ChoiceFormQuestion> {
+
+	private final String type;
+	private final String title;
+	private final List<CreateChoice> choiceRequestList;
+	private final Integer maxSelectableCount;
+	private final Integer order;
+
+	@Override
+	public ChoiceFormQuestion getConcreteQuestion(IdGenerator idGenerator) {
+		return ChoiceFormQuestion.builder()
+			.id(idGenerator.generate())
+			.questionType(QuestionType.SHORT)
+			.choiceFormQuestionType(ChoiceFormQuestionType.CUSTOM)
+			.choiceList(
+				choiceRequestList.stream()
+					.map(cr -> Choice.builder()
+						.id(idGenerator.generate())
+						.content(cr.getContent())
+						.order(cr.getOrder())
+						.build())
+					.collect(Collectors.toList())
+			)
+			.maxSelectionCount(maxSelectableCount)
+			.order(order)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.build();
+	}
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateQuestionable.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateQuestionable.java
@@ -1,0 +1,10 @@
+package me.nalab.survey.application.port.in.create.request;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+import me.nalab.survey.domain.survey.FormQuestionable;
+
+public interface CreateQuestionable<T extends FormQuestionable> {
+
+	T getConcreteQuestion(IdGenerator idGenerator);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateShortQuestion.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateShortQuestion.java
@@ -1,0 +1,35 @@
+package me.nalab.survey.application.port.in.create.request;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+import me.nalab.survey.domain.survey.QuestionType;
+import me.nalab.survey.domain.survey.ShortFormQuestion;
+import me.nalab.survey.domain.survey.ShortFormQuestionType;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CreateShortQuestion implements CreateQuestionable<ShortFormQuestion> {
+
+	private final String title;
+	private final Integer order;
+
+	@Override
+	public ShortFormQuestion getConcreteQuestion(IdGenerator idGenerator) {
+		return ShortFormQuestion.builder()
+			.id(idGenerator.generate())
+			.order(order)
+			.questionType(QuestionType.SHORT)
+			.shortFormQuestionType(ShortFormQuestionType.CUSTOM)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.title(title)
+			.build();
+	}
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateSurveyRequest.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/create/request/CreateSurveyRequest.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.port.in.create.request;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import me.nalab.survey.domain.survey.FormQuestionable;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CreateSurveyRequest {
+
+	private final Integer questionCount;
+	private final List<CreateQuestionable<? extends FormQuestionable>> questionableList;
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/CreateSurveyPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/CreateSurveyPort.java
@@ -1,0 +1,18 @@
+package me.nalab.survey.application.port.out.persistence.create;
+
+import me.nalab.survey.application.port.out.persistence.create.request.PersistenceSurveyRequest;
+
+/**
+ * 생성된 Survey를 저장하는 역할을 하는 인터페이스
+ * <br>
+ * 이 인터페이스의 구현체는 Survey 도메인을 저장해야함.
+ */
+public interface CreateSurveyPort {
+
+	/**
+	 * 이 메소드는 Survey를 저장함.
+	 * @param persistenceSurveyRequest 저장할 Survey Request
+	 */
+	void persistenceSurvey(PersistenceSurveyRequest persistenceSurveyRequest);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/FindTargetPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/FindTargetPort.java
@@ -1,0 +1,16 @@
+package me.nalab.survey.application.port.out.persistence.create;
+
+/**
+ * 저장되어있는 Target을 조회하는 인터페이스
+ */
+public interface FindTargetPort {
+
+	/**
+	 * targetId에 해당하는 target이 저장되어있는지 확인합니다.
+	 *
+	 * @param targetId 존재하는지 확인할 target의 ID
+	 * @return boolean 존재한다면 true / 존재하지 않는다면, false
+	 */
+	boolean isExistTarget(Long targetId);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceChoice.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceChoice.java
@@ -1,0 +1,18 @@
+package me.nalab.survey.application.port.out.persistence.create.request;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class PersistenceChoice {
+
+	private final Long id;
+	private final String content;
+	private final Integer order;
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceChoiceFormQuestion.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceChoiceFormQuestion.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.port.out.persistence.create.request;
+
+import java.util.List;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class PersistenceChoiceFormQuestion extends PersistenceFormQuestionable {
+
+	private final List<PersistenceChoice> persistenceChoiceList;
+	private final Integer maxSelectionCount;
+	private final PersistenceChoiceFormQuestionType persistenceChoiceFormQuestionType;
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceChoiceFormQuestionType.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceChoiceFormQuestionType.java
@@ -1,6 +1,6 @@
 package me.nalab.survey.application.port.out.persistence.create.request;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import me.nalab.survey.domain.survey.ChoiceFormQuestionType;
@@ -36,12 +36,13 @@ public enum PersistenceChoiceFormQuestionType {
 		Converter.TYPE_CONVERTER.put(choiceFormQuestionType, this);
 	}
 
-	public static PersistenceChoiceFormQuestionType convert(ChoiceFormQuestionType choiceFormQuestionType){
+	public static PersistenceChoiceFormQuestionType convert(ChoiceFormQuestionType choiceFormQuestionType) {
 		return Converter.TYPE_CONVERTER.get(choiceFormQuestionType);
 	}
 
 	private static final class Converter {
-		private static final Map<ChoiceFormQuestionType, PersistenceChoiceFormQuestionType> TYPE_CONVERTER = new HashMap<>();
+		private static final Map<ChoiceFormQuestionType, PersistenceChoiceFormQuestionType> TYPE_CONVERTER
+			= new EnumMap<>(ChoiceFormQuestionType.class);
 	}
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceChoiceFormQuestionType.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceChoiceFormQuestionType.java
@@ -1,0 +1,47 @@
+package me.nalab.survey.application.port.out.persistence.create.request;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import me.nalab.survey.domain.survey.ChoiceFormQuestionType;
+
+/**
+ * 객관식 질문의 타입들
+ */
+public enum PersistenceChoiceFormQuestionType {
+
+	/**
+	 * 기본타입 `나와의 협업 경험 유무` <br>
+	 * ChoiceFormQuestionType.COLLABORATION_EXPERIENCE -> PersistenceChoiceFormQuestionType.COLLABORATION_EXPERIENCE
+	 */
+	COLLABORATION_EXPERIENCE(ChoiceFormQuestionType.COLLABORATION_EXPERIENCE),
+	/**
+	 * 기본타입 `리뷰어의 직군` <br>
+	 * ChoiceFormQuestionType.POSITION -> PersistenceChoiceFormQuestionType.POSITION
+	 */
+	POSITION(ChoiceFormQuestionType.POSITION),
+	/**
+	 * 기본타입 `나의 성향` <br>
+	 * ChoiceFormQuestionType.TENDENCY -> PersistenceChoiceFormQuestionType.TENDENCY
+	 */
+	TENDENCY(ChoiceFormQuestionType.TENDENCY),
+	/**
+	 * 커스텀 타입 `타겟이 생성한 객관식 질문` <br>
+	 * ChoiceFormQuestionType.CUSTOM -> PersistenceChoiceFormQuestionType.CUSTOM
+	 */
+	CUSTOM(ChoiceFormQuestionType.CUSTOM),
+	;
+
+	PersistenceChoiceFormQuestionType(ChoiceFormQuestionType choiceFormQuestionType) {
+		Converter.TYPE_CONVERTER.put(choiceFormQuestionType, this);
+	}
+
+	public static PersistenceChoiceFormQuestionType convert(ChoiceFormQuestionType choiceFormQuestionType){
+		return Converter.TYPE_CONVERTER.get(choiceFormQuestionType);
+	}
+
+	private static final class Converter {
+		private static final Map<ChoiceFormQuestionType, PersistenceChoiceFormQuestionType> TYPE_CONVERTER = new HashMap<>();
+	}
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceFormQuestionable.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceFormQuestionable.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.application.port.out.persistence.create.request;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+public abstract class PersistenceFormQuestionable {
+
+	protected final Long id;
+	protected final String title;
+	protected final LocalDateTime createdAt;
+	protected final LocalDateTime updatedAt;
+	protected final Integer order;
+	protected final PersistenceQuestionType persistenceQuestionType;
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceQuestionType.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceQuestionType.java
@@ -1,0 +1,37 @@
+package me.nalab.survey.application.port.out.persistence.create.request;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import me.nalab.survey.domain.survey.QuestionType;
+
+/**
+ * 질문의 유형들
+ */
+public enum PersistenceQuestionType {
+
+	/**
+	 * 객관식 질문 <br>
+	 * QuestionType.CHOICE -> PersistenceQuestionType.CHOICE
+	 */
+	CHOICE(QuestionType.CHOICE),
+	/**
+	 * 주관식 질문 <br>
+	 * QuestionType.SHORT -> PersistenceQuestionType.SHORT
+	 */
+	SHORT(QuestionType.SHORT),
+	;
+
+	PersistenceQuestionType(QuestionType questionType){
+		Converter.TYPE_CONVERTER.put(questionType, this);
+	}
+
+	public static PersistenceQuestionType convert(QuestionType questionType){
+		return Converter.TYPE_CONVERTER.get(questionType);
+	}
+
+	private static final class Converter {
+		private static final Map<QuestionType, PersistenceQuestionType> TYPE_CONVERTER = new HashMap<>();
+	}
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceQuestionType.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceQuestionType.java
@@ -1,6 +1,6 @@
 package me.nalab.survey.application.port.out.persistence.create.request;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import me.nalab.survey.domain.survey.QuestionType;
@@ -22,16 +22,17 @@ public enum PersistenceQuestionType {
 	SHORT(QuestionType.SHORT),
 	;
 
-	PersistenceQuestionType(QuestionType questionType){
+	PersistenceQuestionType(QuestionType questionType) {
 		Converter.TYPE_CONVERTER.put(questionType, this);
 	}
 
-	public static PersistenceQuestionType convert(QuestionType questionType){
+	public static PersistenceQuestionType convert(QuestionType questionType) {
 		return Converter.TYPE_CONVERTER.get(questionType);
 	}
 
 	private static final class Converter {
-		private static final Map<QuestionType, PersistenceQuestionType> TYPE_CONVERTER = new HashMap<>();
+		private static final Map<QuestionType, PersistenceQuestionType> TYPE_CONVERTER
+			= new EnumMap<>(QuestionType.class);
 	}
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceShortFormQuestion.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceShortFormQuestion.java
@@ -1,0 +1,16 @@
+package me.nalab.survey.application.port.out.persistence.create.request;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class PersistenceShortFormQuestion extends PersistenceFormQuestionable {
+
+	private final PersistenceShortFormQuestionType persistenceShortFormQuestionType;
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceShortFormQuestionType.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceShortFormQuestionType.java
@@ -1,0 +1,42 @@
+package me.nalab.survey.application.port.out.persistence.create.request;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import me.nalab.survey.domain.survey.ShortFormQuestionType;
+
+/**
+ * 주관식 질문의 타입들
+ */
+public enum PersistenceShortFormQuestionType {
+
+	/**
+	 * 기본타입 `나의 강점` <br>
+	 * ShortFormQuestionType.STRENGTH -> PersistenceShortFormQuestionType.STRENGTH
+	 */
+	STRENGTH(ShortFormQuestionType.STRENGTH),
+	/**
+	 * 기본타입 `나의 약점` <br>
+	 * ShortFormQuestionType.WEAKNESS -> PersistenceShortFormQuestionType.WEAKNESS
+	 */
+	WEAKNESS(ShortFormQuestionType.WEAKNESS),
+	/**
+	 * 커스텀 타입 `타겟이 생성한 주관식 질문` <br>
+	 * ShortFormQuestionType.CUSTOM -> PersistenceShortFormQuestionType.CUSTOM
+	 */
+	CUSTOM(ShortFormQuestionType.CUSTOM),
+	;
+
+	PersistenceShortFormQuestionType(ShortFormQuestionType shortFormQuestionType) {
+		Converter.TYPE_CONVERTER.put(shortFormQuestionType, this);
+	}
+
+	public static PersistenceShortFormQuestionType convert(ShortFormQuestionType shortFormQuestionType){
+		return Converter.TYPE_CONVERTER.get(shortFormQuestionType);
+	}
+
+	private static final class Converter {
+		private static final Map<ShortFormQuestionType, PersistenceShortFormQuestionType> TYPE_CONVERTER = new HashMap<>();
+	}
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceShortFormQuestionType.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceShortFormQuestionType.java
@@ -1,6 +1,6 @@
 package me.nalab.survey.application.port.out.persistence.create.request;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import me.nalab.survey.domain.survey.ShortFormQuestionType;
@@ -31,12 +31,13 @@ public enum PersistenceShortFormQuestionType {
 		Converter.TYPE_CONVERTER.put(shortFormQuestionType, this);
 	}
 
-	public static PersistenceShortFormQuestionType convert(ShortFormQuestionType shortFormQuestionType){
+	public static PersistenceShortFormQuestionType convert(ShortFormQuestionType shortFormQuestionType) {
 		return Converter.TYPE_CONVERTER.get(shortFormQuestionType);
 	}
 
 	private static final class Converter {
-		private static final Map<ShortFormQuestionType, PersistenceShortFormQuestionType> TYPE_CONVERTER = new HashMap<>();
+		private static final Map<ShortFormQuestionType, PersistenceShortFormQuestionType> TYPE_CONVERTER
+			= new EnumMap<>(ShortFormQuestionType.class);
 	}
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceSurveyRequest.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceSurveyRequest.java
@@ -1,0 +1,23 @@
+package me.nalab.survey.application.port.out.persistence.create.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class PersistenceSurveyRequest {
+
+	private final Long id;
+	private final Long targetId;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+	private final List<PersistenceFormQuestionable> persistenceFormQuestionableList;
+
+}

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -1,0 +1,18 @@
+module luffy.survey.application.main {
+
+	exports me.nalab.survey.application.port.in.create;
+	exports me.nalab.survey.application.port.in.create.request;
+	exports me.nalab.survey.application.port.out.persistence.create;
+	exports me.nalab.survey.application.port.out.persistence.create.request;
+
+	requires luffy.survey.domain.main;
+	requires luffy.core.id.generator.id.generator.starter.main;
+
+	requires lombok;
+
+	requires spring.boot;
+	requires spring.boot.autoconfigure;
+	requires spring.context;
+	requires spring.tx;
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/TestIdGenerator.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/TestIdGenerator.java
@@ -1,0 +1,32 @@
+package me.nalab.survey.application;
+
+import java.security.SecureRandom;
+import java.util.function.Supplier;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+
+public class TestIdGenerator implements IdGenerator {
+
+	private Supplier<Long> idGenerateAlgorithm;
+
+	public TestIdGenerator() {
+		idGenerateAlgorithm = new Supplier<>() {
+			final SecureRandom secureRandom = new SecureRandom();
+
+			@Override
+			public Long get() {
+				return secureRandom.nextLong();
+			}
+		};
+	}
+
+	@Override
+	public long generate() {
+		return idGenerateAlgorithm.get();
+	}
+
+	public void setIdGenerateAlgorithm(Supplier<Long> idGenerateAlgorithm) {
+		this.idGenerateAlgorithm = idGenerateAlgorithm;
+	}
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/fixture/CreateSurveyFixture.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/fixture/CreateSurveyFixture.java
@@ -1,0 +1,49 @@
+package me.nalab.survey.application.fixture;
+
+import java.util.List;
+
+import me.nalab.survey.application.port.in.create.request.CreateChoice;
+import me.nalab.survey.application.port.in.create.request.CreateChoiceQuestion;
+import me.nalab.survey.application.port.in.create.request.CreateQuestionable;
+import me.nalab.survey.application.port.in.create.request.CreateShortQuestion;
+import me.nalab.survey.application.port.in.create.request.CreateSurveyRequest;
+import me.nalab.survey.domain.survey.FormQuestionable;
+import me.nalab.survey.domain.survey.ShortFormQuestion;
+
+public class CreateSurveyFixture {
+
+	public static CreateSurveyRequest getSurveyCreateRequest(Integer questionCount
+		, List<CreateQuestionable<? extends FormQuestionable>> questionableList) {
+		return CreateSurveyRequest.builder()
+			.questionCount(questionCount)
+			.questionableList(questionableList)
+			.build();
+	}
+
+	public static CreateQuestionable<? extends FormQuestionable> getChoiceQuestionRequest(String title
+		, Integer maxSelectableCount
+		, Integer order
+		, List<CreateChoice> choiceRequestList) {
+		return CreateChoiceQuestion.builder()
+			.title(title)
+			.maxSelectableCount(maxSelectableCount)
+			.order(order)
+			.choiceRequestList(choiceRequestList)
+			.build();
+	}
+
+	public static CreateChoice getChoiceRequest(Integer order, String content) {
+		return CreateChoice.builder()
+			.order(order)
+			.content(content)
+			.build();
+	}
+
+	public static CreateQuestionable<ShortFormQuestion> getShortQuestionRequest(Integer order, String title) {
+		return CreateShortQuestion.builder()
+			.title(title)
+			.order(order)
+			.build();
+	}
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/port/in/create/CreateSurveyRequestTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/port/in/create/CreateSurveyRequestTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import me.nalab.core.idgenerator.idcore.IdGenerator;
 import me.nalab.survey.application.TestIdGenerator;
-import me.nalab.survey.application.port.in.create.request.CreateSurveyRequest;
 import me.nalab.survey.application.port.in.create.request.CreateQuestionable;
+import me.nalab.survey.application.port.in.create.request.CreateSurveyRequest;
 import me.nalab.survey.domain.survey.ChoiceFormQuestion;
 import me.nalab.survey.domain.survey.FormQuestionable;
 import me.nalab.survey.domain.survey.ShortFormQuestion;

--- a/survey/application/src/test/java/me/nalab/survey/application/port/in/create/CreateSurveyRequestTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/port/in/create/CreateSurveyRequestTest.java
@@ -1,0 +1,93 @@
+package me.nalab.survey.application.port.in.create;
+
+import static me.nalab.survey.application.fixture.CreateSurveyFixture.getChoiceQuestionRequest;
+import static me.nalab.survey.application.fixture.CreateSurveyFixture.getChoiceRequest;
+import static me.nalab.survey.application.fixture.CreateSurveyFixture.getShortQuestionRequest;
+import static me.nalab.survey.application.fixture.CreateSurveyFixture.getSurveyCreateRequest;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+import me.nalab.survey.application.TestIdGenerator;
+import me.nalab.survey.application.port.in.create.request.CreateSurveyRequest;
+import me.nalab.survey.application.port.in.create.request.CreateQuestionable;
+import me.nalab.survey.domain.survey.ChoiceFormQuestion;
+import me.nalab.survey.domain.survey.FormQuestionable;
+import me.nalab.survey.domain.survey.ShortFormQuestion;
+
+class CreateSurveyRequestTest {
+
+	private static final IdGenerator ID_GENERATOR = new TestIdGenerator();
+
+	@ParameterizedTest
+	@MethodSource("createSurveyRequestSources")
+	void CREATE_SURVEY_SUCCESS(Supplier<CreateSurveyRequest> surveyCreateRequestSupplier) {
+		assertDoesNotThrow(surveyCreateRequestSupplier::get);
+	}
+
+	@ParameterizedTest
+	@MethodSource("createConcreteFormSources")
+	void CONVERT_TO_CONCRETE_CLASS_SUCCESS(CreateQuestionable<?> questionable, Class<? extends FormQuestionable> type) {
+		assertEquals(questionable.getConcreteQuestion(ID_GENERATOR).getClass(), type);
+	}
+
+	private static Stream<Arguments> createSurveyRequestSources() {
+		return Stream.of(
+			of((Supplier<Object>)() -> getSurveyCreateRequest(0, List.of())),
+			of((Supplier<Object>)() -> getSurveyCreateRequest(0, null)),
+			of((Supplier<Object>)() -> getSurveyCreateRequest(
+				3, List.of(
+					getChoiceQuestionRequest("hello-world1", 3, 1, List.of(
+						getChoiceRequest(1, "first"),
+						getChoiceRequest(2, "second"),
+						getChoiceRequest(3, "third")
+					)),
+					getShortQuestionRequest(2, "hello-world1"),
+					getShortQuestionRequest(3, "hello-world2")
+				)
+			)),
+			of((Supplier<Object>)() -> getSurveyCreateRequest(
+				2, List.of(
+					getChoiceQuestionRequest("hello-world2", 2, 1, List.of(
+						getChoiceRequest(1, "first"),
+						getChoiceRequest(2, "second"),
+						getChoiceRequest(3, "third")
+					)),
+					getChoiceQuestionRequest("hello-world3", 3, 2, List.of(
+						getChoiceRequest(1, "first"),
+						getChoiceRequest(2, "second"),
+						getChoiceRequest(3, "third")
+					))
+				)
+			)),
+			of((Supplier<Object>)() -> getSurveyCreateRequest(
+				2, List.of(
+					getShortQuestionRequest(2, "hello-world1"),
+					getShortQuestionRequest(3, "hello-world2")
+				)
+			))
+		);
+	}
+
+	private static Stream<Arguments> createConcreteFormSources() {
+		return Stream.of(
+			of(getChoiceQuestionRequest("hello-world1", 3, 1, List.of(
+					getChoiceRequest(1, "first"),
+					getChoiceRequest(2, "second"),
+					getChoiceRequest(3, "third")
+				)
+			), ChoiceFormQuestion.class),
+			of(getShortQuestionRequest(2, "hello-world1"), ShortFormQuestion.class)
+		);
+	}
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/port/out/create/CreatePersistenceSurveyEnumTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/port/out/create/CreatePersistenceSurveyEnumTest.java
@@ -1,0 +1,85 @@
+package me.nalab.survey.application.port.out.create;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import me.nalab.survey.application.port.out.persistence.create.request.PersistenceChoiceFormQuestionType;
+import me.nalab.survey.application.port.out.persistence.create.request.PersistenceQuestionType;
+import me.nalab.survey.application.port.out.persistence.create.request.PersistenceShortFormQuestionType;
+import me.nalab.survey.domain.survey.ChoiceFormQuestionType;
+import me.nalab.survey.domain.survey.QuestionType;
+import me.nalab.survey.domain.survey.ShortFormQuestionType;
+
+class CreatePersistenceSurveyEnumTest {
+
+	@ParameterizedTest
+	@MethodSource("persistenceQuestionTypeSources")
+	void PERSISTENCE_QUESTION_TYPE_CONVERT(QuestionType questionType
+		, PersistenceQuestionType expected
+		, boolean result) {
+		assertEquals(result, expected == PersistenceQuestionType.convert(questionType));
+	}
+
+	@ParameterizedTest
+	@MethodSource("persistenceShortQuestionTypeSources")
+	void PERSISTENCE_QUESTION_SHORT_QUESTION_TYPE_CONVERT(ShortFormQuestionType shortFormQuestionType
+		, PersistenceShortFormQuestionType expected
+		, boolean result) {
+		assertEquals(result, expected == PersistenceShortFormQuestionType.convert(shortFormQuestionType));
+	}
+
+	@ParameterizedTest
+	@MethodSource("persistenceChoiceQuestionTypeSources")
+	void PERSISTENCE_CHOICE_QUESTION_TYPE_CONVERT(ChoiceFormQuestionType choiceFormQuestionType
+		, PersistenceChoiceFormQuestionType expected
+		, boolean result) {
+		assertEquals(result, expected == PersistenceChoiceFormQuestionType.convert(choiceFormQuestionType));
+	}
+
+	private static Stream<Arguments> persistenceQuestionTypeSources() {
+		return Stream.of(
+			of(QuestionType.CHOICE, PersistenceQuestionType.CHOICE, true)
+			, of(QuestionType.SHORT, PersistenceQuestionType.SHORT, true)
+
+			, of(QuestionType.CHOICE, PersistenceQuestionType.SHORT, false)
+			, of(QuestionType.SHORT, PersistenceQuestionType.CHOICE, false)
+		);
+	}
+
+	private static Stream<Arguments> persistenceShortQuestionTypeSources() {
+		return Stream.of(
+			of(ShortFormQuestionType.STRENGTH, PersistenceShortFormQuestionType.STRENGTH, true)
+			, of(ShortFormQuestionType.WEAKNESS, PersistenceShortFormQuestionType.WEAKNESS, true)
+			, of(ShortFormQuestionType.CUSTOM, PersistenceShortFormQuestionType.CUSTOM, true)
+
+			, of(ShortFormQuestionType.STRENGTH, PersistenceShortFormQuestionType.WEAKNESS, false)
+			, of(ShortFormQuestionType.WEAKNESS, PersistenceShortFormQuestionType.STRENGTH, false)
+			, of(ShortFormQuestionType.CUSTOM, PersistenceShortFormQuestionType.STRENGTH, false)
+			, of(ShortFormQuestionType.STRENGTH, PersistenceShortFormQuestionType.CUSTOM, false)
+			, of(ShortFormQuestionType.WEAKNESS, PersistenceShortFormQuestionType.CUSTOM, false)
+			, of(ShortFormQuestionType.CUSTOM, PersistenceShortFormQuestionType.WEAKNESS, false)
+		);
+	}
+
+	private static Stream<Arguments> persistenceChoiceQuestionTypeSources() {
+		return Stream.of(
+			of(ChoiceFormQuestionType.TENDENCY, PersistenceChoiceFormQuestionType.TENDENCY, true)
+			, of(ChoiceFormQuestionType.POSITION, PersistenceChoiceFormQuestionType.POSITION, true)
+			, of(ChoiceFormQuestionType.COLLABORATION_EXPERIENCE
+				, PersistenceChoiceFormQuestionType.COLLABORATION_EXPERIENCE, true)
+			, of(ChoiceFormQuestionType.CUSTOM, PersistenceChoiceFormQuestionType.CUSTOM, true)
+
+			, of(ChoiceFormQuestionType.TENDENCY, PersistenceChoiceFormQuestionType.POSITION, false)
+			, of(ChoiceFormQuestionType.POSITION, PersistenceChoiceFormQuestionType.CUSTOM, false)
+			, of(ChoiceFormQuestionType.COLLABORATION_EXPERIENCE, PersistenceChoiceFormQuestionType.TENDENCY, false)
+			, of(ChoiceFormQuestionType.CUSTOM, PersistenceChoiceFormQuestionType.POSITION, false)
+		);
+	}
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Survey create usecase의 `in.port`와 `out.port`를 정의하고, port별 `Request Dto` 를 만들었습니다.

## 어떻게 해결했나요?
- [x] in.port에 `CreateSurveyUseCase` 인터페이스를 정의했습니다.
- [x] `CreateSurveyUseCase` 에서 사용하는 Request Dto를 정의했습니다.
- [x] out.port에 `CreateSurveyPort` 와 `FindTargetPort` 인터페이스를 정의했습니다.
- [x] `FindTargetPort` 에서 사용하는 Request Dto를 정의했습니다.

## 어떤 부분에 집중하여 리뷰해야 할까요?
__질문폼 생성 usecase의 port별 dto가 많아서.. PR이 너무 커져 port 인터페이스와 request만 따로 올립니다..!__

dto는 `lombok` 으로 `Builder` `Getter` `EqualsAndHashCode` `ToString` 만 정의 되어있는게 대부분이라 빠르게 넘겨도 될거같고 
인터페이스랑 테스트코드 위주로 봐주시면 될거 같습니다.

dto 특이점 으로는..
out.port의 requestDto에서, enum 타입인, [`PersistenceQuestionType`](survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceQuestionType.java), [`PersistenceChoiceFormQuestionType`](survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceChoiceFormQuestionType.java), [`PersistenceShortFormQuestionType`](survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/create/request/PersistenceShortFormQuestionType.java) 정도 봐주시면 될거 같아요!

## 참고자료
