### PR TITLE
[feat] : 질문 폼 조회 application의 port 인터페이스 수정

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/survey/find/SurveyFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/survey/find/SurveyFindPort.java
@@ -1,9 +1,9 @@
 package me.nalab.survey.application.port.out.persistence.survey.find;
 
-import me.nalab.survey.application.common.dto.SurveyDto;
+import me.nalab.survey.domain.survey.Survey;
 
 public interface SurveyFindPort {
 
-	SurveyDto getSurvey(Long surveyId);
+	Survey getSurvey(Long surveyId);
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/target/find/TargetFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/target/find/TargetFindPort.java
@@ -1,8 +1,10 @@
 package me.nalab.survey.application.port.out.persistence.target.find;
 
-import me.nalab.survey.application.common.dto.TargetDto;
+import me.nalab.survey.domain.target.Target;
 
 public interface TargetFindPort {
 
-	TargetDto getTarget(Long surveyId);
+	Target getTarget(Long targetId);
+
+	Long getTargetId(Long surveyId);
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/survey/find/SurveyFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/survey/find/SurveyFindService.java
@@ -5,18 +5,24 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.survey.application.common.dto.SurveyDto;
+import me.nalab.survey.application.common.mapper.SurveyDtoMapper;
 import me.nalab.survey.application.port.in.web.survey.find.SurveyFindUseCase;
 import me.nalab.survey.application.port.out.persistence.survey.find.SurveyFindPort;
+import me.nalab.survey.application.port.out.persistence.target.find.TargetFindPort;
+import me.nalab.survey.domain.survey.Survey;
 
 @Service
 @RequiredArgsConstructor
 public class SurveyFindService implements SurveyFindUseCase {
 
+	private final TargetFindPort targetFindPort;
 	private final SurveyFindPort surveyFindPort;
 
 	@Override
 	@Transactional(readOnly = true)
 	public SurveyDto findSurvey(Long surveyId) {
-		return surveyFindPort.getSurvey(surveyId);
+		Long targetId = targetFindPort.getTargetId(surveyId);
+		Survey survey = surveyFindPort.getSurvey(surveyId);
+		return SurveyDtoMapper.toSurveyDto(targetId, survey);
 	}
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/target/find/TargetFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/target/find/TargetFindService.java
@@ -5,8 +5,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.survey.application.common.dto.TargetDto;
+import me.nalab.survey.application.common.mapper.TargetDtoMapper;
 import me.nalab.survey.application.port.in.web.target.find.TargetFindUseCase;
 import me.nalab.survey.application.port.out.persistence.target.find.TargetFindPort;
+import me.nalab.survey.domain.target.Target;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +19,7 @@ public class TargetFindService implements TargetFindUseCase {
 	@Override
 	@Transactional(readOnly = true)
 	public TargetDto findTarget(Long targetId) {
-		return targetFindPort.getTarget(targetId);
+		Target target = targetFindPort.getTarget(targetId);
+		return TargetDtoMapper.toTargetDto(target);
 	}
 }

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -5,6 +5,8 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.out.persistence;
 	exports me.nalab.survey.application.port.in.web.survey.find;
 	exports me.nalab.survey.application.port.in.web.target.find;
+	exports me.nalab.survey.application.port.out.persistence.survey.find;
+	exports me.nalab.survey.application.port.out.persistence.target.find;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/application/src/test/java/me/nalab/survey/application/RandomSurveyDtoFixture.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/RandomSurveyDtoFixture.java
@@ -59,6 +59,7 @@ public class RandomSurveyDtoFixture {
 	public static SurveyDto createRandomSurveyDto() {
 		return SurveyDto.builder()
 			.id(randomIdGenerator.get())
+			.targetId(randomIdGenerator.get())
 			.createdAt(randomDateTimeGenerator.get())
 			.updatedAt(randomDateTimeGenerator.get())
 			.formQuestionDtoableList(getRandomFormQuestionDtoableList())

--- a/survey/application/src/test/java/me/nalab/survey/application/service/survey/find/SurveyFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/survey/find/SurveyFindServiceTest.java
@@ -36,9 +36,6 @@ class SurveyFindServiceTest {
 	@Test
 	void SURVEY_FIND_SERVICE_TEST() {
 
-		// 총 테스트 돌릴 횟수
-		int numberOfTestCases = 10;
-
 		// random으로 생성
 		SurveyDto randomSurveyDto = createRandomSurveyDto();
 		Long surveyId = randomSurveyDto.getId();

--- a/survey/application/src/test/java/me/nalab/survey/application/service/survey/find/SurveyFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/survey/find/SurveyFindServiceTest.java
@@ -1,6 +1,9 @@
 package me.nalab.survey.application.service.survey.find;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static me.nalab.survey.application.RandomSurveyDtoFixture.createRandomSurveyDto;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -9,9 +12,15 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import me.nalab.survey.application.common.dto.SurveyDto;
+import me.nalab.survey.application.common.mapper.SurveyDtoMapper;
 import me.nalab.survey.application.port.out.persistence.survey.find.SurveyFindPort;
+import me.nalab.survey.application.port.out.persistence.target.find.TargetFindPort;
+import me.nalab.survey.domain.survey.Survey;
 
 class SurveyFindServiceTest {
+
+	@Mock
+	private TargetFindPort targetFindPort;
 
 	@Mock
 	private SurveyFindPort surveyFindPort;
@@ -19,24 +28,34 @@ class SurveyFindServiceTest {
 	private SurveyFindService surveyFindService;
 
 	@BeforeEach
-	public void setUp() {
+	void setup() {
 		MockitoAnnotations.openMocks(this);
-		surveyFindService = new SurveyFindService(surveyFindPort);
+		surveyFindService = new SurveyFindService(targetFindPort, surveyFindPort);
 	}
 
 	@Test
-	void surveyFindService() {
-		// given
-		Long surveyId = 1L;
-		SurveyDto expectedSurveyDto = SurveyDto.builder()
-			.id(surveyId)
-			.build();
-		when(surveyFindPort.getSurvey(surveyId)).thenReturn(expectedSurveyDto);
+	void SURVEY_FIND_SERVICE_TEST() {
+		// 총 테스트 돌릴 횟수
+		int numberOfTestCases = 10;
 
-		// when
-		SurveyDto actualSurveyDto = surveyFindService.findSurvey(surveyId);
+		for(int i = 0; i < numberOfTestCases; i++) {
+			// random으로 생성
+			SurveyDto randomSurveyDto = createRandomSurveyDto();
+			Long surveyId = randomSurveyDto.getId();
+			Long targetId = randomSurveyDto.getTargetId();
+			Survey survey = SurveyDtoMapper.toSurvey(randomSurveyDto);
 
-		// then
-		assertEquals(expectedSurveyDto, actualSurveyDto);
+			when(targetFindPort.getTargetId(surveyId)).thenReturn(targetId);
+			when(surveyFindPort.getSurvey(surveyId)).thenReturn(survey);
+
+			SurveyDto result = surveyFindService.findSurvey(surveyId);
+
+			assertAll(
+				() -> assertNotNull(result),
+				() -> assertEquals(targetId, result.getTargetId()),
+				() -> assertEquals(survey, SurveyDtoMapper.toSurvey(result))
+			);
+
+		}
 	}
 }

--- a/survey/application/src/test/java/me/nalab/survey/application/service/survey/find/SurveyFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/survey/find/SurveyFindServiceTest.java
@@ -35,27 +35,26 @@ class SurveyFindServiceTest {
 
 	@Test
 	void SURVEY_FIND_SERVICE_TEST() {
+
 		// 총 테스트 돌릴 횟수
 		int numberOfTestCases = 10;
 
-		for(int i = 0; i < numberOfTestCases; i++) {
-			// random으로 생성
-			SurveyDto randomSurveyDto = createRandomSurveyDto();
-			Long surveyId = randomSurveyDto.getId();
-			Long targetId = randomSurveyDto.getTargetId();
-			Survey survey = SurveyDtoMapper.toSurvey(randomSurveyDto);
+		// random으로 생성
+		SurveyDto randomSurveyDto = createRandomSurveyDto();
+		Long surveyId = randomSurveyDto.getId();
+		Long targetId = randomSurveyDto.getTargetId();
+		Survey survey = SurveyDtoMapper.toSurvey(randomSurveyDto);
 
-			when(targetFindPort.getTargetId(surveyId)).thenReturn(targetId);
-			when(surveyFindPort.getSurvey(surveyId)).thenReturn(survey);
+		when(targetFindPort.getTargetId(surveyId)).thenReturn(targetId);
+		when(surveyFindPort.getSurvey(surveyId)).thenReturn(survey);
 
-			SurveyDto result = surveyFindService.findSurvey(surveyId);
+		SurveyDto result = surveyFindService.findSurvey(surveyId);
 
-			assertAll(
-				() -> assertNotNull(result),
-				() -> assertEquals(targetId, result.getTargetId()),
-				() -> assertEquals(survey, SurveyDtoMapper.toSurvey(result))
-			);
+		assertAll(
+			() -> assertNotNull(result),
+			() -> assertEquals(targetId, result.getTargetId()),
+			() -> assertEquals(survey, SurveyDtoMapper.toSurvey(result))
+		);
 
-		}
 	}
 }

--- a/survey/application/src/test/java/me/nalab/survey/application/service/target/find/TargetFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/target/find/TargetFindServiceTest.java
@@ -1,6 +1,5 @@
 package me.nalab.survey.application.service.target.find;
 
-import static me.nalab.survey.application.RandomSurveyDtoFixture.createRandomSurveyDto;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
@@ -9,50 +8,38 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import me.nalab.survey.application.common.dto.SurveyDto;
-import me.nalab.survey.application.common.mapper.SurveyDtoMapper;
-import me.nalab.survey.application.port.out.persistence.survey.find.SurveyFindPort;
+import me.nalab.survey.application.common.dto.TargetDto;
+import me.nalab.survey.application.common.mapper.TargetDtoMapper;
 import me.nalab.survey.application.port.out.persistence.target.find.TargetFindPort;
-import me.nalab.survey.application.service.survey.find.SurveyFindService;
-import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.domain.target.Target;
 
 class TargetFindServiceTest {
 
 	@Mock
 	private TargetFindPort targetFindPort;
 
-	@Mock
-	private SurveyFindPort surveyFindPort;
-
-	private SurveyFindService surveyFindService;
+	private TargetFindService targetFindService;
 
 	@BeforeEach
 	void setup() {
 		MockitoAnnotations.openMocks(this);
-		surveyFindService = new SurveyFindService(targetFindPort, surveyFindPort);
+		targetFindService = new TargetFindService(targetFindPort);
 	}
 
 	@Test
 	void TARGET_FIND_SERVICE_TEST() {
-		// 총 테스트 돌릴 횟수
-		int numberOfTestCases = 10;
-		for(int i = 0; i < numberOfTestCases; i++) {
-			// ramdom으로 생성
-			SurveyDto randomSurveyDto = createRandomSurveyDto();
-			Long surveyId = randomSurveyDto.getId();
-			Long targetId = randomSurveyDto.getTargetId();
-			Survey survey = SurveyDtoMapper.toSurvey(randomSurveyDto);
 
-			when(targetFindPort.getTargetId(surveyId)).thenReturn(targetId);
-			when(surveyFindPort.getSurvey(surveyId)).thenReturn(survey);
+		Long targetId = 123L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
 
-			SurveyDto surveyDto = surveyFindService.findSurvey(surveyId);
+		when(targetFindPort.getTarget(targetId)).thenReturn(target);
 
-			assertAll(
-				() -> assertNotNull(surveyDto),
-				() -> assertEquals(targetId, surveyDto.getTargetId()),
-				() -> assertEquals(survey, SurveyDtoMapper.toSurvey(surveyDto))
-			);
-		}
+		TargetDto result = targetFindService.findTarget(targetId);
+
+		assertEquals(TargetDtoMapper.toTargetDto(target), result);
+
 	}
 }

--- a/survey/application/src/test/java/me/nalab/survey/application/service/target/find/TargetFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/target/find/TargetFindServiceTest.java
@@ -1,5 +1,6 @@
 package me.nalab.survey.application.service.target.find;
 
+import static me.nalab.survey.application.RandomSurveyDtoFixture.createRandomSurveyDto;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
@@ -8,36 +9,50 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import me.nalab.survey.application.common.dto.TargetDto;
+import me.nalab.survey.application.common.dto.SurveyDto;
+import me.nalab.survey.application.common.mapper.SurveyDtoMapper;
+import me.nalab.survey.application.port.out.persistence.survey.find.SurveyFindPort;
 import me.nalab.survey.application.port.out.persistence.target.find.TargetFindPort;
+import me.nalab.survey.application.service.survey.find.SurveyFindService;
+import me.nalab.survey.domain.survey.Survey;
 
 class TargetFindServiceTest {
 
 	@Mock
 	private TargetFindPort targetFindPort;
 
-	private TargetFindService targetFindService;
+	@Mock
+	private SurveyFindPort surveyFindPort;
+
+	private SurveyFindService surveyFindService;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		MockitoAnnotations.openMocks(this);
-		targetFindService = new TargetFindService(targetFindPort);
+		surveyFindService = new SurveyFindService(targetFindPort, surveyFindPort);
 	}
 
 	@Test
-	void targetFindService() {
-		// given
-		Long targetId = 1L;
-		TargetDto expectedTargetDto = TargetDto.builder()
-			.id(1L)
-			.nickname("sujin")
-			.build();
-		when(targetFindPort.getTarget(targetId)).thenReturn(expectedTargetDto);
+	void TARGET_FIND_SERVICE_TEST() {
+		// 총 테스트 돌릴 횟수
+		int numberOfTestCases = 10;
+		for(int i = 0; i < numberOfTestCases; i++) {
+			// ramdom으로 생성
+			SurveyDto randomSurveyDto = createRandomSurveyDto();
+			Long surveyId = randomSurveyDto.getId();
+			Long targetId = randomSurveyDto.getTargetId();
+			Survey survey = SurveyDtoMapper.toSurvey(randomSurveyDto);
 
-		// when
-		TargetDto actualTargetDto = targetFindService.findTarget(targetId);
+			when(targetFindPort.getTargetId(surveyId)).thenReturn(targetId);
+			when(surveyFindPort.getSurvey(surveyId)).thenReturn(survey);
 
-		// then
-		assertEquals(expectedTargetDto, actualTargetDto);
+			SurveyDto surveyDto = surveyFindService.findSurvey(surveyId);
+
+			assertAll(
+				() -> assertNotNull(surveyDto),
+				() -> assertEquals(targetId, surveyDto.getTargetId()),
+				() -> assertEquals(survey, SurveyDtoMapper.toSurvey(surveyDto))
+			);
+		}
 	}
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문 폼 조회 application의 persistence 쪽으로 나가는 port의 반환 타입이 틀렸었습니다
jaa-adaptor 쪽을 구현하다가 알아차리고 다시 급하게 수정하였습니다
반환타입은 도메인이어야합니다.
도메인으로 변경하고, 해당 service의 테스트코드도 수정이 많이 일어나 테스트코드도 거의 다시 짰습니다


## 어떻게 해결했나요?

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
