### PR TITLE
[feat] : Survey create usecase 관련된 `jpa-adaptor` 추가

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/LatestSurveyIdFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/LatestSurveyIdFindPort.java
@@ -13,6 +13,6 @@ public interface LatestSurveyIdFindPort {
 	 * @param targetId surveyId를 조회할 타겟의 ID
 	 * @return Optional 만약, 어떠한 SurveyId도 조회할 수 없을경우, Optional.empty() 를 반환해야 합니다.
 	 */
-	Optional<Long> getLatestSurveyIdByTargetId(Long targetId);
+	Optional<Long> findLatestSurveyIdByTargetId(Long targetId);
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/SurveyCreatePort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/SurveyCreatePort.java
@@ -14,6 +14,6 @@ public interface SurveyCreatePort {
 	 * @param survey 저장할 Survey의 정보
 	 * @param targetId Survey를 생성한 Target의 id
 	 */
-	void persistenceSurvey(Long targetId, Survey survey);
+	void createSurvey(Long targetId, Survey survey);
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/TargetExistCheckPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/TargetExistCheckPort.java
@@ -11,6 +11,6 @@ public interface TargetExistCheckPort {
 	 * @param targetId 존재하는지 확인할 target의 ID
 	 * @return boolean 존재한다면 true / 존재하지 않는다면, false
 	 */
-	boolean isExistTarget(Long targetId);
+	boolean isExistTargetByTargetId(Long targetId);
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/create/LatestSurveyIdFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/create/LatestSurveyIdFindService.java
@@ -16,7 +16,7 @@ public class LatestSurveyIdFindService implements LatestSurveyIdFindUseCase {
 	@Override
 	@Transactional(readOnly = true)
 	public Long getLatestSurveyIdByTargetId(Long targetId) {
-		return latestSurveyIdFindPort.getLatestSurveyIdByTargetId(targetId)
+		return latestSurveyIdFindPort.findLatestSurveyIdByTargetId(targetId)
 			.orElseThrow(() -> {
 				throw new IllegalStateException(
 					"Cannot find any survey. \"This method must be called after one or more surveys have been created.\""

--- a/survey/application/src/main/java/me/nalab/survey/application/service/create/SurveyCreateService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/create/SurveyCreateService.java
@@ -27,11 +27,11 @@ class SurveyCreateService implements CreateSurveyUseCase {
 		throwIfDoesNotExistTarget(targetId);
 		Survey survey = SurveyDtoMapper.toSurvey(surveyDto);
 		survey.withId(idGenerator::generate);
-		surveyCreatePort.persistenceSurvey(targetId, survey);
+		surveyCreatePort.createSurvey(targetId, survey);
 	}
 
 	private void throwIfDoesNotExistTarget(Long targetId) {
-		if(!targetExistCheckPort.isExistTarget(targetId)) {
+		if(!targetExistCheckPort.isExistTargetByTargetId(targetId)) {
 			throw new TargetDoesNotExistException(targetId);
 		}
 	}

--- a/survey/application/src/test/java/me/nalab/survey/application/service/create/LatestSurveyIdFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/create/LatestSurveyIdFindServiceTest.java
@@ -35,7 +35,7 @@ class LatestSurveyIdFindServiceTest {
 		Long surveyId = 12345677890L;
 
 		// when
-		when(latestSurveyIdFindPort.getLatestSurveyIdByTargetId(targetId)).thenReturn(Optional.of(surveyId));
+		when(latestSurveyIdFindPort.findLatestSurveyIdByTargetId(targetId)).thenReturn(Optional.of(surveyId));
 
 		// then
 		assertEquals(surveyId, latestSurveyIdFindUseCase.getLatestSurveyIdByTargetId(targetId));
@@ -49,7 +49,7 @@ class LatestSurveyIdFindServiceTest {
 		Long surveyId = 1234567890L;
 
 		// when
-		when(latestSurveyIdFindPort.getLatestSurveyIdByTargetId(targetId)).thenReturn(Optional.empty());
+		when(latestSurveyIdFindPort.findLatestSurveyIdByTargetId(targetId)).thenReturn(Optional.empty());
 
 		// then
 		assertThrows(IllegalStateException.class,

--- a/survey/application/src/test/java/me/nalab/survey/application/service/create/SurveyCreateServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/create/SurveyCreateServiceTest.java
@@ -51,7 +51,7 @@ class SurveyCreateServiceTest {
 		idGenerator.setIdGenerateAlgorithm(() -> 1L);
 
 		// when
-		when(findTargetPort.isExistTarget(targetId)).thenReturn(true);
+		when(findTargetPort.isExistTargetByTargetId(targetId)).thenReturn(true);
 
 		// then
 		assertDoesNotThrow(() -> createSurveyUseCase.createSurvey(targetId, surveyDto));
@@ -65,7 +65,7 @@ class SurveyCreateServiceTest {
 		idGenerator.setIdGenerateAlgorithm(() -> 1L);
 
 		// when
-		when(findTargetPort.isExistTarget(targetId)).thenReturn(true);
+		when(findTargetPort.isExistTargetByTargetId(targetId)).thenReturn(true);
 
 		// then
 		assertThrows(IdAlreadyGeneratedException.class, () -> createSurveyUseCase.createSurvey(targetId, surveyDto));
@@ -78,7 +78,7 @@ class SurveyCreateServiceTest {
 		Long targetId = 1L;
 
 		// when
-		when(findTargetPort.isExistTarget(targetId)).thenReturn(false);
+		when(findTargetPort.isExistTargetByTargetId(targetId)).thenReturn(false);
 
 		// then
 		assertThrows(TargetDoesNotExistException.class, () -> createSurveyUseCase.createSurvey(targetId, null));

--- a/survey/jpa-adaptor/build.gradle
+++ b/survey/jpa-adaptor/build.gradle
@@ -4,4 +4,6 @@ dependencies {
     implementation project(':core:data')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    testImplementation 'com.h2database:h2:2.1.214'
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/LatestSurveyIdFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/LatestSurveyIdFindAdaptor.java
@@ -4,17 +4,17 @@ import java.util.Optional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
 
 import org.springframework.stereotype.Repository;
 
-import lombok.RequiredArgsConstructor;
 import me.nalab.survey.application.port.out.persistence.LatestSurveyIdFindPort;
 
 @Repository
-@RequiredArgsConstructor
 public class LatestSurveyIdFindAdaptor implements LatestSurveyIdFindPort {
 
-	private final EntityManager entityManager;
+	@PersistenceContext
+	private EntityManager entityManager;
 
 	@Override
 	public Optional<Long> findLatestSurveyIdByTargetId(Long targetId) {

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/LatestSurveyIdFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/LatestSurveyIdFindAdaptor.java
@@ -1,0 +1,34 @@
+package me.nalab.survey.jpa.adaptor.create;
+
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.port.out.persistence.LatestSurveyIdFindPort;
+
+@Repository
+@RequiredArgsConstructor
+public class LatestSurveyIdFindAdaptor implements LatestSurveyIdFindPort {
+
+	private final EntityManager entityManager;
+
+	@Override
+	public Optional<Long> findLatestSurveyIdByTargetId(Long targetId) {
+		try {
+			Long result = entityManager.createQuery(
+					"select se.id from SurveyEntity se where se.targetId = :targetId order by se.createdAt desc",
+					Long.class)
+				.setParameter("targetId", targetId)
+				.setMaxResults(1)
+				.getSingleResult();
+			return Optional.of(result);
+		} catch(NoResultException noResultException) {
+			return Optional.empty();
+		}
+	}
+
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/SurveyCreateAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/SurveyCreateAdaptor.java
@@ -1,0 +1,24 @@
+package me.nalab.survey.jpa.adaptor.create;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.survey.application.port.out.persistence.SurveyCreatePort;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+import me.nalab.survey.jpa.adaptor.create.repository.SurveyCreateJpaRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class SurveyCreateAdaptor implements SurveyCreatePort {
+
+	private final SurveyCreateJpaRepository surveyCreateJpaRepository;
+
+	@Override
+	public void createSurvey(Long targetId, Survey survey) {
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetId, survey);
+		surveyCreateJpaRepository.save(surveyEntity);
+	}
+
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/TargetExistCheckAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/TargetExistCheckAdaptor.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.jpa.adaptor.create;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.port.out.persistence.TargetExistCheckPort;
+import me.nalab.survey.jpa.adaptor.create.repository.TargetExistJpaRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class TargetExistCheckAdaptor implements TargetExistCheckPort {
+
+	private final TargetExistJpaRepository targetExistJpaRepository;
+
+	@Override
+	public boolean isExistTargetByTargetId(Long targetId) {
+		return targetExistJpaRepository.existsById(targetId);
+	}
+
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/repository/SurveyCreateJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/repository/SurveyCreateJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.create.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface SurveyCreateJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/repository/TargetExistJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/create/repository/TargetExistJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.create.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TargetExistJpaRepository extends JpaRepository<TargetEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/main/java/module-info.java
+++ b/survey/jpa-adaptor/src/main/java/module-info.java
@@ -7,5 +7,7 @@ module luffy.survey.jpa.adaptor.main {
 	requires spring.data.jpa;
 
 	requires lombok;
+	requires java.persistence;
+	requires spring.context;
 
 }

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/LatestSurveyIdFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/LatestSurveyIdFindAdaptorTest.java
@@ -1,0 +1,114 @@
+package me.nalab.survey.jpa.adaptor.create;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = LatestSurveyIdFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class LatestSurveyIdFindAdaptorTest {
+
+	@Autowired
+	private LatestSurveyIdFindAdaptor latestSurveyIdFindAdaptor;
+
+	@Autowired
+	private TestSurveyJpaRepository testSurveyJpaRepository;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@BeforeEach
+	void OPTIMIZE_RANDOM_FIXTURE() {
+		RandomSurveyFixture.initGenerator();
+		RandomSurveyFixture.setRandomQuestionCountGenerator(() -> 2);
+		RandomSurveyFixture.setRandomChoiceCountGenerator(() -> 2);
+	}
+
+	@Test
+	@DisplayName("최근 생성된 Survey의 ID 조회 성공 테스트")
+	void FIND_SURVEY_ID_SUCCESS() {
+		// given
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(1L)
+			.nickname("Hello")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.build();
+
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(),
+			RandomSurveyFixture.createRandomSurvey());
+
+		// when
+		testTargetJpaRepository.save(targetEntity);
+		testSurveyJpaRepository.save(surveyEntity);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		Optional<Long> result = latestSurveyIdFindAdaptor.findLatestSurveyIdByTargetId(targetEntity.getId());
+
+		// then
+		assertTrue(result.isPresent());
+		assertEquals(surveyEntity.getId(), result.get());
+	}
+
+	@Test
+	@DisplayName("최근 생성된 Survey의 ID 조회 성공 테스트 - Survey가 2개")
+	void FIND_SURVEY_ID_SUCCESS_MULTIPLE_SURVEY() {
+		// given
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(1L)
+			.nickname("Hello")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.build();
+
+		RandomSurveyFixture.setRandomDateTimeGenerator(() -> LocalDateTime.now().minusDays(1));
+		SurveyEntity pastSurvey = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(),
+			RandomSurveyFixture.createRandomSurvey());
+
+		RandomSurveyFixture.setRandomDateTimeGenerator(LocalDateTime::now);
+		SurveyEntity latestSurvey = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(),
+			RandomSurveyFixture.createRandomSurvey());
+
+		// when
+		testTargetJpaRepository.save(targetEntity);
+		testSurveyJpaRepository.save(latestSurvey);
+		testSurveyJpaRepository.save(pastSurvey);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		Optional<Long> result = latestSurveyIdFindAdaptor.findLatestSurveyIdByTargetId(targetEntity.getId());
+
+		// then
+		assertTrue(result.isPresent());
+		assertEquals(latestSurvey.getId(), result.get());
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/SurveyCreateAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/SurveyCreateAdaptorTest.java
@@ -1,0 +1,78 @@
+package me.nalab.survey.jpa.adaptor.create;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = SurveyCreateAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class SurveyCreateAdaptorTest {
+
+	@Autowired
+	private SurveyCreateAdaptor surveyCreateAdaptor;
+
+	@Autowired
+	private TestSurveyJpaRepository testSurveyJpaRepository;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@BeforeEach
+	void OPTIMIZE_RANDOM_FIXTURE() {
+		RandomSurveyFixture.initGenerator();
+		RandomSurveyFixture.setRandomQuestionCountGenerator(() -> 2);
+		RandomSurveyFixture.setRandomChoiceCountGenerator(() -> 2);
+	}
+
+	@Test
+	@DisplayName("Survey 생성 성공 테스트")
+	void SURVEY_PERSISTENCE_SUCCESS() {
+		// given
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(101L)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.nickname("test target")
+			.build();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+
+		// when
+		testTargetJpaRepository.save(targetEntity);
+		surveyCreateAdaptor.createSurvey(targetEntity.getId(), survey);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		SurveyEntity created = testSurveyJpaRepository.findById(survey.getId()).orElse(null);
+
+		// then
+		assertNotNull(created);
+		assertEquals(survey, SurveyEntityMapper.toSurvey(created));
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/TargetExistCheckAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/TargetExistCheckAdaptorTest.java
@@ -1,0 +1,60 @@
+package me.nalab.survey.jpa.adaptor.create;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.target.TargetEntity;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = TargetExistCheckAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class TargetExistCheckAdaptorTest {
+
+	@Autowired
+	private TargetExistCheckAdaptor targetExistCheckAdaptor;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("Target존재하는지 확인 테스트")
+	void CHECK_EXIST_TARGET_SUCCESS() {
+		// given
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(1L)
+			.nickname("Hello")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.build();
+
+		testTargetJpaRepository.saveAndFlush(targetEntity);
+		entityManager.clear();
+
+		// when
+		boolean existTrue = targetExistCheckAdaptor.isExistTargetByTargetId(1L);
+		boolean existFalse = targetExistCheckAdaptor.isExistTargetByTargetId(2L);
+
+		// then
+		assertTrue(existTrue);
+		assertFalse(existFalse);
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/TestSurveyJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/TestSurveyJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.create;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/TestTargetJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/create/TestTargetJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.create;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TestTargetJpaRepository extends JpaRepository<TargetEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/resources/h2.properties
+++ b/survey/jpa-adaptor/src/test/resources/h2.properties
@@ -1,0 +1,16 @@
+spring.datasource.driver-class-name = org.h2.Driver
+spring.datasource.url = jdbc:h2:mem:test
+
+spring.jpa.hibernated.ddl-auto = create-drop
+spring.jpa.database-platform = org.hibernate.dialect.H2Dialect
+
+spring.datasource.hikari.maximum-pool-size = 4
+spring.datasource.hikari.pool-name = H2_TEST_POOL
+
+### FOR DEBUGGING ###
+logging.level.org.hibernate.SQL = debug
+logging.level.org.hibernate.type.descriptor.sql = trace
+
+spring.jpa.properties.hibernate.format_sql = true
+spring.jpa.properties.hibernate.highlight_sql = true
+spring.jpa.properties.hibernate.use_sql_comments = true


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Survey를 생성하는 usecase의 `jpa-apdaptor`를 추가했습니다.

## 어떻게 해결했나요?
- [x] out.port의 네이밍을 컨벤션에 맞게 수정했습니다.
- [x] Survey를 생성하는 adaptor를 추가했습니다.
- [x] Target이 존재하는지 체크하는 adaptor를 추가했습니다.
- [x] 가장 최근 생성된 Survey의 id를 조회하는 adaptor를 추가했습니다.
- [x] 관련 테스트케이스를 추가했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
