### PR TITLE
[fix] : 질문 폼 조회 usecase에서 questions반환 시 order로 정렬한 후 반환하는 로직 추가

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/service/find/SurveyFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/find/SurveyFindService.java
@@ -1,5 +1,10 @@
 package me.nalab.survey.application.service.find;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +15,7 @@ import me.nalab.survey.application.exception.SurveyDoesNotExistException;
 import me.nalab.survey.application.port.in.web.survey.find.SurveyFindUseCase;
 import me.nalab.survey.application.port.out.persistence.survey.find.SurveyFindPort;
 import me.nalab.survey.application.port.out.persistence.target.find.TargetFindPort;
+import me.nalab.survey.domain.survey.FormQuestionable;
 import me.nalab.survey.domain.survey.Survey;
 
 @Service
@@ -30,6 +36,8 @@ public class SurveyFindService implements SurveyFindUseCase {
 		Survey survey = surveyFindPort.findSurvey(surveyId).orElseThrow(() -> {
 			throw new SurveyDoesNotExistException(surveyId);
 		});
+
+		survey.getFormQuestionableList().sort(Comparator.comparing(FormQuestionable::getOrder));
 		return SurveyDtoMapper.toSurveyDto(targetId, survey);
 	}
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/find/SurveyFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/find/SurveyFindService.java
@@ -1,7 +1,5 @@
 package me.nalab.survey.application.service.find;
 
-import java.util.Comparator;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,7 +32,7 @@ public class SurveyFindService implements SurveyFindUseCase {
 			throw new SurveyDoesNotExistException(surveyId);
 		});
 
-		survey.getFormQuestionableList().sort(Comparator.comparing(FormQuestionable::getOrder));
+		survey.getFormQuestionableList().sort(FormQuestionable::compareTo);
 		return SurveyDtoMapper.toSurveyDto(targetId, survey);
 	}
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/find/SurveyFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/find/SurveyFindService.java
@@ -1,9 +1,6 @@
 package me.nalab.survey.application.service.find;
 
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/survey/application/src/main/java/me/nalab/survey/application/service/find/SurveyFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/find/SurveyFindService.java
@@ -10,7 +10,6 @@ import me.nalab.survey.application.exception.SurveyDoesNotExistException;
 import me.nalab.survey.application.port.in.web.survey.find.SurveyFindUseCase;
 import me.nalab.survey.application.port.out.persistence.survey.find.SurveyFindPort;
 import me.nalab.survey.application.port.out.persistence.target.find.TargetFindPort;
-import me.nalab.survey.domain.survey.FormQuestionable;
 import me.nalab.survey.domain.survey.Survey;
 
 @Service
@@ -32,7 +31,6 @@ public class SurveyFindService implements SurveyFindUseCase {
 			throw new SurveyDoesNotExistException(surveyId);
 		});
 
-		survey.getFormQuestionableList().sort(FormQuestionable::compareTo);
 		return SurveyDtoMapper.toSurveyDto(targetId, survey);
 	}
 }

--- a/survey/application/src/test/java/me/nalab/survey/application/service/find/SurveyFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/find/SurveyFindServiceTest.java
@@ -1,16 +1,21 @@
 package me.nalab.survey.application.service.find;
 
 import static me.nalab.survey.application.RandomSurveyDtoFixture.createRandomSurveyDto;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import me.nalab.survey.application.common.dto.FormQuestionDtoable;
 import me.nalab.survey.application.common.dto.SurveyDto;
 import me.nalab.survey.application.common.mapper.SurveyDtoMapper;
 import me.nalab.survey.application.exception.SurveyDoesNotExistException;
@@ -46,9 +51,15 @@ class SurveyFindServiceTest {
 
 		SurveyDto result = surveyFindService.findSurvey(surveyId);
 
+		boolean isSortedByOrder = result.getFormQuestionDtoableList().stream()
+			.sorted(Comparator.comparingInt(FormQuestionDtoable::getOrder))
+			.collect(Collectors.toList())
+			.equals(result.getFormQuestionDtoableList());
+
 		assertNotNull(result);
 		assertEquals(targetId, result.getTargetId());
 		assertEquals(surveyId, result.getId());
+		assertEquals(isSortedByOrder, true);
 	}
 
 	@Test

