### PR TITLE
[refactor] : `position`, `collaboration-experience ` enum 삭제

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/RequestSample.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/RequestSample.java
@@ -33,7 +33,7 @@ final class RequestSample {
 				.formQuestionRequestableList(
 					List.of(ChoiceFormQuestionRequest.builder()
 							.questionType("choice")
-							.choiceFormQuestionType("position")
+							.choiceFormQuestionType("custom")
 							.title("당신의 포지션을 알려주세요.")
 							.maxSelectableCount(1)
 							.order(3)
@@ -130,7 +130,7 @@ final class RequestSample {
 				.formQuestionRequestableList(
 					List.of(ChoiceFormQuestionRequest.builder()
 							.questionType("choice")
-							.choiceFormQuestionType("position")
+							.choiceFormQuestionType("custom")
 							.title("당신의 포지션을 알려주세요.")
 							.maxSelectableCount(1)
 							.order(3)

--- a/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntityType.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntityType.java
@@ -8,14 +8,6 @@ package me.nalab.core.data.survey;
 public enum ChoiceFormQuestionEntityType {
 
 	/**
-	 * COLLABORATION_EXPERIENCE 는 기본질문중 `협업경험` 을 나타냅니다.
-	 */
-	COLLABORATION_EXPERIENCE,
-	/**
-	 * POSITION 은 기본질문중 `직군` 을 나타냅니다.
-	 */
-	POSITION,
-	/**
 	 * TENDENCY 는 기본질문중 `성향` 을 나타냅니다.
 	 */
 	TENDENCY,

--- a/survey/application/src/main/java/me/nalab/survey/application/common/dto/ChoiceFormQuestionDtoType.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/common/dto/ChoiceFormQuestionDtoType.java
@@ -11,14 +11,6 @@ import me.nalab.survey.domain.survey.ChoiceFormQuestionType;
 public enum ChoiceFormQuestionDtoType {
 
 	/**
-	 * 기본타입 `나와의 협업 경험 유무`
-	 */
-	COLLABORATION_EXPERIENCE(ChoiceFormQuestionType.COLLABORATION_EXPERIENCE),
-	/**
-	 * 기본타입 `리뷰어의 직군`
-	 */
-	POSITION(ChoiceFormQuestionType.POSITION),
-	/**
 	 * 기본타입 `나의 성향`
 	 */
 	TENDENCY(ChoiceFormQuestionType.TENDENCY),

--- a/survey/application/src/test/java/me/nalab/survey/application/common/dto/CommonDtoEnumTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/common/dto/CommonDtoEnumTest.java
@@ -66,15 +66,7 @@ class CommonDtoEnumTest {
 	private static Stream<Arguments> choiceQuestionTypeDtoSources() {
 		return Stream.of(
 			of(ChoiceFormQuestionType.TENDENCY, ChoiceFormQuestionDtoType.TENDENCY, true),
-			of(ChoiceFormQuestionType.POSITION, ChoiceFormQuestionDtoType.POSITION, true),
-			of(ChoiceFormQuestionType.COLLABORATION_EXPERIENCE, ChoiceFormQuestionDtoType.COLLABORATION_EXPERIENCE,
-				true),
-			of(ChoiceFormQuestionType.CUSTOM, ChoiceFormQuestionDtoType.CUSTOM, true),
-
-			of(ChoiceFormQuestionType.TENDENCY, ChoiceFormQuestionDtoType.POSITION, false),
-			of(ChoiceFormQuestionType.POSITION, ChoiceFormQuestionDtoType.CUSTOM, false),
-			of(ChoiceFormQuestionType.COLLABORATION_EXPERIENCE, ChoiceFormQuestionDtoType.TENDENCY, false),
-			of(ChoiceFormQuestionType.CUSTOM, ChoiceFormQuestionDtoType.POSITION, false)
+			of(ChoiceFormQuestionType.CUSTOM, ChoiceFormQuestionDtoType.CUSTOM, true)
 		);
 	}
 

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestionType.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestionType.java
@@ -6,14 +6,6 @@ package me.nalab.survey.domain.survey;
 public enum ChoiceFormQuestionType {
 
 	/**
-	 * 기본타입 `나와의 협업 경험 유무`
-	 */
-	COLLABORATION_EXPERIENCE,
-	/**
-	 * 기본타입 `리뷰어의 직군`
-	 */
-	POSITION,
-	/**
 	 * 기본타입 `나의 성향`
 	 */
 	TENDENCY,

--- a/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/createsurvey/TestJson.java
+++ b/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/createsurvey/TestJson.java
@@ -41,7 +41,7 @@ class TestJson {
 		+ "    },\n"
 		+ "    {\n"
 		+ "      \"type\": \"choice\",\n"
-		+ "      \"form_type\": \"position\",\n"
+		+ "      \"form_type\": \"custom\",\n"
 		+ "      \"title\": \"저는 UI, UX, GUI 중에 어떤 분야를 가장 잘하는 것 같나요?\",\n"
 		+ "      \"choices\": [\n"
 		+ "        {\n"


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`position` 과 `collaboration-experience` enum을 도메인, dto, entity에서 삭제했습니다.

## 어떻게 해결했나요?
- [x] `position` 과 `collaboration-experience` enum을 `도메인`, `dto`, `entity` 에서 삭제.
- [x] 관련 테스트 케이스 수정
- [x] 관련 비즈니스 로직 수정  

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
