### PR TITLE
[feat] : survey id 유즈케이스  `jpa-adaptor` 추가

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findid/SurveyIdFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findid/SurveyIdFindPort.java
@@ -14,6 +14,6 @@ public interface SurveyIdFindPort {
 	 * @param targetId surveyId를 생성한 유저의 id
 	 * @return List SurveyId의 list
 	 */
-	List<Long> findSurveyIdByTargetId(Long targetId);
+	List<Long> findAllSurveyIdByTargetId(Long targetId);
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/getid/SurveyIdGetService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/getid/SurveyIdGetService.java
@@ -19,7 +19,7 @@ public class SurveyIdGetService implements SurveyIdGetUseCase {
 	@Override
 	@Transactional(readOnly = true)
 	public List<Long> getSurveyIdByTargetId(Long targetId) {
-		List<Long> surveyIdList = surveyIdFindPort.findSurveyIdByTargetId(targetId);
+		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(targetId);
 		if(surveyIdList == null || surveyIdList.isEmpty()){
 			throw new EmptySurveyIdListException(targetId);
 		}

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.in.web.target.find;
 	exports me.nalab.survey.application.port.out.persistence.survey.find;
 	exports me.nalab.survey.application.port.out.persistence.target.find;
+	exports me.nalab.survey.application.port.out.persistence.findid;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/application/src/test/java/me/nalab/survey/application/service/getid/SurveyIdGetServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/getid/SurveyIdGetServiceTest.java
@@ -36,7 +36,7 @@ class SurveyIdGetServiceTest {
 		List<Long> expectedSurveyIdList = List.of(1L, 2L, 3L);
 
 		// when
-		when(surveyIdFindPort.findSurveyIdByTargetId(anyLong())).thenReturn(expectedSurveyIdList);
+		when(surveyIdFindPort.findAllSurveyIdByTargetId(anyLong())).thenReturn(expectedSurveyIdList);
 
 		List<Long> resultSurveyIdList = surveyIdGetUseCase.getSurveyIdByTargetId(1L);
 
@@ -51,7 +51,7 @@ class SurveyIdGetServiceTest {
 		List<Long> expectedSurveyIdList = List.of();
 
 		// when
-		when(surveyIdFindPort.findSurveyIdByTargetId(anyLong())).thenReturn(expectedSurveyIdList);
+		when(surveyIdFindPort.findAllSurveyIdByTargetId(anyLong())).thenReturn(expectedSurveyIdList);
 
 		// then
 		assertThrows(EmptySurveyIdListException.class, () -> surveyIdGetUseCase.getSurveyIdByTargetId(1L));
@@ -61,7 +61,7 @@ class SurveyIdGetServiceTest {
 	@DisplayName("SurveyId List 조회 실패 테스트 - List가 null")
 	void GET_SURVEY_ID_LIST_FAIL_NULL_LIST() {
 		// when
-		when(surveyIdFindPort.findSurveyIdByTargetId(anyLong())).thenReturn(null);
+		when(surveyIdFindPort.findAllSurveyIdByTargetId(anyLong())).thenReturn(null);
 
 		// then
 		assertThrows(EmptySurveyIdListException.class, () -> surveyIdGetUseCase.getSurveyIdByTargetId(1L));

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptor.java
@@ -1,0 +1,22 @@
+package me.nalab.survey.jpa.adaptor.findid;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.port.out.persistence.findid.SurveyIdFindPort;
+import me.nalab.survey.jpa.adaptor.findid.repository.SurveyIdFindJpaRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class SurveyIdFindAdaptor implements SurveyIdFindPort {
+
+	private final SurveyIdFindJpaRepository surveyIdFindJpaRepository;
+
+	@Override
+	public List<Long> findSurveyIdByTargetId(Long targetId) {
+		return surveyIdFindJpaRepository.findIdByTargetId(targetId);
+	}
+
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptor.java
@@ -16,7 +16,7 @@ public class SurveyIdFindAdaptor implements SurveyIdFindPort {
 
 	@Override
 	public List<Long> findAllSurveyIdByTargetId(Long targetId) {
-		return surveyIdFindJpaRepository.findIdByTargetId(targetId);
+		return surveyIdFindJpaRepository.findAllIdByTargetId(targetId);
 	}
 
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptor.java
@@ -15,7 +15,7 @@ public class SurveyIdFindAdaptor implements SurveyIdFindPort {
 	private final SurveyIdFindJpaRepository surveyIdFindJpaRepository;
 
 	@Override
-	public List<Long> findSurveyIdByTargetId(Long targetId) {
+	public List<Long> findAllSurveyIdByTargetId(Long targetId) {
 		return surveyIdFindJpaRepository.findIdByTargetId(targetId);
 	}
 

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/repository/SurveyIdFindJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/repository/SurveyIdFindJpaRepository.java
@@ -11,6 +11,6 @@ import me.nalab.core.data.survey.SurveyEntity;
 public interface SurveyIdFindJpaRepository extends JpaRepository<SurveyEntity, Long> {
 
 	@Query("select s.id from SurveyEntity s where s.targetId = :targetId")
-	List<Long> findIdByTargetId(@Param("targetId") Long targetId);
+	List<Long> findAllIdByTargetId(@Param("targetId") Long targetId);
 
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/repository/SurveyIdFindJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findid/repository/SurveyIdFindJpaRepository.java
@@ -1,0 +1,16 @@
+package me.nalab.survey.jpa.adaptor.findid.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface SurveyIdFindJpaRepository extends JpaRepository<SurveyEntity, Long> {
+
+	@Query("select s.id from SurveyEntity s where s.targetId = :targetId")
+	List<Long> findIdByTargetId(@Param("targetId") Long targetId);
+
+}

--- a/survey/jpa-adaptor/src/main/java/module-info.java
+++ b/survey/jpa-adaptor/src/main/java/module-info.java
@@ -9,5 +9,6 @@ module luffy.survey.jpa.adaptor.main {
 	requires lombok;
 	requires java.persistence;
 	requires spring.context;
+	requires spring.data.commons;
 
 }

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -47,13 +48,14 @@ class SurveyIdFindAdaptorTest {
 	@DisplayName("Survey Id 조회 성공 테스트 - Survey Id가 1개")
 	void FIND_SURVEY_ID_SUCCESS() {
 		// given
+		Long targetId = 123L;
 		TargetEntity targetEntity = TargetEntity.builder()
-			.id(123L)
+			.id(targetId)
 			.nickname("james")
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.build();
-		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetId, RandomSurveyFixture.createRandomSurvey());
 
 		// when
 		testTargetJpaRepository.save(targetEntity);
@@ -62,7 +64,7 @@ class SurveyIdFindAdaptorTest {
 		entityManager.flush();
 		entityManager.clear();
 
-		List<Long> surveyIdList = surveyIdFindPort.findSurveyIdByTargetId(123L);
+		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(targetId);
 
 		// then
 		assertSurveyId(surveyIdList, surveyEntity);
@@ -72,38 +74,38 @@ class SurveyIdFindAdaptorTest {
 	@DisplayName("Survey Id 조회 성공 테스트 - survey Id가 여러개")
 	void FIND_SURVEY_ID_SUCCESS_MULTIPLE_SURVEY_ID() {
 		// given
+		Long targetId = 123L;
 		TargetEntity targetEntity = TargetEntity.builder()
-			.id(123L)
+			.id(targetId)
 			.nickname("james")
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.build();
-		SurveyEntity surveyEntity1 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
-		SurveyEntity surveyEntity2 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
-		SurveyEntity surveyEntity3 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
-		SurveyEntity surveyEntity4 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
-		SurveyEntity surveyEntity5 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
+		List<SurveyEntity> surveyEntityList = new ArrayList<>();
+		for(int i = 0; i < 5; i++){
+			surveyEntityList.add(SurveyEntityMapper.toSurveyEntity(targetId, RandomSurveyFixture.createRandomSurvey()));
+		}
 
 		// when
 		testTargetJpaRepository.save(targetEntity);
-		testSurveyJpaRepository.saveAll(
-			List.of(surveyEntity1, surveyEntity2, surveyEntity3, surveyEntity4, surveyEntity5));
+		testSurveyJpaRepository.saveAll(surveyEntityList);
 
 		entityManager.flush();
 		entityManager.clear();
 
-		List<Long> surveyIdList = surveyIdFindPort.findSurveyIdByTargetId(123L);
+		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(123L);
 
 		// then
-		assertSurveyId(surveyIdList, surveyEntity1, surveyEntity2, surveyEntity3, surveyEntity4, surveyEntity5);
+		assertSurveyId(surveyIdList, surveyEntityList.toArray(new SurveyEntity[]{}));
 	}
 
 	@Test
 	@DisplayName("Survey Id 조회 성공 테스트 - 어떤 surveyId도 찾을 수 없음")
 	void FIND_SURVEY_ID_SUCCESS_EMPTY_SURVEY_LIST() {
 		// given
+		Long targetId = 123L;
 		TargetEntity targetEntity = TargetEntity.builder()
-			.id(123L)
+			.id(targetId)
 			.nickname("james")
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
@@ -115,7 +117,7 @@ class SurveyIdFindAdaptorTest {
 		entityManager.flush();
 		entityManager.clear();
 
-		List<Long> surveyIdList = surveyIdFindPort.findSurveyIdByTargetId(123L);
+		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(targetId);
 
 		// then
 		assertSurveyId(surveyIdList);

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
@@ -93,7 +93,7 @@ class SurveyIdFindAdaptorTest {
 		entityManager.flush();
 		entityManager.clear();
 
-		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(123L);
+		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(targetId);
 
 		// then
 		assertSurveyId(surveyIdList, surveyEntityList.toArray(new SurveyEntity[]{}));

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
@@ -1,0 +1,129 @@
+package me.nalab.survey.jpa.adaptor.findid;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.findid.SurveyIdFindPort;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = SurveyIdFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class SurveyIdFindAdaptorTest {
+
+	@Autowired
+	private SurveyIdFindPort surveyIdFindPort;
+
+	@Autowired
+	private TestSurveyJpaRepository testSurveyJpaRepository;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("Survey Id 조회 성공 테스트 - Survey Id가 1개")
+	void FIND_SURVEY_ID_SUCCESS() {
+		// given
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(123L)
+			.nickname("james")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.build();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
+
+		// when
+		testTargetJpaRepository.save(targetEntity);
+		testSurveyJpaRepository.save(surveyEntity);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		List<Long> surveyIdList = surveyIdFindPort.findSurveyIdByTargetId(123L);
+
+		// then
+		assertSurveyId(surveyIdList, surveyEntity);
+	}
+
+	@Test
+	@DisplayName("Survey Id 조회 성공 테스트 - survey Id가 여러개")
+	void FIND_SURVEY_ID_SUCCESS_MULTIPLE_SURVEY_ID() {
+		// given
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(123L)
+			.nickname("james")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.build();
+		SurveyEntity surveyEntity1 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
+		SurveyEntity surveyEntity2 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
+		SurveyEntity surveyEntity3 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
+		SurveyEntity surveyEntity4 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
+		SurveyEntity surveyEntity5 = SurveyEntityMapper.toSurveyEntity(123L, RandomSurveyFixture.createRandomSurvey());
+
+		// when
+		testTargetJpaRepository.save(targetEntity);
+		testSurveyJpaRepository.saveAll(
+			List.of(surveyEntity1, surveyEntity2, surveyEntity3, surveyEntity4, surveyEntity5));
+
+		entityManager.flush();
+		entityManager.clear();
+
+		List<Long> surveyIdList = surveyIdFindPort.findSurveyIdByTargetId(123L);
+
+		// then
+		assertSurveyId(surveyIdList, surveyEntity1, surveyEntity2, surveyEntity3, surveyEntity4, surveyEntity5);
+	}
+
+	@Test
+	@DisplayName("Survey Id 조회 성공 테스트 - 어떤 surveyId도 찾을 수 없음")
+	void FIND_SURVEY_ID_SUCCESS_EMPTY_SURVEY_LIST() {
+		// given
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(123L)
+			.nickname("james")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.build();
+
+		// when
+		testTargetJpaRepository.save(targetEntity);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		List<Long> surveyIdList = surveyIdFindPort.findSurveyIdByTargetId(123L);
+
+		// then
+		assertSurveyId(surveyIdList);
+	}
+
+	private void assertSurveyId(List<Long> expectedSurveyIdList, SurveyEntity... resultEntities) {
+		assertEquals(expectedSurveyIdList.size(), resultEntities.length);
+		Stream.of(resultEntities).forEach(re -> assertTrue(expectedSurveyIdList.contains(re.getId())));
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
@@ -57,12 +57,12 @@ class SurveyIdFindAdaptorTest {
 			.build();
 		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetId, RandomSurveyFixture.createRandomSurvey());
 
-		// when
 		testTargetJpaRepository.save(targetEntity);
 		testSurveyJpaRepository.save(surveyEntity);
 
 		entityManager.flush();
 		entityManager.clear();
+		// when
 
 		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(targetId);
 
@@ -86,12 +86,12 @@ class SurveyIdFindAdaptorTest {
 			surveyEntityList.add(SurveyEntityMapper.toSurveyEntity(targetId, RandomSurveyFixture.createRandomSurvey()));
 		}
 
-		// when
 		testTargetJpaRepository.save(targetEntity);
 		testSurveyJpaRepository.saveAll(surveyEntityList);
 
 		entityManager.flush();
 		entityManager.clear();
+		// when
 
 		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(targetId);
 
@@ -111,11 +111,12 @@ class SurveyIdFindAdaptorTest {
 			.updatedAt(LocalDateTime.now())
 			.build();
 
-		// when
 		testTargetJpaRepository.save(targetEntity);
 
 		entityManager.flush();
 		entityManager.clear();
+
+		// when
 
 		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(targetId);
 

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/SurveyIdFindAdaptorTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
@@ -55,7 +57,8 @@ class SurveyIdFindAdaptorTest {
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.build();
-		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetId, RandomSurveyFixture.createRandomSurvey());
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetId,
+			RandomSurveyFixture.createRandomSurvey());
 
 		testTargetJpaRepository.save(targetEntity);
 		testSurveyJpaRepository.save(surveyEntity);
@@ -82,7 +85,7 @@ class SurveyIdFindAdaptorTest {
 			.updatedAt(LocalDateTime.now())
 			.build();
 		List<SurveyEntity> surveyEntityList = new ArrayList<>();
-		for(int i = 0; i < 5; i++){
+		for(int i = 0; i < 5; i++) {
 			surveyEntityList.add(SurveyEntityMapper.toSurveyEntity(targetId, RandomSurveyFixture.createRandomSurvey()));
 		}
 
@@ -96,7 +99,7 @@ class SurveyIdFindAdaptorTest {
 		List<Long> surveyIdList = surveyIdFindPort.findAllSurveyIdByTargetId(targetId);
 
 		// then
-		assertSurveyId(surveyIdList, surveyEntityList.toArray(new SurveyEntity[]{}));
+		assertSurveyId(surveyIdList, surveyEntityList.toArray(new SurveyEntity[] {}));
 	}
 
 	@Test
@@ -126,7 +129,10 @@ class SurveyIdFindAdaptorTest {
 
 	private void assertSurveyId(List<Long> expectedSurveyIdList, SurveyEntity... resultEntities) {
 		assertEquals(expectedSurveyIdList.size(), resultEntities.length);
-		Stream.of(resultEntities).forEach(re -> assertTrue(expectedSurveyIdList.contains(re.getId())));
+
+		Set<Long> resultLongSet = Stream.of(resultEntities).map(SurveyEntity::getId).collect(Collectors.toSet());
+
+		expectedSurveyIdList.forEach(e -> assertTrue(resultLongSet.contains(e)));
 	}
 
 }

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/TestSurveyJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/TestSurveyJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.findid;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/TestTargetJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findid/TestTargetJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.findid;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TestTargetJpaRepository extends JpaRepository<TargetEntity, Long> {
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
survey id 유즈케이스에서 사용하는 `jpa-adaptor`를 추가했습니다.

## 어떻게 해결했나요?
- [x] SurveyIdFindPort를 구현한 `SurveyIdFindAdaptor` 추가
- [x] 관련 jpa-repository 추가
- [x] 관련 테스트코드 추가

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
