### PR TITLE
[fix] : `JpaEntity` 클래스에 -Entity 접미사 추가

### DIFF
--- a/core/data/src/main/java/me/nalab/core/data/survey/ChoiceEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ChoiceEntity.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Choice {
+public class ChoiceEntity {
 
 	@Id
 	@Column(name = "choice_id")
@@ -35,6 +35,6 @@ public class Choice {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "form_question_id", nullable = false)
-	private ChoiceFormQuestion choiceFormQuestion;
+	private ChoiceFormQuestionEntity choiceFormQuestion;
 
 }

--- a/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntity.java
@@ -21,16 +21,16 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChoiceFormQuestion extends FormQuestion {
+public class ChoiceFormQuestionEntity extends FormQuestionEntity {
 
 	@OneToMany(mappedBy = "choiceFormQuestion", fetch = FetchType.LAZY)
-	private List<Choice> choiceList;
+	private List<ChoiceEntity> choiceList;
 
 	@Column(name = "max_selection_count")
 	private Integer maxSelectionCount;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "choice_question_type")
-	private ChoiceFormQuestionType choiceFormQuestionType;
+	private ChoiceFormQuestionEntityType choiceFormQuestionType;
 
 }

--- a/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntityType.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntityType.java
@@ -5,7 +5,7 @@ package me.nalab.core.data.survey;
  *
  * @author devxb
  */
-public enum ChoiceFormQuestionType {
+public enum ChoiceFormQuestionEntityType {
 
 	/**
 	 * COLLABORATION_EXPERIENCE 는 기본질문중 `협업경험` 을 나타냅니다.

--- a/core/data/src/main/java/me/nalab/core/data/survey/FormQuestionEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/FormQuestionEntity.java
@@ -23,7 +23,7 @@ import me.nalab.core.data.common.TimeBaseEntity;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public abstract class FormQuestion extends TimeBaseEntity {
+public abstract class FormQuestionEntity extends TimeBaseEntity {
 
 	@Id
 	@Column(name = "form_question_id")
@@ -37,10 +37,10 @@ public abstract class FormQuestion extends TimeBaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "question_type")
-	protected QuestionType questionType;
+	protected QuestionEntityType questionType;
 
 	@ManyToOne
 	@JoinColumn(name = "survey_id", nullable = false)
-	protected Survey survey;
+	protected SurveyEntity survey;
 
 }

--- a/core/data/src/main/java/me/nalab/core/data/survey/QuestionEntityType.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/QuestionEntityType.java
@@ -6,7 +6,7 @@ package me.nalab.core.data.survey;
  *
  * @author devxb
  */
-public enum QuestionType {
+public enum QuestionEntityType {
 
 	/**
 	 * 객관식

--- a/core/data/src/main/java/me/nalab/core/data/survey/ShortFormQuestionEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ShortFormQuestionEntity.java
@@ -17,10 +17,10 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ShortFormQuestion extends FormQuestion {
+public class ShortFormQuestionEntity extends FormQuestionEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "short_form_question_type")
-	private ShortFormQuestionType shortFormQuestionType;
+	private ShortFormQuestionEntityType shortFormQuestionType;
 
 }

--- a/core/data/src/main/java/me/nalab/core/data/survey/ShortFormQuestionEntityType.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ShortFormQuestionEntityType.java
@@ -5,7 +5,7 @@ package me.nalab.core.data.survey;
  *
  * @author devxb
  */
-public enum ShortFormQuestionType {
+public enum ShortFormQuestionEntityType {
 
 	/**
 	 * 주관식 기본질문중 `나의 강점` Type

--- a/core/data/src/main/java/me/nalab/core/data/survey/SurveyEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/SurveyEntity.java
@@ -24,14 +24,14 @@ import me.nalab.core.data.common.TimeBaseEntity;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Survey extends TimeBaseEntity {
+public class SurveyEntity extends TimeBaseEntity {
 
 	@Id
 	@Column(name = "survey_id")
 	private Long id;
 
 	@OneToMany(mappedBy = "survey", fetch = FetchType.LAZY)
-	private List<FormQuestion> formQuestionableList;
+	private List<FormQuestionEntity> formQuestionableList;
 
 	@JoinColumn(name = "target_id", nullable = false)
 	private Long targetId;

--- a/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
@@ -19,7 +19,7 @@ import me.nalab.core.data.common.TimeBaseEntity;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Target extends TimeBaseEntity {
+public class TargetEntity extends TimeBaseEntity {
 
 	@Id
 	@Column(name = "target_id")


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
jpa-entity 클래스와 domain 클래스의 이름이 같아. 변환시 한쪽을 `public Survey toSurvey (me.nalab.core.data.Survey survey){...}` 와 같이 사용해야하는 문제점이 있어, JpaEntity에 -Entity 접미사를 추가했습니다.

## 어떻게 해결했나요?
- [x] JpaEntity 클래스에 -Entity 접미사를 추가했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
