### PR TITLE
[refactor] : `position`, `collaboration-experience ` enum 삭제

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
@@ -28,6 +28,15 @@ public abstract class AbstractSurveyTestSupporter {
 			.content(content));
 	}
 
+	protected ResultActions getLoginedSurveyId(String token) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.get(API_VERSION + "/surveys-id")
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header(HttpHeaders.AUTHORIZATION, token)
+		);
+	}
+
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/RequestSample.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/RequestSample.java
@@ -1,4 +1,4 @@
-package me.nalab.luffy.api.acceptance.test.survey.create;
+package me.nalab.luffy.api.acceptance.test.survey;
 
 import java.util.List;
 
@@ -7,16 +7,16 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import me.nalab.luffy.api.acceptance.test.survey.create.dto.ChoiceFormQuestionRequest;
-import me.nalab.luffy.api.acceptance.test.survey.create.dto.ChoiceRequest;
-import me.nalab.luffy.api.acceptance.test.survey.create.dto.ShortFormQuestionRequest;
-import me.nalab.luffy.api.acceptance.test.survey.create.dto.SurveyCreateRequest;
+import me.nalab.luffy.api.acceptance.test.survey.dto.ChoiceFormQuestionRequest;
+import me.nalab.luffy.api.acceptance.test.survey.dto.ChoiceRequest;
+import me.nalab.luffy.api.acceptance.test.survey.dto.ShortFormQuestionRequest;
+import me.nalab.luffy.api.acceptance.test.survey.dto.SurveyCreateRequest;
 