--- a/survey/application/src/test/java/me/nalab/survey/application/service/find/SurveyFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/find/SurveyFindServiceTest.java
@@ -1,12 +1,10 @@
 package me.nalab.survey.application.service.find;
 
 import static me.nalab.survey.application.RandomSurveyDtoFixture.createRandomSurveyDto;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import java.util.Comparator;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 

--- a/survey/application/src/test/java/me/nalab/survey/application/service/find/SurveyFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/find/SurveyFindServiceTest.java
@@ -4,9 +4,7 @@ import static me.nalab.survey.application.RandomSurveyDtoFixture.createRandomSur
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
-import java.util.Comparator;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +36,7 @@ class SurveyFindServiceTest {
 	}
 
 	@Test
-	void SURVEY_FIND_SERVICE_TEST() {
+	void SURVEY_FIND_SERVICE_TEST() throws RuntimeException {
 		SurveyDto randomSurveyDto = createRandomSurveyDto();
 		Long surveyId = randomSurveyDto.getId();
 		Long targetId = randomSurveyDto.getTargetId();
@@ -49,15 +47,21 @@ class SurveyFindServiceTest {
 
 		SurveyDto result = surveyFindService.findSurvey(surveyId);
 
-		boolean isSortedByOrder = result.getFormQuestionDtoableList().stream()
-			.sorted(Comparator.comparingInt(FormQuestionDtoable::getOrder))
-			.collect(Collectors.toList())
-			.equals(result.getFormQuestionDtoableList());
+		boolean isAscendingOrder = result.getFormQuestionDtoableList().stream()
+			.map(FormQuestionDtoable::getOrder)
+			.reduce((prev, current) -> {
+				if(prev.compareTo(current) < 0) {
+					return current;
+				} else {
+					throw new RuntimeException();
+				}
+			})
+			.isPresent();
 
 		assertNotNull(result);
 		assertEquals(targetId, result.getTargetId());
 		assertEquals(surveyId, result.getId());
-		assertEquals(true, isSortedByOrder);
+		assertTrue(isAscendingOrder);
 	}
 
 	@Test

--- a/survey/application/src/test/java/me/nalab/survey/application/service/find/SurveyFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/find/SurveyFindServiceTest.java
@@ -57,7 +57,7 @@ class SurveyFindServiceTest {
 		assertNotNull(result);
 		assertEquals(targetId, result.getTargetId());
 		assertEquals(surveyId, result.getId());
-		assertEquals(isSortedByOrder, true);
+		assertEquals(true, isSortedByOrder);
 	}
 
 	@Test

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Choice.java
@@ -1,5 +1,6 @@
 package me.nalab.survey.domain.survey;
 
+import java.util.Comparator;
 import java.util.function.LongSupplier;
 
 import lombok.Builder;
@@ -13,7 +14,7 @@ import me.nalab.survey.domain.support.IdGeneratable;
 @Getter
 @EqualsAndHashCode
 @ToString
-public class Choice implements IdGeneratable {
+public class Choice implements IdGeneratable, Comparable<Choice> {
 
 	private Long id;
 	private final String content;
@@ -27,4 +28,9 @@ public class Choice implements IdGeneratable {
 		id = idSupplier.getAsLong();
 	}
 
+	@Override
+	public int compareTo(Choice other) {
+		return Comparator.comparingInt(Choice::getOrder)
+			.compare(this, other);
+	}
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -1,8 +1,8 @@
 package me.nalab.survey.domain.survey;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.LongSupplier;
-import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -22,16 +22,15 @@ public class ChoiceFormQuestion extends FormQuestionable {
 
 	ChoiceFormQuestion(ChoiceFormQuestionBuilder<?, ?> builder) {
 		super(builder);
-		choiceList = sortChoiceList(builder.choiceList);
-		maxSelectionCount = builder.maxSelectionCount;
-		choiceFormQuestionType = builder.choiceFormQuestionType;
+		this.choiceList = builder.choiceList;
+		withSortedChoiceList(this.choiceList);
+		this.maxSelectionCount = builder.maxSelectionCount;
+		this.choiceFormQuestionType = builder.choiceFormQuestionType;
 		ChoiceFormQuestionValidator.validSelf(this);
 	}
 
-	private List<Choice> sortChoiceList(List<Choice> choiceList) {
-		return choiceList.stream()
-			.sorted()
-			.collect(Collectors.toList());
+	private void withSortedChoiceList(List<Choice> choiceList) {
+		Collections.sort(choiceList);
 	}
 
 	@Override

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/ChoiceFormQuestion.java
@@ -2,6 +2,7 @@ package me.nalab.survey.domain.survey;
 
 import java.util.List;
 import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -21,10 +22,16 @@ public class ChoiceFormQuestion extends FormQuestionable {
 
 	ChoiceFormQuestion(ChoiceFormQuestionBuilder<?, ?> builder) {
 		super(builder);
-		choiceList = builder.choiceList;
+		choiceList = sortChoiceList(builder.choiceList);
 		maxSelectionCount = builder.maxSelectionCount;
 		choiceFormQuestionType = builder.choiceFormQuestionType;
 		ChoiceFormQuestionValidator.validSelf(this);
+	}
+
+	private List<Choice> sortChoiceList(List<Choice> choiceList) {
+		return choiceList.stream()
+			.sorted()
+			.collect(Collectors.toList());
 	}
 
 	@Override

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/FormQuestionable.java
@@ -1,6 +1,7 @@
 package me.nalab.survey.domain.survey;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.function.LongSupplier;
 
 import lombok.EqualsAndHashCode;
@@ -14,7 +15,7 @@ import me.nalab.survey.domain.support.IdGeneratable;
 @Getter
 @ToString
 @EqualsAndHashCode
-public abstract class FormQuestionable implements IdGeneratable {
+public abstract class FormQuestionable implements IdGeneratable, Comparable<FormQuestionable> {
 
 	protected Long id;
 	protected final String title;
@@ -35,4 +36,9 @@ public abstract class FormQuestionable implements IdGeneratable {
 	protected void cascadeId(LongSupplier idSupplier) {
 	}
 
+	@Override
+	public int compareTo(FormQuestionable other) {
+		return Comparator.comparingInt(FormQuestionable::getOrder)
+			.compare(this, other);
+	}
 }

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -1,9 +1,9 @@
 package me.nalab.survey.domain.survey;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.LongSupplier;
-import java.util.stream.Collectors;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -29,14 +29,13 @@ public class Survey implements IdGeneratable {
 		this.id = id;
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
-		this.formQuestionableList = sortFormQuestionableList(formQuestionableList);
+		this.formQuestionableList = formQuestionableList;
+		withSortedQuestionList(this.formQuestionableList);
 		SurveyValidator.validSelf(this);
 	}
 
-	private List<FormQuestionable> sortFormQuestionableList(List<FormQuestionable> formQuestionableList) {
-		return formQuestionableList.stream()
-			.sorted()
-			.collect(Collectors.toList());
+	private void withSortedQuestionList(List<FormQuestionable> formQuestionableList) {
+		Collections.sort(formQuestionableList);
 	}
 
 	@Override

--- a/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/survey/Survey.java
@@ -3,6 +3,7 @@ package me.nalab.survey.domain.survey;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -28,8 +29,14 @@ public class Survey implements IdGeneratable {
 		this.id = id;
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
-		this.formQuestionableList = formQuestionableList;
+		this.formQuestionableList = sortFormQuestionableList(formQuestionableList);
 		SurveyValidator.validSelf(this);
+	}
+
+	private List<FormQuestionable> sortFormQuestionableList(List<FormQuestionable> formQuestionableList) {
+		return formQuestionableList.stream()
+			.sorted()
+			.collect(Collectors.toList());
 	}
 
 	@Override

--- a/survey/domain/src/test/java/me/nalab/survey/domain/AbstractSurveySources.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/AbstractSurveySources.java
@@ -3,6 +3,7 @@ package me.nalab.survey.domain;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -24,13 +25,18 @@ public abstract class AbstractSurveySources {
 	protected static Stream<Arguments> surveyCreateSuccessSources() {
 		return Stream.of(
 			of(
-				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now())
-				, (Supplier<List<FormQuestionable>>)() -> List.of(
-					choiceFormQuestion(2L, "choice-form1", LocalDateTime.now(), LocalDateTime.now(), 1,
-						List.of(choice(3L, 1, "choice1"), choice(4L, 2, "choice2")))
-					, shortFormQuestion(5L, "short-form2", LocalDateTime.now(), LocalDateTime.now(), 2
-					)
-				)
+				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now()),
+				(Supplier<List<FormQuestionable>>)() -> {
+					List<FormQuestionable> formQuestionables = new ArrayList<>();
+					List<Choice> choiceList = new ArrayList<>();
+					choiceList.add(choice(3L, 1, "choice1"));
+					choiceList.add(choice(4L, 2, "choice2"));
+					formQuestionables.add(choiceFormQuestion(2L, "choice-form1", LocalDateTime.now(),
+						LocalDateTime.now(), 1, choiceList));
+					formQuestionables.add(shortFormQuestion(5L, "short-form2", LocalDateTime.now(),
+						LocalDateTime.now(), 2));
+					return formQuestionables;
+				}
 			)
 		);
 	}
@@ -38,24 +44,31 @@ public abstract class AbstractSurveySources {
 	protected static Stream<Arguments> surveyCreateFailOrderSources() {
 		return Stream.of(
 			of(
-				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now())
-				, (Supplier<List<FormQuestionable>>)() -> List.of(
-					choiceFormQuestion(2L, "choice-form-fail1", LocalDateTime.now(), LocalDateTime.now(), 1
-						, List.of(choice(3L, 1, "choice1"), choice(4L, 2, "choice2")))
-					, shortFormQuestion(11L, "short-form-fail", LocalDateTime.now(), LocalDateTime.now(), 1)
-				)
-			)
-			, of(
-				surveyFunction(6L, LocalDateTime.now(), LocalDateTime.now())
-				, (Supplier<List<FormQuestionable>>)() -> List.of(
-					choiceFormQuestion(7L, "choice-form-fail3", LocalDateTime.now(), LocalDateTime.now(), 1
-						, List.of(
-							choice(8L, 2, "choice3")
-							, choice(4L, 2, "choice4")
-							, choice(4L, 2, "choice4")
-						)
-					)
-				)
+				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now()),
+				(Supplier<List<FormQuestionable>>)() -> {
+					List<FormQuestionable> formQuestionables = new ArrayList<>();
+					List<Choice> choiceList = new ArrayList<>();
+					choiceList.add(choice(3L, 1, "choice1"));
+					choiceList.add(choice(4L, 2, "choice2"));
+					formQuestionables.add(choiceFormQuestion(2L, "choice-form-fail1", LocalDateTime.now(),
+						LocalDateTime.now(), 1, choiceList));
+					formQuestionables.add(shortFormQuestion(11L, "short-form-fail", LocalDateTime.now(),
+						LocalDateTime.now(), 1));
+					return formQuestionables;
+				}
+			),
+			of(
+				surveyFunction(6L, LocalDateTime.now(), LocalDateTime.now()),
+				(Supplier<List<FormQuestionable>>)() -> {
+					List<FormQuestionable> formQuestionables = new ArrayList<>();
+					List<Choice> choiceList = new ArrayList<>();
+					choiceList.add(choice(8L, 2, "choice3"));
+					choiceList.add(choice(4L, 2, "choice4"));
+					choiceList.add(choice(4L, 2, "choice4"));
+					formQuestionables.add(choiceFormQuestion(7L, "choice-form-fail3", LocalDateTime.now(),
+						LocalDateTime.now(), 1, choiceList));
+					return formQuestionables;
+				}
 			)
 		);
 	}
@@ -64,31 +77,51 @@ public abstract class AbstractSurveySources {
 		return Stream.of(
 			of(
 				surveyFunction(null, LocalDateTime.now(), LocalDateTime.now()),
-				(Supplier<List<FormQuestionable>>)() -> List.of(
-					choiceFormQuestion(null, "choice-form-fail1", LocalDateTime.now(), LocalDateTime.now(), 1,
-						List.of(choice(null, 1, "choice1"), choice(1L, 2, "choice2")))
-				)
+				(Supplier<List<FormQuestionable>>)() -> {
+					List<FormQuestionable> formQuestionables = new ArrayList<>();
+					List<Choice> choiceList = new ArrayList<>();
+					choiceList.add(choice(null, 1, "choice1"));
+					choiceList.add(choice(1L, 2, "choice2"));
+					formQuestionables.add(choiceFormQuestion(null, "choice-form-fail1", LocalDateTime.now(),
+						LocalDateTime.now(), 1, choiceList));
+					return formQuestionables;
+				}
 			),
 			of(
 				surveyFunction(null, LocalDateTime.now(), LocalDateTime.now()),
-				(Supplier<List<FormQuestionable>>)() -> List.of(
-					choiceFormQuestion(null, "choice-form-fail1", LocalDateTime.now(), LocalDateTime.now(), 1,
-						List.of(choice(1L, 1, "choice1"), choice(1L, 2, "choice2")))
-				)
+				(Supplier<List<FormQuestionable>>)() -> {
+					List<FormQuestionable> formQuestionables = new ArrayList<>();
+					List<Choice> choiceList = new ArrayList<>();
+					choiceList.add(choice(1L, 1, "choice3"));
+					choiceList.add(choice(1L, 2, "choice4"));
+					formQuestionables.add(choiceFormQuestion(null, "choice-form-fail1", LocalDateTime.now(),
+						LocalDateTime.now(), 1, choiceList));
+					return formQuestionables;
+				}
 			),
 			of(
 				surveyFunction(null, LocalDateTime.now(), LocalDateTime.now()),
-				(Supplier<List<FormQuestionable>>)() -> List.of(
-					choiceFormQuestion(1L, "choice-form-fail1", LocalDateTime.now(), LocalDateTime.now(), 1,
-						List.of(choice(1L, 1, "choice1"), choice(1L, 2, "choice2")))
-				)
+				(Supplier<List<FormQuestionable>>)() -> {
+					List<FormQuestionable> formQuestionables = new ArrayList<>();
+					List<Choice> choiceList = new ArrayList<>();
+					choiceList.add(choice(1L, 1, "choice3"));
+					choiceList.add(choice(1L, 2, "choice4"));
+					formQuestionables.add(choiceFormQuestion(1L, "choice-form-fail1", LocalDateTime.now(),
+						LocalDateTime.now(), 1, choiceList));
+					return formQuestionables;
+				}
 			),
 			of(
 				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now()),
-				(Supplier<List<FormQuestionable>>)() -> List.of(
-					choiceFormQuestion(1L, "choice-form-fail1", LocalDateTime.now(), LocalDateTime.now(), 1,
-						List.of(choice(1L, 1, "choice1"), choice(1L, 2, "choice2")))
-				)
+				(Supplier<List<FormQuestionable>>)() -> {
+					List<FormQuestionable> formQuestionables = new ArrayList<>();
+					List<Choice> choiceList = new ArrayList<>();
+					choiceList.add(choice(1L, 1, "choice3"));
+					choiceList.add(choice(1L, 2, "choice4"));
+					formQuestionables.add(choiceFormQuestion(1L, "choice-form-fail1", LocalDateTime.now(),
+						LocalDateTime.now(), 1, choiceList));
+					return formQuestionables;
+				}
 			)
 		);
 	}

--- a/survey/domain/src/test/java/me/nalab/survey/domain/AbstractTargetSources.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/AbstractTargetSources.java
@@ -3,6 +3,7 @@ package me.nalab.survey.domain;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -10,6 +11,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.params.provider.Arguments;
 
+import me.nalab.survey.domain.survey.Choice;
 import me.nalab.survey.domain.survey.FormQuestionable;
 import me.nalab.survey.domain.survey.Survey;
 import me.nalab.survey.domain.target.Target;
@@ -20,13 +22,21 @@ public abstract class AbstractTargetSources extends AbstractSurveySources {
 		return Stream.of(
 			of(
 				targetFunction(10L, "mike"),
-				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now())
-				, (Supplier<List<FormQuestionable>>)() -> List.of(
-					choiceFormQuestion(2L, "choice-form1", LocalDateTime.now(), LocalDateTime.now(), 1,
-						List.of(choice(3L, 1, "choice1"), choice(4L, 2, "choice2")))
-					, shortFormQuestion(5L, "short-form2", LocalDateTime.now(), LocalDateTime.now(), 2
-					)
-				)
+				surveyFunction(1L, LocalDateTime.now(), LocalDateTime.now()),
+				(Supplier<List<FormQuestionable>>)() -> {
+					List<Choice> choiceList = new ArrayList<>();
+					choiceList.add(Choice.builder().id(2L).order(1).content("choice1").build());
+					choiceList.add(Choice.builder().id(4L).order(2).content("choice2").build());
+					ArrayList<FormQuestionable> formQuestionables = new ArrayList<>();
+					formQuestionables.add(
+						choiceFormQuestion(2L, "choice-form1", LocalDateTime.now(), LocalDateTime.now(), 1,
+							choiceList)
+					);
+					formQuestionables.add(
+						shortFormQuestion(5L, "short-form2", LocalDateTime.now(), LocalDateTime.now(), 2)
+					);
+					return formQuestionables;
+				}
 			)
 		);
 	}

--- a/survey/domain/src/test/java/me/nalab/survey/domain/survey/ChoiceTest.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/survey/ChoiceTest.java
@@ -1,0 +1,33 @@
+package me.nalab.survey.domain.survey;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ChoiceTest {
+
+	@Test
+	void testCompareTo() {
+
+		Choice choice1 = Choice.builder()
+			.id(1L)
+			.content("choice 1")
+			.order(2)
+			.build();
+
+		Choice choice2 = Choice.builder()
+			.id(2L)
+			.content("choice 2")
+			.order(1)
+			.build();
+
+		Choice choice3 = Choice.builder()
+			.id(3L)
+			.content("choice 3")
+			.order(3)
+			.build();
+
+		Assertions.assertTrue(choice1.compareTo(choice2) > 0);
+		Assertions.assertTrue(choice1.compareTo(choice3) < 0);
+		Assertions.assertTrue(choice2.compareTo(choice3) < 0);
+	}
+}

--- a/survey/domain/src/test/java/me/nalab/survey/domain/survey/FormQuestionableTest.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/survey/FormQuestionableTest.java
@@ -1,0 +1,48 @@
+package me.nalab.survey.domain.survey;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FormQuestionableTest {
+
+	@Test
+	void testCompareTo() {
+
+		ChoiceFormQuestion question1 = ChoiceFormQuestion.builder()
+			.title("Question 1")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.order(1)
+			.questionType(QuestionType.CHOICE)
+			.choiceList(List.of(Choice.builder().id(1L).content("content").order(1).build(),
+				Choice.builder().id(2L).content("content").order(2).build(),
+				Choice.builder().id(3L).content("content").order(3).build()))
+			.build();
+
+		FormQuestionable question2 = ChoiceFormQuestion.builder()
+			.title("Question 2")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.order(2)
+			.questionType(QuestionType.CHOICE)
+			.choiceList(List.of(Choice.builder().id(1L).content("content").order(1).build(),
+				Choice.builder().id(2L).content("content").order(2).build(),
+				Choice.builder().id(3L).content("content").order(3).build()))
+			.build();
+
+		FormQuestionable question3 = ShortFormQuestion.builder()
+			.title("Question 3")
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.order(3)
+			.questionType(QuestionType.SHORT)
+			.build();
+
+		Assertions.assertTrue(question1.compareTo(question2) < 0);
+		Assertions.assertTrue(question2.compareTo(question3) < 0);
+		Assertions.assertTrue(question1.compareTo(question3) < 0);
+	}
+}

--- a/survey/domain/src/test/java/me/nalab/survey/domain/survey/FormQuestionableTest.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/survey/FormQuestionableTest.java
@@ -1,6 +1,7 @@
 package me.nalab.survey.domain.survey;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
@@ -11,26 +12,28 @@ class FormQuestionableTest {
 	@Test
 	void testCompareTo() {
 
+		List<Choice> choiceList1 = new ArrayList<>();
+		choiceList1.add(Choice.builder().id(2L).content("content").order(2).build());
+		choiceList1.add(Choice.builder().id(3L).content("content").order(3).build());
 		ChoiceFormQuestion question1 = ChoiceFormQuestion.builder()
 			.title("Question 1")
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.order(1)
 			.questionType(QuestionType.CHOICE)
-			.choiceList(List.of(Choice.builder().id(1L).content("content").order(1).build(),
-				Choice.builder().id(2L).content("content").order(2).build(),
-				Choice.builder().id(3L).content("content").order(3).build()))
+			.choiceList(choiceList1)
 			.build();
 
+		List<Choice> choiceList2 = new ArrayList<>();
+		choiceList2.add(Choice.builder().id(2L).content("content").order(2).build());
+		choiceList2.add(Choice.builder().id(3L).content("content").order(3).build());
 		FormQuestionable question2 = ChoiceFormQuestion.builder()
 			.title("Question 2")
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.order(2)
 			.questionType(QuestionType.CHOICE)
-			.choiceList(List.of(Choice.builder().id(1L).content("content").order(1).build(),
-				Choice.builder().id(2L).content("content").order(2).build(),
-				Choice.builder().id(3L).content("content").order(3).build()))
+			.choiceList(choiceList2)
 			.build();
 
 		FormQuestionable question3 = ShortFormQuestion.builder()

--- a/survey/domain/src/test/java/me/nalab/survey/domain/survey/SurveyDomainTest.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/survey/SurveyDomainTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
@@ -132,41 +133,41 @@ class SurveyDomainTest extends AbstractSurveySources {
 	}
 
 	private List<FormQuestionable> getDefaultQuestionFormList() {
-		return List.of(
-			ShortFormQuestion.builder()
-				.title("short")
-				.questionType(QuestionType.SHORT)
-				.shortFormQuestionType(ShortFormQuestionType.CUSTOM)
-				.order(1)
-				.createdAt(LocalDateTime.now())
-				.updatedAt(LocalDateTime.now())
-				.build(),
-			ChoiceFormQuestion.builder()
-				.title("choice")
-				.questionType(QuestionType.CHOICE)
-				.choiceFormQuestionType(ChoiceFormQuestionType.CUSTOM)
-				.createdAt(LocalDateTime.now())
-				.updatedAt(LocalDateTime.now())
-				.order(2)
-				.maxSelectionCount(1)
-				.choiceList(
-					getDefaultChoiceList()
-				)
-				.build()
-		);
+		List<FormQuestionable> formQuestionableList = new ArrayList<>();
+		formQuestionableList.add(ShortFormQuestion.builder()
+			.title("short")
+			.questionType(QuestionType.SHORT)
+			.shortFormQuestionType(ShortFormQuestionType.CUSTOM)
+			.order(1)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.build());
+		formQuestionableList.add(ChoiceFormQuestion.builder()
+			.title("choice")
+			.questionType(QuestionType.CHOICE)
+			.choiceFormQuestionType(ChoiceFormQuestionType.CUSTOM)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.order(2)
+			.maxSelectionCount(1)
+			.choiceList(
+				getDefaultChoiceList()
+			)
+			.build());
+		return formQuestionableList;
 	}
 
 	private List<Choice> getDefaultChoiceList() {
-		return List.of(
-			Choice.builder()
-				.content("choice1")
-				.order(1)
-				.build(),
-			Choice.builder()
-				.content("choce2")
-				.order(2)
-				.build()
-		);
+		List<Choice> choiceList = new ArrayList<>();
+		choiceList.add(Choice.builder()
+			.content("choice1")
+			.order(1)
+			.build());
+		choiceList.add(Choice.builder()
+			.content("choce2")
+			.order(2)
+			.build());
+		return choiceList;
 	}
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문 폼 조회 usecase에
survey 반환 시에, survey의 모든 질문들을 지정된 order에 맞게 반환하는 로직을 추가했습니다

## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
