### PR TITLE
[fix] : `@Entity` 생성시, 자식에게 `FK auto set` 이 안되는 문제

### DIFF
--- a/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntity.java
@@ -32,12 +32,11 @@ public class ChoiceFormQuestionEntity extends FormQuestionEntity {
 	@Column(name = "choice_question_type")
 	private ChoiceFormQuestionEntityType choiceFormQuestionType;
 
-	public ChoiceFormQuestionEntity(FormQuestionEntityBuilder<?, ?> b, List<ChoiceEntity> choiceList,
-		Integer maxSelectionCount, ChoiceFormQuestionEntityType choiceFormQuestionType) {
-		super(b);
-		this.maxSelectionCount = maxSelectionCount;
-		this.choiceFormQuestionType = choiceFormQuestionType;
-		this.choiceList = choiceList;
+	ChoiceFormQuestionEntity(ChoiceFormQuestionEntityBuilder<?, ?> choiceFormQuestionEntityBuilder) {
+		super(choiceFormQuestionEntityBuilder);
+		this.maxSelectionCount = choiceFormQuestionEntityBuilder.maxSelectionCount;
+		this.choiceFormQuestionType = choiceFormQuestionEntityBuilder.choiceFormQuestionType;
+		this.choiceList = choiceFormQuestionEntityBuilder.choiceList;
 		cascadeChoiceFormQuestion();
 	}
 

--- a/core/data/src/main/java/me/nalab/core/data/survey/SurveyEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/SurveyEntity.java
@@ -35,12 +35,11 @@ public class SurveyEntity extends TimeBaseEntity {
 	@JoinColumn(name = "target_id", nullable = false)
 	private Long targetId;
 
-	public SurveyEntity(TimeBaseEntityBuilder<?, ?> b, Long id, List<FormQuestionEntity> formQuestionableList,
-		Long targetId) {
-		super(b);
-		this.id = id;
-		this.targetId = targetId;
-		this.formQuestionableList = formQuestionableList;
+	SurveyEntity(SurveyEntityBuilder<?, ?> surveyEntityBuilder){
+		super(surveyEntityBuilder);
+		this.id = surveyEntityBuilder.id;
+		this.formQuestionableList = surveyEntityBuilder.formQuestionableList;
+		this.targetId = surveyEntityBuilder.targetId;
 		cascadeSurvey();
 	}
 


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`@Entity` 생성시, 자식에게 `FK auto set` 이 안되는 문제를 수정했습니다.

## 어떻게 해결했나요?
- [x] lombok의 `@SuperBuilder` 가 호출하는 생성자가 잘못 구현되어 있어서, 생성자를 다시 구현했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
