### PR TITLE
[fix] : `@Entity`의 column이름 수정 및 cascade정책

### DIFF
--- a/core/data/src/main/java/me/nalab/core/data/survey/ChoiceEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ChoiceEntity.java
@@ -30,11 +30,11 @@ public class ChoiceEntity {
 	@Column(name = "content", length = 18, nullable = false)
 	private String content;
 
-	@Column(name = "order", nullable = false)
+	@Column(name = "orders", nullable = false)
 	private Integer order;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "form_question_id", nullable = false)
+	@JoinColumn(name = "form_question_id")
 	private ChoiceFormQuestionEntity choiceFormQuestion;
 
 }

--- a/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntity.java
@@ -2,6 +2,7 @@ package me.nalab.core.data.survey;
 
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -9,7 +10,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -20,10 +20,9 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
 public class ChoiceFormQuestionEntity extends FormQuestionEntity {
 
-	@OneToMany(mappedBy = "choiceFormQuestion", fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "choiceFormQuestion", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
 	private List<ChoiceEntity> choiceList;
 
 	@Column(name = "max_selection_count")
@@ -32,5 +31,23 @@ public class ChoiceFormQuestionEntity extends FormQuestionEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "choice_question_type")
 	private ChoiceFormQuestionEntityType choiceFormQuestionType;
+
+	public ChoiceFormQuestionEntity(FormQuestionEntityBuilder<?, ?> b, List<ChoiceEntity> choiceList,
+		Integer maxSelectionCount, ChoiceFormQuestionEntityType choiceFormQuestionType) {
+		super(b);
+		this.maxSelectionCount = maxSelectionCount;
+		this.choiceFormQuestionType = choiceFormQuestionType;
+		this.choiceList = choiceList;
+		cascadeChoiceFormQuestion();
+	}
+
+	private void cascadeChoiceFormQuestion() {
+		for(ChoiceEntity choiceEntity : choiceList) {
+			if(choiceEntity.getChoiceFormQuestion() == this) {
+				continue;
+			}
+			choiceEntity.setChoiceFormQuestion(this);
+		}
+	}
 
 }

--- a/core/data/src/main/java/me/nalab/core/data/survey/FormQuestionEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/FormQuestionEntity.java
@@ -4,6 +4,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -32,15 +33,15 @@ public abstract class FormQuestionEntity extends TimeBaseEntity {
 	@Column(name = "title", nullable = false, length = 45)
 	protected String title;
 
-	@Column(name = "order", nullable = false)
+	@Column(name = "orders", nullable = false)
 	protected Integer order;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "question_type")
 	protected QuestionEntityType questionType;
 
-	@ManyToOne
-	@JoinColumn(name = "survey_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "survey_id")
 	protected SurveyEntity survey;
 
 }

--- a/core/data/src/main/java/me/nalab/core/data/survey/SurveyEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/SurveyEntity.java
@@ -2,6 +2,7 @@ package me.nalab.core.data.survey;
 
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -10,7 +11,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,17 +23,34 @@ import me.nalab.core.data.common.TimeBaseEntity;
 @Setter
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
 public class SurveyEntity extends TimeBaseEntity {
 
 	@Id
 	@Column(name = "survey_id")
 	private Long id;
 
-	@OneToMany(mappedBy = "survey", fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "survey", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
 	private List<FormQuestionEntity> formQuestionableList;
 
 	@JoinColumn(name = "target_id", nullable = false)
 	private Long targetId;
+
+	public SurveyEntity(TimeBaseEntityBuilder<?, ?> b, Long id, List<FormQuestionEntity> formQuestionableList,
+		Long targetId) {
+		super(b);
+		this.id = id;
+		this.targetId = targetId;
+		this.formQuestionableList = formQuestionableList;
+		cascadeSurvey();
+	}
+
+	private void cascadeSurvey() {
+		for(FormQuestionEntity formQuestionEntity : formQuestionableList) {
+			if(formQuestionEntity.getSurvey() == this) {
+				continue;
+			}
+			formQuestionEntity.setSurvey(this);
+		}
+	}
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`@Entity`의 column명을 수정하고, Cascade정책을 추가 했습니다.

## 어떻게 해결했나요?
- [x] `@Entity`의 column명중, DB예약어인 `order`를 `orders`로 변경 했습니다.
- [x] `cascade` 정책을, DB저장시 자신에게 속해있는 질문폼과 선택지도 함께 저장되도록 수정했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
