### PR TITLE
[test] : 질문 폼의 피드백 요약 인수테스트 작성

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
@@ -4,11 +4,17 @@ import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MockMvcBuilder;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import me.nalab.luffy.api.acceptance.test.DatabaseCleaner;
+import me.nalab.luffy.api.acceptance.test.survey.AbstractSurveyTestSupporter;
 
-public abstract class AbstractFeedbackTestSupporter {
+public abstract class AbstractFeedbackTestSupporter extends AbstractSurveyTestSupporter  {
 
 	private MockMvc mockMvc;
 	private DatabaseCleaner databaseCleaner;
@@ -16,6 +22,17 @@ public abstract class AbstractFeedbackTestSupporter {
 	private static final Set<String> tableNameSet = Set.of("feedback", "form_feedback", "reviewer");
 
 	//: TODO 여기에 Feedback api관련된 호출 메소드를 만들어 주세요. AbstractSurveyTestSupporter 참고해서 작성하면 됩니다.
+
+	//: TODO
+	protected ResultActions findFeedbackSummary(String token, String surveyId) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.get(API_VERSION + "/feedbacks/summary")
+			.queryParam("survey_id", surveyId)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header(HttpHeaders.AUTHORIZATION, token)
+		);
+	}
 
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -1,5 +1,12 @@
 package me.nalab.luffy.api.acceptance.test.feedback;
 
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
 public final class FeedbackAcceptanceValidator {
 
 	private FeedbackAcceptanceValidator() {
@@ -7,5 +14,15 @@ public final class FeedbackAcceptanceValidator {
 	}
 
 	//:TODO 여기에 Feedback 인수테스트 validator 로직을 static으로 작성 해주세요. SurveyAcceptanceValidator 참고해서 작성하면 됩니다.
+
+	//: TODO
+	public static void assertIsFeedbackSummaryFound(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.all_feedback_count").isNumber(),
+			jsonPath("$.new_feedback_count").isNumber()
+		);
+	}
 
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummery/FeedbackFindSummaryAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummery/FeedbackFindSummaryAcceptanceTest.java
@@ -1,0 +1,63 @@
+package me.nalab.luffy.api.acceptance.test.feedback.findsummery;
+
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.assertIsFeedbackSummaryFound;
+
+import java.time.LocalDateTime;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.feedback.AbstractFeedbackTestSupporter;
+import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+public class FeedbackFindSummaryAcceptanceTest extends AbstractFeedbackTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	@Test
+	@DisplayName("질문 폼의 전체 피드백 수와 읽지 않은 피드백 수 조회")
+	void FEEFBACK_SUMMARY_FIND_SUCCESS_TEST() throws Exception {
+
+		String token = "luffy's-double-token";
+		Long targetId = targetInitializer.saveTargetAndGetId("sujin", LocalDateTime.now());
+		applicationEventPublisher.publishEvent(
+			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());
+
+		Long surveyId = createSurveyAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+
+		ResultActions resultActions = findFeedbackSummary(token, surveyId.toString());
+
+		assertIsFeedbackSummaryFound(resultActions);
+	}
+
+	private Long createSurveyAndGetSurveyId(String token, String content) throws Exception {
+		String stringResponse = createSurvey(token, content).andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		JSONObject jsonObject = new JSONObject(stringResponse);
+		return jsonObject.getLong("survey_id");
+	}
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문 폼의 피드백 요약 (해당 전체 피드백 수와 읽지 않은 피드백의 수) API에 대한 인수테스트를 작성했습니다

- [x]  /feedback/findsummary 패키지에 질문 폼의 피드백 요약 `인수테스트` 클래스를 생성했습니다
- [x] `FeedbackAcceptanceValidator` 에 요청로직에 대한 validation 로직을 추가했습니다 -> `assertIsFeedbackSummaryFound`
- [x] `AbstractFeedbackTestSupporter` 에 요청로직을 추가했습니다 -> `findFeedbackSummary` 


## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
