### PR TITLE
[fix] : `data` 모듈 청소

### DIFF
--- a/core/data/build.gradle
+++ b/core/data/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'javax.persistence:javax.persistence-api:2.2'
 }

--- a/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestion.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestion.java
@@ -16,8 +16,8 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Setter
 @Getter
+@Setter
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/core/data/src/main/java/me/nalab/core/data/target/Target.java
+++ b/core/data/src/main/java/me/nalab/core/data/target/Target.java
@@ -4,7 +4,6 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.validation.Valid;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,7 +19,6 @@ import me.nalab.core.data.common.TimeBaseEntity;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-@Valid
 public class Target extends TimeBaseEntity {
 
 	@Id

--- a/core/data/src/main/java/module-info.java
+++ b/core/data/src/main/java/module-info.java
@@ -6,7 +6,6 @@ module luffy.core.data.main {
 
 	requires lombok;
 	requires java.persistence;
-	requires java.validation;
 	requires spring.data.commons;
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`Entity`가 위치한 `data` 모듈에서, 더 이상 사용하지 않는 의존성을 삭제하고, `Entity class`간 어노테이션 순서를 맞췄습니다

## 어떻게 해결했나요?
- [x] 사용하지 않는, `java.validation` 에 대한 의존성 삭제
- [x] 사용하지 않는, `java.validation` 어노테이션 삭제
- [x] `ChoiceFormQuestion` entity의 `@Getter` `@Setter` 어노테이션 순서 변경

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
