### PR TITLE
[feat] : Survey 생성 service를 추가했습니다.

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/common/mapper/SurveyDtoMapper.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/common/mapper/SurveyDtoMapper.java
@@ -1,6 +1,5 @@
 package me.nalab.survey.application.common.mapper;
 
-import java.time.LocalDateTime;
 import java.util.stream.Collectors;
 
 import me.nalab.survey.application.common.dto.ChoiceDto;

--- a/survey/application/src/main/java/me/nalab/survey/application/exception/TargetDoesNotExistException.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/exception/TargetDoesNotExistException.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.exception;
+
+import lombok.Getter;
+
+public final class TargetDoesNotExistException extends RuntimeException {
+
+	@Getter
+	private final Long id;
+
+	public TargetDoesNotExistException(Long id) {
+		super("Cannot find target id \"" + id + "\"");
+		this.id = id;
+	}
+
+	@Override
+	public synchronized Throwable fillInStackTrace() {
+		return this;
+	}
+	
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/CreateSurveyPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/CreateSurveyPort.java
@@ -1,6 +1,6 @@
 package me.nalab.survey.application.port.out.persistence;
 
-import me.nalab.survey.application.common.dto.SurveyDto;
+import me.nalab.survey.domain.survey.Survey;
 
 /**
  * 생성된 Survey를 저장하는 역할을 하는 인터페이스
@@ -11,8 +11,9 @@ public interface CreateSurveyPort {
 
 	/**
 	 * 이 메소드는 Survey를 저장함.
-	 * @param surveyDto 저장할 Survey의 정보
+	 * @param survey 저장할 Survey의 정보
+	 * @param targetId Survey를 생성한 Target의 id
 	 */
-	void persistenceSurvey(SurveyDto surveyDto);
+	void persistenceSurvey(Long targetId, Survey survey);
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/create/CreateSurveyService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/create/CreateSurveyService.java
@@ -1,0 +1,41 @@
+package me.nalab.survey.application.service.create;
+
+import org.springframework.stereotype.Service;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+import me.nalab.survey.application.common.dto.SurveyDto;
+import me.nalab.survey.application.common.mapper.SurveyDtoMapper;
+import me.nalab.survey.application.exception.TargetDoesNotExistException;
+import me.nalab.survey.application.port.in.web.CreateSurveyUseCase;
+import me.nalab.survey.application.port.out.persistence.CreateSurveyPort;
+import me.nalab.survey.application.port.out.persistence.FindTargetPort;
+import me.nalab.survey.domain.survey.Survey;
+
+@Service
+class CreateSurveyService implements CreateSurveyUseCase {
+
+	private final CreateSurveyPort createSurveyPort;
+	private final FindTargetPort findTargetPort;
+	private final IdGenerator idGenerator;
+
+	CreateSurveyService(CreateSurveyPort createSurveyPort, FindTargetPort findTargetPort, IdGenerator idGenerator) {
+		this.createSurveyPort = createSurveyPort;
+		this.findTargetPort = findTargetPort;
+		this.idGenerator = idGenerator;
+	}
+
+	@Override
+	public void createSurvey(Long targetId, SurveyDto surveyDto) {
+		throwIfDoesNotExistTarget(targetId);
+		Survey survey = SurveyDtoMapper.toSurvey(surveyDto);
+		survey.withId(idGenerator::generate);
+		createSurveyPort.persistenceSurvey(targetId, survey);
+	}
+
+	private void throwIfDoesNotExistTarget(Long targetId) {
+		if(!findTargetPort.isExistTarget(targetId)) {
+			throw new TargetDoesNotExistException(targetId);
+		}
+	}
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/RandomSurveyDtoFixture.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/RandomSurveyDtoFixture.java
@@ -1,0 +1,131 @@
+package me.nalab.survey.application;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+import lombok.Setter;
+import me.nalab.survey.application.common.dto.ChoiceDto;
+import me.nalab.survey.application.common.dto.ChoiceFormQuestionDto;
+import me.nalab.survey.application.common.dto.ChoiceFormQuestionDtoType;
+import me.nalab.survey.application.common.dto.FormQuestionDtoable;
+import me.nalab.survey.application.common.dto.QuestionDtoType;
+import me.nalab.survey.application.common.dto.ShortFormQuestionDto;
+import me.nalab.survey.application.common.dto.ShortFormQuestionDtoType;
+import me.nalab.survey.application.common.dto.SurveyDto;
+
+public class RandomSurveyDtoFixture {
+
+	@Setter
+	private static Supplier<Long> randomIdGenerator;
+	@Setter
+	private static Supplier<LocalDateTime> randomDateTimeGenerator;
+	@Setter
+	private static Supplier<Integer> randomQuestionCountGenerator;
+	@Setter
+	private static Supplier<String> randomStringGenerator;
+	@Setter
+	private static Supplier<ChoiceFormQuestionDtoType> randomChoiceFormQuestionDtoTypeGenerator;
+	@Setter
+	private static Supplier<ShortFormQuestionDtoType> randomShortFormQuestionDtoTypeGenerator;
+	@Setter
+	private static Supplier<Integer> randomChoiceDtoCountGenerator;
+
+	static {
+		initGenerator();
+	}
+
+	public static void initGenerator() {
+		randomIdGenerator = () -> 1L;
+		randomDateTimeGenerator = LocalDateTime::now;
+		randomQuestionCountGenerator = () -> (new Random()).nextInt(10) + 1;
+		randomStringGenerator = () -> {
+			Random random = new Random();
+			return random.ints('0', (int)'z' + 1)
+				.filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+				.limit(5)
+				.collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+				.toString();
+		};
+		randomChoiceFormQuestionDtoTypeGenerator = () -> ChoiceFormQuestionDtoType.values()[(new Random()).nextInt(
+			ChoiceFormQuestionDtoType.values().length)];
+		randomShortFormQuestionDtoTypeGenerator = () -> ShortFormQuestionDtoType.values()[(new Random()).nextInt(
+			ShortFormQuestionDtoType.values().length)];
+		randomChoiceDtoCountGenerator = () -> (new Random()).nextInt(100) + 1;
+	}
+
+	public static SurveyDto createRandomSurveyDto() {
+		return SurveyDto.builder()
+			.id(randomIdGenerator.get())
+			.createdAt(randomDateTimeGenerator.get())
+			.updatedAt(randomDateTimeGenerator.get())
+			.formQuestionDtoableList(getRandomFormQuestionDtoableList())
+			.build();
+	}
+
+	private static List<FormQuestionDtoable> getRandomFormQuestionDtoableList() {
+		List<FormQuestionDtoable> formQuestionDtoableList = new ArrayList<>();
+		formQuestionDtoableList.addAll(getRandomChoiceFormQuestionDtoList(1));
+		formQuestionDtoableList.addAll(getRandomShortFormQuestionDtoList(formQuestionDtoableList.size() + 1));
+		return formQuestionDtoableList;
+	}
+
+	private static List<ChoiceFormQuestionDto> getRandomChoiceFormQuestionDtoList(int startOrder) {
+		List<ChoiceFormQuestionDto> randomChoiceFormQuestionList = new ArrayList<>();
+		int questionCount = randomQuestionCountGenerator.get();
+		for(int i = 0; i < questionCount; i++) {
+			List<ChoiceDto> choiceDtoList = getRandomChoiceDtoList();
+			randomChoiceFormQuestionList.add(
+				ChoiceFormQuestionDto.builder()
+					.id(randomIdGenerator.get())
+					.title(randomStringGenerator.get())
+					.questionDtoType(QuestionDtoType.CHOICE)
+					.createdAt(randomDateTimeGenerator.get())
+					.updatedAt(randomDateTimeGenerator.get())
+					.choiceFormQuestionDtoType(randomChoiceFormQuestionDtoTypeGenerator.get())
+					.choiceDtoList(choiceDtoList)
+					.maxSelectionCount(choiceDtoList.size())
+					.order(startOrder + randomChoiceFormQuestionList.size())
+					.build()
+			);
+		}
+		return randomChoiceFormQuestionList;
+	}
+
+	private static List<ChoiceDto> getRandomChoiceDtoList() {
+		int choiceCount = randomChoiceDtoCountGenerator.get();
+		List<ChoiceDto> choiceList = new ArrayList<>();
+		for(int i = 0; i < choiceCount; i++) {
+			choiceList.add(
+				ChoiceDto.builder()
+					.id(randomIdGenerator.get())
+					.order(choiceList.size() + 1)
+					.content(randomStringGenerator.get())
+					.build()
+			);
+		}
+		return choiceList;
+	}
+
+	private static List<ShortFormQuestionDto> getRandomShortFormQuestionDtoList(int startOrder) {
+		List<ShortFormQuestionDto> randomShortFormQuestionList = new ArrayList<>();
+		int questionCount = randomQuestionCountGenerator.get();
+		for(int i = 0; i < questionCount; i++) {
+			randomShortFormQuestionList.add(
+				ShortFormQuestionDto.builder()
+					.id(randomIdGenerator.get())
+					.order(startOrder + randomShortFormQuestionList.size())
+					.questionDtoType(QuestionDtoType.SHORT)
+					.title(randomStringGenerator.get())
+					.createdAt(randomDateTimeGenerator.get())
+					.updatedAt(randomDateTimeGenerator.get())
+					.shortFormQuestionDtoType(randomShortFormQuestionDtoTypeGenerator.get())
+					.build()
+			);
+		}
+		return randomShortFormQuestionList;
+	}
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/service/create/CreateSurveyServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/create/CreateSurveyServiceTest.java
@@ -1,0 +1,107 @@
+package me.nalab.survey.application.service.create;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.survey.application.RandomSurveyDtoFixture;
+import me.nalab.survey.application.TestIdGenerator;
+import me.nalab.survey.application.common.dto.SurveyDto;
+import me.nalab.survey.application.exception.TargetDoesNotExistException;
+import me.nalab.survey.application.port.in.web.CreateSurveyUseCase;
+import me.nalab.survey.application.port.out.persistence.CreateSurveyPort;
+import me.nalab.survey.application.port.out.persistence.FindTargetPort;
+import me.nalab.survey.domain.exception.IdAlreadyGeneratedException;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {CreateSurveyService.class, TestIdGenerator.class})
+class CreateSurveyServiceTest {
+
+	@Autowired
+	private CreateSurveyUseCase createSurveyUseCase;
+
+	@MockBean
+	private TestIdGenerator idGenerator;
+
+	@MockBean
+	private CreateSurveyPort createSurveyPort;
+
+	@MockBean
+	private FindTargetPort findTargetPort;
+
+	@ParameterizedTest
+	@MethodSource("surveyDtoLargeNullIdSources")
+	void CREATE_NEW_SURVEY_SUCCESS(SurveyDto surveyDto) {
+		// given
+		Long targetId = 1L;
+		idGenerator.setIdGenerateAlgorithm(() -> 1L);
+
+		// when
+		when(findTargetPort.isExistTarget(targetId)).thenReturn(true);
+
+		// then
+		assertDoesNotThrow(() -> createSurveyUseCase.createSurvey(targetId, surveyDto));
+	}
+
+	@ParameterizedTest
+	@MethodSource("surveyDtoSmallNotNullIdSources")
+	void CREATE_NEW_SURVEY_FAIL_DUPLICATED_ID_CALL(SurveyDto surveyDto) {
+		// given
+		Long targetId = 1L;
+		idGenerator.setIdGenerateAlgorithm(() -> 1L);
+
+		// when
+		when(findTargetPort.isExistTarget(targetId)).thenReturn(true);
+
+		// then
+		assertThrows(IdAlreadyGeneratedException.class, () -> createSurveyUseCase.createSurvey(targetId, surveyDto));
+	}
+
+	@Test
+	@DisplayName("Survey 생성 실패 테스트 - TargetId를 찾을 수 없음")
+	void CREATE_NEW_SURVEY_FAIL_CANNOT_FIND_TARGET_ID() {
+		// given
+		Long targetId = 1L;
+
+		// when
+		when(findTargetPort.isExistTarget(targetId)).thenReturn(false);
+
+		// then
+		assertThrows(TargetDoesNotExistException.class, () -> createSurveyUseCase.createSurvey(targetId, null));
+	}
+
+	private static Stream<SurveyDto> surveyDtoLargeNullIdSources() {
+		RandomSurveyDtoFixture.initGenerator();
+		RandomSurveyDtoFixture.setRandomIdGenerator(() -> null);
+		List<SurveyDto> surveyDtoList = new ArrayList<>();
+		for(int i = 0; i < 100; i++) {
+			surveyDtoList.add(RandomSurveyDtoFixture.createRandomSurveyDto());
+		}
+		return surveyDtoList.stream();
+	}
+
+	private static Stream<SurveyDto> surveyDtoSmallNotNullIdSources(){
+		RandomSurveyDtoFixture.initGenerator();
+		RandomSurveyDtoFixture.setRandomIdGenerator(() -> 1L);
+		List<SurveyDto> surveyDtoList = new ArrayList<>();
+		for(int i = 0; i < 20; i++) {
+			surveyDtoList.add(RandomSurveyDtoFixture.createRandomSurveyDto());
+		}
+		return surveyDtoList.stream();
+	}
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
application 모듈의 survey 생성 service를 추가했습니다.

## 어떻게 해결했나요?
- [x] `in.port` 에서 요청을 받아, id를 세팅후 `out.port` 에 저장하는 요청 로직을 구성 했습니다.
- [x] survey를 생성할때, survey 생성 요청을 한 `target` 을 찾을 수 없는 경우, `TargetDoesNotExistException` 을 던지게 했습니다.
- [x] 관련 테스트 케이스를 작성 했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
