### PR TITLE
[feat] : `javax.validation` 전역 예외 핸들러 추가

### DIFF
--- a/core/exception-handler/build.gradle
+++ b/core/exception-handler/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    testImplementation 'javax.validation:validation-api:2.0.1.Final'
+    testImplementation 'org.springframework.boot:spring-boot-starter-validation'
+}

--- a/core/exception-handler/src/main/java/me/nalab/core/exception/handler/ErrorTemplate.java
+++ b/core/exception-handler/src/main/java/me/nalab/core/exception/handler/ErrorTemplate.java
@@ -1,0 +1,21 @@
+package me.nalab.core.exception.handler;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorTemplate {
+
+	@JsonProperty("response_messages")
+	private final String message;
+
+	private ErrorTemplate(String message) {
+		this.message = message;
+	}
+
+	public static ErrorTemplate of(String message) {
+		return new ErrorTemplate(message);
+	}
+
+}

--- a/core/exception-handler/src/main/java/me/nalab/core/exception/handler/ValidationControllerAdvice.java
+++ b/core/exception-handler/src/main/java/me/nalab/core/exception/handler/ValidationControllerAdvice.java
@@ -1,0 +1,26 @@
+package me.nalab.core.exception.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * javax.validation 어노테이션의 message를 잡아 내려줍니다
+ */
+@RestControllerAdvice
+public class ValidationControllerAdvice {
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorTemplate catchValidationException(MethodArgumentNotValidException methodArgumentNotValidException) {
+		String messages = methodArgumentNotValidException
+			.getBindingResult()
+			.getAllErrors()
+			.get(0)
+			.getDefaultMessage();
+		return ErrorTemplate.of(messages);
+	}
+
+}

--- a/core/exception-handler/src/main/java/me/nalab/core/exception/handler/ValidationControllerAdvice.java
+++ b/core/exception-handler/src/main/java/me/nalab/core/exception/handler/ValidationControllerAdvice.java
@@ -1,5 +1,7 @@
 package me.nalab.core.exception.handler;
 
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
  * javax.validation 어노테이션의 message를 잡아 내려줍니다
  */
 @RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class ValidationControllerAdvice {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)

--- a/core/exception-handler/src/main/java/module-info.java
+++ b/core/exception-handler/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module luffy.core.exception.handler.main {
+	requires spring.web;
+	requires lombok;
+	requires com.fasterxml.jackson.annotation;
+}

--- a/core/exception-handler/src/main/java/module-info.java
+++ b/core/exception-handler/src/main/java/module-info.java
@@ -2,4 +2,5 @@ module luffy.core.exception.handler.main {
 	requires spring.web;
 	requires lombok;
 	requires com.fasterxml.jackson.annotation;
+	requires spring.core;
 }

--- a/core/exception-handler/src/test/java/me/nalab/core/exception/handler/TestController.java
+++ b/core/exception-handler/src/test/java/me/nalab/core/exception/handler/TestController.java
@@ -1,0 +1,15 @@
+package me.nalab.core.exception.handler;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class TestController {
+
+	@PostMapping("/hello")
+	void hello(@RequestBody @Validated TestRequest testRequest) {
+	}
+
+}

--- a/core/exception-handler/src/test/java/me/nalab/core/exception/handler/TestRequest.java
+++ b/core/exception-handler/src/test/java/me/nalab/core/exception/handler/TestRequest.java
@@ -1,0 +1,24 @@
+package me.nalab.core.exception.handler;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.Length;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+class TestRequest {
+
+	@Length(max = 5, message = "overflow")
+	@NotNull(message = "null")
+	@NotBlank(message = "blank")
+	private String hello;
+
+}

--- a/core/exception-handler/src/test/java/me/nalab/core/exception/handler/ValidationControllerAdviceTest.java
+++ b/core/exception-handler/src/test/java/me/nalab/core/exception/handler/ValidationControllerAdviceTest.java
@@ -29,7 +29,7 @@ class ValidationControllerAdviceTest {
 	private ObjectMapper objectMapper;
 
 	@BeforeEach
-	private void setObjectMapper(){
+	private void setObjectMapper() {
 		objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
 	}
 
@@ -61,7 +61,7 @@ class ValidationControllerAdviceTest {
 
 	@Test
 	@DisplayName("Validation controller advice 예외 핸들링 테스트 - blank")
-	void VALID_BLANK() throws Exception{
+	void VALID_BLANK() throws Exception {
 		// given
 		TestRequest testRequest = new TestRequest("   ");
 

--- a/core/exception-handler/src/test/java/me/nalab/core/exception/handler/ValidationControllerAdviceTest.java
+++ b/core/exception-handler/src/test/java/me/nalab/core/exception/handler/ValidationControllerAdviceTest.java
@@ -1,0 +1,103 @@
+package me.nalab.core.exception.handler;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest
+@ContextConfiguration(classes = {TestController.class, ValidationControllerAdvice.class})
+class ValidationControllerAdviceTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	private void setObjectMapper(){
+		objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+	}
+
+	@Test
+	@DisplayName("Validation controller advice 예외 핸들링 테스트 - length overflow")
+	void VALID_OVERFLOW() throws Exception {
+		// given
+		TestRequest testRequest = new TestRequest("abcdasd");
+
+		// when
+		ResultActions resultActions = callHello(testRequest);
+
+		// then
+		assertIsOverFlow(resultActions);
+	}
+
+	@Test
+	@DisplayName("Validation controller advice 예외 핸들링 테스트 - null")
+	void VALID_NULL() throws Exception {
+		// given
+		TestRequest testRequest = new TestRequest(null);
+
+		// when
+		ResultActions resultActions = callHello(testRequest);
+
+		// then
+		assertIsNull(resultActions);
+	}
+
+	@Test
+	@DisplayName("Validation controller advice 예외 핸들링 테스트 - blank")
+	void VALID_BLANK() throws Exception{
+		// given
+		TestRequest testRequest = new TestRequest("   ");
+
+		// when
+		ResultActions resultActions = callHello(testRequest);
+
+		// then
+		assertIsBlank(resultActions);
+	}
+
+	private ResultActions callHello(TestRequest request) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders.post("/hello")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request))
+		);
+	}
+
+	private void assertIsOverFlow(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isBadRequest(),
+			jsonPath("$.response_messages").value("overflow")
+		);
+	}
+
+	private void assertIsNull(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isBadRequest(),
+			jsonPath("$.response_messages").value("null")
+		);
+	}
+
+	private void assertIsBlank(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isBadRequest(),
+			jsonPath("$.response_messages").value("blank")
+		);
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,3 +32,5 @@ include 'core:id-generator:id-core'
 include 'core:id-generator:mock-id-generator'
 include 'core:id-generator:id-generator-starter'
 
+include 'core:exception-handler'
+


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`javax.validation` 예외를 처리하는 전역 예외 핸들러를 추가했습니다.

## 어떻게 해결했나요?
- [x] `MethodArgumentNotValidException` 를 처리하는 전역 `@RestControllerAdvice`를 추가했습니다.
- [x] 관련 테스트 코드를 추가했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
