### PR TITLE
[feat] :  `create-survey` 인수테스트 작성 및 버그 수정

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/DatabaseCleaner.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/DatabaseCleaner.java
@@ -5,28 +5,23 @@ import java.util.Set;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-public abstract class AbstractDatabaseCleaner {
-
-	protected EntityManager entityManager;
+@Component
+public class DatabaseCleaner {
 
 	@PersistenceContext
-	final void setEntityManager(EntityManager entityManager) {
-		this.entityManager = entityManager;
-	}
+	protected EntityManager entityManager;
 
-	@BeforeEach
 	@Transactional
-	void dbCleanUp() {
-		Set<String> tableNameSet = getTableNameCollection();
+	@Modifying
+	public void dbCleanUp(Set<String> tableNameSet) {
 		entityManager.createNativeQuery(H2Dialect.REFERER_FALSE).executeUpdate();
-		tableNameSet.forEach(n -> entityManager.createNamedQuery(H2Dialect.TRUNCATE + n));
+		tableNameSet.forEach(n -> entityManager.createNativeQuery(H2Dialect.TRUNCATE + n));
 		entityManager.createNativeQuery(H2Dialect.REFERER_TRUE).executeUpdate();
 	}
-
-	protected abstract Set<String> getTableNameCollection();
 
 	private static final class H2Dialect {
 		private static final String REFERER_TRUE = "SET REFERENTIAL_INTEGRITY TRUE";

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/TargetInitializer.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/TargetInitializer.java
@@ -1,0 +1,36 @@
+package me.nalab.luffy.api.acceptance.test;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+
+@Component
+public class TargetInitializer {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Autowired
+	private IdGenerator idGenerator;
+
+	@Transactional
+	public Long saveTargetAndGetId(String name, LocalDateTime date) {
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(idGenerator.generate())
+			.nickname(name)
+			.createdAt(date)
+			.updatedAt(date)
+			.build();
+		entityManager.persist(targetEntity);
+		return targetEntity.getId();
+	}
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/TestEntryPoint.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/TestEntryPoint.java
@@ -1,0 +1,7 @@
+package me.nalab.luffy.api.acceptance.test;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {"me.nalab"})
+public class TestEntryPoint {
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
@@ -1,25 +1,23 @@
 package me.nalab.luffy.api.acceptance.test.survey;
 
-import java.time.LocalDateTime;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.transaction.annotation.Transactional;
 
-import me.nalab.core.data.target.TargetEntity;
-import me.nalab.core.idgenerator.idcore.IdGenerator;
-import me.nalab.luffy.api.acceptance.test.AbstractDatabaseCleaner;
+import me.nalab.luffy.api.acceptance.test.DatabaseCleaner;
 
-public abstract class AbstractSurveyTestSupporter extends AbstractDatabaseCleaner {
+public abstract class AbstractSurveyTestSupporter {
 
 	private MockMvc mockMvc;
-	private IdGenerator idGenerator;
+	private DatabaseCleaner databaseCleaner;
 	private static final String API_VERSION = "/v1";
+	private static final Set<String> tableNameSet = Set.of("target", "survey", "form_question", "choice");
 
 	protected ResultActions createSurvey(String token, String content) throws Exception {
 		return mockMvc.perform(MockMvcRequestBuilders
@@ -30,31 +28,19 @@ public abstract class AbstractSurveyTestSupporter extends AbstractDatabaseCleane
 			.content(content));
 	}
 
-	@Transactional
-	protected Long saveTarget(String name, LocalDateTime date) {
-		TargetEntity targetEntity = TargetEntity.builder()
-			.id(idGenerator.generate())
-			.nickname(name)
-			.createdAt(date)
-			.updatedAt(date)
-			.build();
-		entityManager.persist(targetEntity);
-		return targetEntity.getId();
-	}
-
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;
 	}
 
 	@Autowired
-	final void setIdGenerator(IdGenerator idGenerator) {
-		this.idGenerator = idGenerator;
+	public void setDatabaseCleaner(DatabaseCleaner databaseCleaner) {
+		this.databaseCleaner = databaseCleaner;
 	}
 
-	@Override
-	protected Set<String> getTableNameCollection() {
-		return Set.of("target", "survey", "form_question", "choice");
+	@BeforeEach
+	void cleanDb() {
+		databaseCleaner.dbCleanUp(tableNameSet);
 	}
 
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
@@ -1,0 +1,20 @@
+package me.nalab.luffy.api.acceptance.test.survey;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class SurveyAcceptanceValidator {
+
+	public static void assertIsSurveyCreated(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isCreated(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.survey_id").isNumber()
+		);
+	}
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/RequestSample.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/RequestSample.java
@@ -1,0 +1,276 @@
+package me.nalab.luffy.api.acceptance.test.survey.create;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import me.nalab.luffy.api.acceptance.test.survey.create.dto.ChoiceFormQuestionRequest;
+import me.nalab.luffy.api.acceptance.test.survey.create.dto.ChoiceRequest;
+import me.nalab.luffy.api.acceptance.test.survey.create.dto.ShortFormQuestionRequest;
+import me.nalab.luffy.api.acceptance.test.survey.create.dto.SurveyCreateRequest;
+
+final class RequestSample {
+
+	private static final ObjectMapper OBJECT_MAPPER;
+	static final String DEFAULT_JSON;
+	static final String CUSTOM_JSON;
+
+	static {
+		OBJECT_MAPPER = new ObjectMapper();
+		OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+		DEFAULT_JSON = loadDefaultJson();
+		CUSTOM_JSON = loadCustomJson();
+	}
+
+	private static String loadDefaultJson() {
+		try {
+			return OBJECT_MAPPER.writeValueAsString(SurveyCreateRequest.builder()
+				.questionCount(1000)
+				.formQuestionRequestableList(
+					List.of(ChoiceFormQuestionRequest.builder()
+							.questionType("choice")
+							.choiceFormQuestionType("position")
+							.title("당신의 포지션을 알려주세요.")
+							.maxSelectableCount(1)
+							.order(3)
+							.choiceRequestList(
+								List.of(
+									ChoiceRequest.builder()
+										.content("programmer")
+										.order(1)
+										.build(),
+									ChoiceRequest.builder()
+										.content("designer")
+										.order(2)
+										.build(),
+									ChoiceRequest.builder()
+										.content("product-manager")
+										.order(3)
+										.build(),
+									ChoiceRequest.builder()
+										.content("other")
+										.order(4)
+										.build()
+								)
+							)
+							.build(),
+						ChoiceFormQuestionRequest.builder()
+							.questionType("choice")
+							.choiceFormQuestionType("tendency")
+							.title("예진님의 성향은 어떤 것이 돋보이나요?")
+							.maxSelectableCount(5)
+							.order(4)
+							.choiceRequestList(
+								List.of(
+									ChoiceRequest.builder()
+										.content("적응력 좋은")
+										.order(1)
+										.build(),
+									ChoiceRequest.builder()
+										.content("완벽주의적인")
+										.order(2)
+										.build(),
+									ChoiceRequest.builder()
+										.content("사교적인")
+										.order(3)
+										.build(),
+									ChoiceRequest.builder()
+										.content("눈치빠른")
+										.order(4)
+										.build(),
+									ChoiceRequest.builder()
+										.content("긍정적인")
+										.order(5)
+										.build(),
+									ChoiceRequest.builder()
+										.content("현실적인")
+										.order(6)
+										.build(),
+									ChoiceRequest.builder()
+										.content("통찰력 있는")
+										.order(7)
+										.build(),
+									ChoiceRequest.builder()
+										.content("추진력 있는")
+										.order(8)
+										.build()
+								)
+							)
+							.build(),
+						ShortFormQuestionRequest.builder()
+							.questionType("short")
+							.shortFormQuestionType("strength")
+							.title("당신이 생각하는 예진님의 직무적 강점은 무엇인가요?")
+							.order(5)
+							.build(),
+						ShortFormQuestionRequest.builder()
+							.questionType("short")
+							.shortFormQuestionType("weakness")
+							.title("당신이 생각하는 예진님의 직무적 약점은 무엇인가요?")
+							.order(6)
+							.build()
+					)
+				)
+				.build()
+			);
+		} catch(JsonProcessingException jpe) {
+			throw new IllegalStateException(
+				"Cannot start acceptance test fail to load \"DEFAULT_JSON\" " + jpe.getMessage());
+		}
+	}
+
+	private static String loadCustomJson() {
+		try {
+			return OBJECT_MAPPER.writeValueAsString(SurveyCreateRequest.builder()
+				.questionCount(1000)
+				.formQuestionRequestableList(
+					List.of(ChoiceFormQuestionRequest.builder()
+							.questionType("choice")
+							.choiceFormQuestionType("position")
+							.title("당신의 포지션을 알려주세요.")
+							.maxSelectableCount(1)
+							.order(3)
+							.choiceRequestList(
+								List.of(
+									ChoiceRequest.builder()
+										.content("programmer")
+										.order(1)
+										.build(),
+									ChoiceRequest.builder()
+										.content("designer")
+										.order(2)
+										.build(),
+									ChoiceRequest.builder()
+										.content("product-manager")
+										.order(3)
+										.build(),
+									ChoiceRequest.builder()
+										.content("other")
+										.order(4)
+										.build()
+								)
+							)
+							.build(),
+						ChoiceFormQuestionRequest.builder()
+							.questionType("choice")
+							.choiceFormQuestionType("tendency")
+							.title("예진님의 성향은 어떤 것이 돋보이나요?")
+							.maxSelectableCount(5)
+							.order(4)
+							.choiceRequestList(
+								List.of(
+									ChoiceRequest.builder()
+										.content("적응력 좋은")
+										.order(1)
+										.build(),
+									ChoiceRequest.builder()
+										.content("완벽주의적인")
+										.order(2)
+										.build(),
+									ChoiceRequest.builder()
+										.content("사교적인")
+										.order(3)
+										.build(),
+									ChoiceRequest.builder()
+										.content("눈치빠른")
+										.order(4)
+										.build(),
+									ChoiceRequest.builder()
+										.content("긍정적인")
+										.order(5)
+										.build(),
+									ChoiceRequest.builder()
+										.content("현실적인")
+										.order(6)
+										.build(),
+									ChoiceRequest.builder()
+										.content("통찰력 있는")
+										.order(7)
+										.build(),
+									ChoiceRequest.builder()
+										.content("추진력 있는")
+										.order(8)
+										.build()
+								)
+							)
+							.build(),
+						ShortFormQuestionRequest.builder()
+							.questionType("short")
+							.shortFormQuestionType("strength")
+							.title("당신이 생각하는 예진님의 직무적 강점은 무엇인가요?")
+							.order(5)
+							.build(),
+						ShortFormQuestionRequest.builder()
+							.questionType("short")
+							.shortFormQuestionType("weakness")
+							.title("당신이 생각하는 예진님의 직무적 약점은 무엇인가요?")
+							.order(6)
+							.build(),
+						ChoiceFormQuestionRequest.builder()
+							.questionType("choice")
+							.choiceFormQuestionType("custom")
+							.title("커스텀 객관식 1")
+							.maxSelectableCount(2)
+							.order(7)
+							.choiceRequestList(
+								List.of(
+									ChoiceRequest.builder()
+										.content("네, 있어요")
+										.order(1)
+										.build(),
+									ChoiceRequest.builder()
+										.content("없어요")
+										.order(2)
+										.build()
+								)
+							)
+							.build(),
+						ShortFormQuestionRequest.builder()
+							.questionType("short")
+							.shortFormQuestionType("custom")
+							.title("커스텀 주관식 1")
+							.order(8)
+							.build(),
+						ShortFormQuestionRequest.builder()
+							.questionType("short")
+							.shortFormQuestionType("custom")
+							.title("커스텀 주관식 2")
+							.order(9)
+							.build(),
+						ChoiceFormQuestionRequest.builder()
+							.questionType("choice")
+							.choiceFormQuestionType("custom")
+							.title("커스텀 객관식 2")
+							.maxSelectableCount(2)
+							.order(10)
+							.choiceRequestList(
+								List.of(
+									ChoiceRequest.builder()
+										.content("네, 있어요")
+										.order(1)
+										.build(),
+									ChoiceRequest.builder()
+										.content("없어요")
+										.order(2)
+										.build(),
+									ChoiceRequest.builder()
+										.content("몰라요")
+										.order(3)
+										.build()
+								)
+							)
+							.build()
+					)
+				)
+				.build()
+			);
+		} catch(JsonProcessingException jpe) {
+			throw new IllegalStateException("Cannot start acceptance test fail to load \"CUSTOM_JSON\"");
+		}
+	}
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/SurveyCreateAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/SurveyCreateAcceptanceTest.java
@@ -1,0 +1,79 @@
+package me.nalab.luffy.api.acceptance.test.survey.create;
+
+import static me.nalab.luffy.api.acceptance.test.survey.SurveyAcceptanceValidator.assertIsSurveyCreated;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.survey.AbstractSurveyTestSupporter;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+class SurveyCreateAcceptanceTest extends AbstractSurveyTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("새로운 Survey 생성 성공 테스트 - 기본 질문")
+	void CREATE_NEW_SURVEY_SUCCESS_DEFAULT() throws Exception {
+		// given
+		Long targetId = targetInitializer.saveTargetAndGetId("luffy", LocalDateTime.now().minusYears(24));
+		String token = "luffy's-double-token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedToken(token)
+			.expectedId(targetId)
+			.build());
+
+		// when
+		ResultActions resultActions = createSurvey(token, RequestSample.DEFAULT_JSON);
+
+		// then
+		assertIsSurveyCreated(resultActions);
+	}
+
+	@Test
+	@DisplayName("새로우 Survey 생성 성공 테스트 - 커스텀 질문 포함")
+	void CREATE_NEW_SURVEY_SUCCESS_SUCCESS_CUSTOM() throws Exception {
+		// given
+		Long targetId = targetInitializer.saveTargetAndGetId("luffy", LocalDateTime.now().minusYears(24));
+		String token = "luffy's-double-token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedToken(token)
+			.expectedId(targetId)
+			.build());
+
+		// when
+		ResultActions resultActions = createSurvey(token, RequestSample.CUSTOM_JSON);
+
+		// then
+		assertIsSurveyCreated(resultActions);
+	}
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/ChoiceFormQuestionRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/ChoiceFormQuestionRequest.java
@@ -1,0 +1,27 @@
+package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class ChoiceFormQuestionRequest extends FormQuestionRequestable {
+
+	@JsonProperty("max_selectable_count")
+	private Integer maxSelectableCount;
+
+	@JsonProperty("form_type")
+	private String choiceFormQuestionType;
+
+	@JsonProperty("choices")
+	private List<ChoiceRequest> choiceRequestList;
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/ChoiceRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/ChoiceRequest.java
@@ -1,0 +1,17 @@
+package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class ChoiceRequest {
+
+	private String content;
+	private Integer order;
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/FormQuestionRequestable.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/FormQuestionRequestable.java
@@ -1,0 +1,23 @@
+package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public abstract class FormQuestionRequestable {
+
+	protected String title;
+
+	protected Integer order;
+
+	@JsonProperty("type")
+	protected String questionType;
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/ShortFormQuestionRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/ShortFormQuestionRequest.java
@@ -1,0 +1,19 @@
+package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class ShortFormQuestionRequest extends FormQuestionRequestable {
+
+	@JsonProperty("form_type")
+	private String shortFormQuestionType;
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/SurveyCreateRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/dto/SurveyCreateRequest.java
@@ -1,0 +1,24 @@
+package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class SurveyCreateRequest {
+
+	@JsonProperty("question_count")
+	private Integer questionCount;
+
+	@JsonProperty("question")
+	private List<FormQuestionRequestable> formQuestionRequestableList;
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/mapper/SurveyFindResponseMapper.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/mapper/SurveyFindResponseMapper.java
@@ -2,8 +2,6 @@ package me.nalab.survey.web.adaptor.survey.find.mapper;
 
 import java.util.stream.Collectors;
 
-import org.springframework.stereotype.Service;
-
 import me.nalab.survey.application.common.dto.ChoiceFormQuestionDto;
 import me.nalab.survey.application.common.dto.FormQuestionDtoable;
 import me.nalab.survey.application.common.dto.ShortFormQuestionDto;
@@ -11,12 +9,11 @@ import me.nalab.survey.application.common.dto.SurveyDto;
 import me.nalab.survey.application.common.dto.TargetDto;
 import me.nalab.survey.web.adaptor.survey.find.response.ChoiceFormQuestionResponse;
 import me.nalab.survey.web.adaptor.survey.find.response.ChoiceResponse;
-import me.nalab.survey.web.adaptor.survey.find.response.SurveyFindResponse;
 import me.nalab.survey.web.adaptor.survey.find.response.FormQuestionResponseable;
 import me.nalab.survey.web.adaptor.survey.find.response.ShortFormQuestionResponse;
+import me.nalab.survey.web.adaptor.survey.find.response.SurveyFindResponse;
 import me.nalab.survey.web.adaptor.survey.find.response.TargetResponse;
 
-@Service
 public class SurveyFindResponseMapper {
 
 	private SurveyFindResponseMapper() {


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
survey를 생성하는 인수테스트를 작성했습니다.
accept-template에 버그들을 수정했습니다.

## 어떻게 해결했나요?
- [x] `create-survey` 인수테스트 작성
- [x] Junit의 `@BeforeEach`가 `dbCleanup` 메소드를 호출해서 `dbCleanup` 메소드가 `@Transactional` 이 안타는 버그 수정
- [x] `TargetEntity` 를 생성하는 메소드가 빈으로 등록되지 않아서, 호출되지 않는 버그 수정

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