-final class RequestSample {
+public final class RequestSample {
 
 	private static final ObjectMapper OBJECT_MAPPER;
-	static final String DEFAULT_JSON;
-	static final String CUSTOM_JSON;
+	public static final String DEFAULT_JSON;
+	public static final String CUSTOM_JSON;
 
 	static {
 		OBJECT_MAPPER = new ObjectMapper();

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/RequestSample.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/RequestSample.java
@@ -33,7 +33,7 @@ public final class RequestSample {
 				.formQuestionRequestableList(
 					List.of(ChoiceFormQuestionRequest.builder()
 							.questionType("choice")
-							.choiceFormQuestionType("position")
+							.choiceFormQuestionType("custom")
 							.title("당신의 포지션을 알려주세요.")
 							.maxSelectableCount(1)
 							.order(3)
@@ -130,7 +130,7 @@ public final class RequestSample {
 				.formQuestionRequestableList(
 					List.of(ChoiceFormQuestionRequest.builder()
 							.questionType("choice")
-							.choiceFormQuestionType("position")
+							.choiceFormQuestionType("custom")
 							.title("당신의 포지션을 알려주세요.")
 							.maxSelectableCount(1)
 							.order(3)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
@@ -17,4 +17,20 @@ public class SurveyAcceptanceValidator {
 		);
 	}
 
+	public static void assertIsSurveyFound(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.survey_id").isNumber()
+		);
+	}
+
+	public static void assertIsTargetDoesNotHasAnySurvey(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isNotFound(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.response_messages").isString()
+		);
+	}
+
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/ChoiceFormQuestionRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/ChoiceFormQuestionRequest.java
@@ -1,4 +1,4 @@
-package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+package me.nalab.luffy.api.acceptance.test.survey.dto;
 
 import java.util.List;
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/ChoiceRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/ChoiceRequest.java
@@ -1,4 +1,4 @@
-package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+package me.nalab.luffy.api.acceptance.test.survey.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/FormQuestionRequestable.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/FormQuestionRequestable.java
@@ -1,4 +1,4 @@
-package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+package me.nalab.luffy.api.acceptance.test.survey.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/ShortFormQuestionRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/ShortFormQuestionRequest.java
@@ -1,4 +1,4 @@
-package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+package me.nalab.luffy.api.acceptance.test.survey.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/SurveyCreateRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/dto/SurveyCreateRequest.java
@@ -1,4 +1,4 @@
-package me.nalab.luffy.api.acceptance.test.survey.create.dto;
+package me.nalab.luffy.api.acceptance.test.survey.dto;
 
 import java.util.List;
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/findid/SurveyFindidAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/findid/SurveyFindidAcceptanceTest.java
@@ -1,11 +1,8 @@
-package me.nalab.luffy.api.acceptance.test.survey.create;
+package me.nalab.luffy.api.acceptance.test.survey.findid;
 
-import static me.nalab.luffy.api.acceptance.test.survey.SurveyAcceptanceValidator.assertIsSurveyCreated;
+import static me.nalab.luffy.api.acceptance.test.survey.SurveyAcceptanceValidator.*;
 
 import java.time.LocalDateTime;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,7 +27,7 @@ import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
 @ComponentScan("me.nalab")
 @EnableJpaRepositories(basePackages = {"me.nalab"})
 @EntityScan(basePackages = {"me.nalab"})
-class SurveyCreateAcceptanceTest extends AbstractSurveyTestSupporter {
+class SurveyFindidAcceptanceTest extends AbstractSurveyTestSupporter {
 
 	@Autowired
 	private ApplicationEventPublisher applicationEventPublisher;
@@ -38,43 +35,40 @@ class SurveyCreateAcceptanceTest extends AbstractSurveyTestSupporter {
 	@Autowired
 	private TargetInitializer targetInitializer;
 
-	@PersistenceContext
-	private EntityManager entityManager;
-
 	@Test
-	@DisplayName("새로운 Survey 생성 성공 테스트 - 기본 질문")
-	void CREATE_NEW_SURVEY_SUCCESS_DEFAULT() throws Exception {
+	@DisplayName("로그인된 타겟의 survey id 조회 성공 테스트")
+	void GET_LOGINED_SURVEY_ID_SUCCESS() throws Exception {
 		// given
-		Long targetId = targetInitializer.saveTargetAndGetId("luffy", LocalDateTime.now().minusYears(24));
-		String token = "luffy's-double-token";
+		Long targetId = targetInitializer.saveTargetAndGetId("nalab", LocalDateTime.now());
+		String token = "nalab-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)
 			.build());
 
 		// when
-		ResultActions resultActions = createSurvey(token, RequestSample.DEFAULT_JSON);
+		createSurvey(token, RequestSample.DEFAULT_JSON);
+		ResultActions result = getLoginedSurveyId(token);
 
 		// then
-		assertIsSurveyCreated(resultActions);
+		assertIsSurveyFound(result);
 	}
 
 	@Test
-	@DisplayName("새로우 Survey 생성 성공 테스트 - 커스텀 질문 포함")
-	void CREATE_NEW_SURVEY_SUCCESS_SUCCESS_CUSTOM() throws Exception {
+	@DisplayName("로그인된 타겟의 survey id 조회 실패 테스트 - 생성된 survey가 없음")
+	void GET_LOGINED_SURVEY_ID_FAIL_NO_SURVEY() throws Exception {
 		// given
-		Long targetId = targetInitializer.saveTargetAndGetId("luffy", LocalDateTime.now().minusYears(24));
-		String token = "luffy's-double-token";
+		Long targetId = targetInitializer.saveTargetAndGetId("nalab", LocalDateTime.now());
+		String token = "nalab-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)
 			.build());
 
-		// when
-		ResultActions resultActions = createSurvey(token, RequestSample.CUSTOM_JSON);
+		ResultActions result = getLoginedSurveyId(token);
 
 		// then
-		assertIsSurveyCreated(resultActions);
+		assertIsTargetDoesNotHasAnySurvey(result);
 	}
 
 }

--- a/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntityType.java
+++ b/core/data/src/main/java/me/nalab/core/data/survey/ChoiceFormQuestionEntityType.java
@@ -8,14 +8,6 @@ package me.nalab.core.data.survey;
 public enum ChoiceFormQuestionEntityType {
 
 	/**
-	 * COLLABORATION_EXPERIENCE 는 기본질문중 `협업경험` 을 나타냅니다.
-	 */
-	COLLABORATION_EXPERIENCE,
-	/**
-	 * POSITION 은 기본질문중 `직군` 을 나타냅니다.
-	 */
-	POSITION,
-	/**
 	 * TENDENCY 는 기본질문중 `성향` 을 나타냅니다.
 	 */
 	TENDENCY,

--- a/survey/application/src/main/java/me/nalab/survey/application/common/dto/ChoiceFormQuestionDtoType.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/common/dto/ChoiceFormQuestionDtoType.java
@@ -11,14 +11,6 @@ import me.nalab.survey.domain.survey.ChoiceFormQuestionType;
 public enum ChoiceFormQuestionDtoType {
 
 	/**
-	 * 기본타입 `나와의 협업 경험 유무`
-	 */
-	COLLABORATION_EXPERIENCE(ChoiceFormQuestionType.COLLABORATION_EXPERIENCE),
-	/**
-	 * 기본타입 `리뷰어의 직군`
-	 */
-	POSITION(ChoiceFormQuestionType.POSITION),
-	/**
 	 * 기본타입 `나의 성향`
 	 */
 	TENDENCY(ChoiceFormQuestionType.TENDENCY),

--- a/survey/application/src/test/java/me/nalab/survey/application/common/dto/CommonDtoEnumTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/common/dto/CommonDtoEnumTest.java
@@ -66,15 +66,7 @@ class CommonDtoEnumTest {
 	private static Stream<Arguments> choiceQuestionTypeDtoSources() {
 		return Stream.of(
 			of(ChoiceFormQuestionType.TENDENCY, ChoiceFormQuestionDtoType.TENDENCY, true),
-			of(ChoiceFormQuestionType.POSITION, ChoiceFormQuestionDtoType.POSITION, true),
-			of(ChoiceFormQuestionType.COLLABORATION_EXPERIENCE, ChoiceFormQuestionDtoType.COLLABORATION_EXPERIENCE,
-				true),
-			of(ChoiceFormQuestionType.CUSTOM, ChoiceFormQuestionDtoType.CUSTOM, true),
-
-			of(ChoiceFormQuestionType.TENDENCY, ChoiceFormQuestionDtoType.POSITION, false),
-			of(ChoiceFormQuestionType.POSITION, ChoiceFormQuestionDtoType.CUSTOM, false),
-			of(ChoiceFormQuestionType.COLLABORATION_EXPERIENCE, ChoiceFormQuestionDtoType.TENDENCY, false),
-			of(ChoiceFormQuestionType.CUSTOM, ChoiceFormQuestionDtoType.POSITION, false)
+			of(ChoiceFormQuestionType.CUSTOM, ChoiceFormQuestionDtoType.CUSTOM, true)
 		);
 	}
 

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestionType.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestionType.java
@@ -6,14 +6,6 @@ package me.nalab.survey.domain.survey;
 public enum ChoiceFormQuestionType {
 
 	/**
-	 * 기본타입 `나와의 협업 경험 유무`
-	 */
-	COLLABORATION_EXPERIENCE,
-	/**
-	 * 기본타입 `리뷰어의 직군`
-	 */
-	POSITION,
-	/**
 	 * 기본타입 `나의 성향`
 	 */
 	TENDENCY,

--- a/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/createsurvey/TestJson.java
+++ b/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/createsurvey/TestJson.java
@@ -41,7 +41,7 @@ class TestJson {
 		+ "    },\n"
 		+ "    {\n"
 		+ "      \"type\": \"choice\",\n"
-		+ "      \"form_type\": \"position\",\n"
+		+ "      \"form_type\": \"custom\",\n"
 		+ "      \"title\": \"저는 UI, UX, GUI 중에 어떤 분야를 가장 잘하는 것 같나요?\",\n"
 		+ "      \"choices\": [\n"
 		+ "        {\n"


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`position` 과 `collaboration-experience` enum을 도메인, dto, entity에서 삭제했습니다.

## 어떻게 해결했나요?
- [x] `position` 과 `collaboration-experience` enum을 `도메인`, `dto`, `entity` 에서 삭제.
- [x] 관련 테스트 케이스 수정
- [x] 관련 비즈니스 로직 수정  

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
