### PR TITLE
[feat] : `Feedback 생성` 유즈케이스 추가

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/createfeedback/FeedbackCreateUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/createfeedback/FeedbackCreateUseCase.java
@@ -2,8 +2,17 @@ package me.nalab.survey.application.port.in.web.createfeedback;
 
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 
+/**
+ * 새로운 피드백을 생성하는 인터페이스 입니다.
+ */
 public interface FeedbackCreateUseCase {
 
+	/**
+	 * surveyId와 feedbackDto를 인자로 받고, surveyId에 해당하는 survey에 feedback을 남깁니다.
+	 *
+	 * @param surveyId feedback을 남길 survey의 id
+	 * @param feedbackDto feedback의 정보들
+	 */
 	void createFeedback(Long surveyId, FeedbackDto feedbackDto);
 
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/createfeedback/FeedbackCreateUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/createfeedback/FeedbackCreateUseCase.java
@@ -1,0 +1,9 @@
+package me.nalab.survey.application.port.in.web.createfeedback;
+
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+
+public interface FeedbackCreateUseCase {
+
+	void createFeedback(Long surveyId, FeedbackDto feedbackDto);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/FeedbackSavePort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/FeedbackSavePort.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.application.port.out.persistence.createfeedback;
+
+import me.nalab.survey.domain.feedback.Feedback;
+
+/**
+ * Survey에 Feedback을 저장하는 인터페이스 입니다.
+ */
+public interface FeedbackSavePort {
+
+	/**
+	 * Feedback domain을 인자로 받아, 저장합니다.
+	 *
+	 * @param feedback 생성할 feedback domain
+	 */
+	void saveFeedback(Feedback feedback);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/ReviewerLatestNameFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/ReviewerLatestNameFindPort.java
@@ -1,0 +1,18 @@
+package me.nalab.survey.application.port.out.persistence.createfeedback;
+
+import java.util.Optional;
+
+/**
+ * 마지막으로 리뷰를 작성한 리뷰어의 이름을 찾는 인터페이스 입니다.
+ */
+public interface ReviewerLatestNameFindPort {
+
+	/**
+	 * 마지막으로 리뷰를한 리뷰어의 nickname을 조회합니다.
+	 *
+	 * @param surveyId 리뷰어의 정보를 찾을 survey의 id입니다.
+	 * @return Optional 마지막으로 리뷰한 리뷰어의 닉네임 입니다. 없다면, Optional.empty를 반환해야합니다.
+	 */
+	Optional<String> getLatestReviewerNameBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/SurveyFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/SurveyFindPort.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.port.out.persistence.createfeedback;
+
+import java.util.Optional;
+
+import me.nalab.survey.domain.survey.Survey;
+
+/**
+ * Survey를 조회하는 인터페이스 입니다.
+ */
+public interface SurveyFindPort {
+
+	/**
+	 * survey의 id를 파라미터로 받아, Survey를 반환합니다.
+	 *
+	 * @param surveyId 조회할 survey의 id 입니다.
+	 * @return Optional 조회된 Survey domain 입니다. 없다면 Optional.empty()를 반환해야합니다.
+	 */
+	Optional<Survey> findSurveyBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/createfeedback/FeedbackCreateService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/createfeedback/FeedbackCreateService.java
@@ -41,10 +41,10 @@ public class FeedbackCreateService implements FeedbackCreateUseCase {
 		feedbackSavePort.saveFeedback(feedback);
 	}
 
-	private void generateNickName(Long surveyId, Reviewer reviewer){
+	private void generateNickName(Long surveyId, Reviewer reviewer) {
 		synchronized(LOCK) {
 			String latestReviewerName = reviewerLatestNameFindPort.getLatestReviewerNameBySurveyId(surveyId)
-					.orElse(null);
+				.orElse(null);
 			if(latestReviewerName == null) {
 				reviewer.generateFirstReviewerNickName();
 				return;

--- a/survey/application/src/main/java/me/nalab/survey/application/service/createfeedback/FeedbackCreateService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/createfeedback/FeedbackCreateService.java
@@ -1,0 +1,56 @@
+package me.nalab.survey.application.service.createfeedback;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
+import me.nalab.survey.application.port.in.web.createfeedback.FeedbackCreateUseCase;
+import me.nalab.survey.application.port.out.persistence.createfeedback.FeedbackSavePort;
+import me.nalab.survey.application.port.out.persistence.createfeedback.ReviewerLatestNameFindPort;
+import me.nalab.survey.application.port.out.persistence.createfeedback.SurveyFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.feedback.Reviewer;
+import me.nalab.survey.domain.survey.Survey;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackCreateService implements FeedbackCreateUseCase {
+
+	private final SurveyFindPort surveyFindPort;
+	private final FeedbackSavePort feedbackSavePort;
+	private final IdGenerator idGenerator;
+	private final ReviewerLatestNameFindPort reviewerLatestNameFindPort;
+	private static final Object LOCK = new Object();
+
+	@Override
+	@Transactional
+	public void createFeedback(Long surveyId, FeedbackDto feedbackDto) {
+		Survey survey = surveyFindPort.findSurveyBySurveyId(surveyId).orElseThrow(
+			() -> {
+				throw new SurveyDoesNotExistException(surveyId);
+			}
+		);
+		Feedback feedback = FeedbackDtoMapper.toDomain(survey, feedbackDto);
+		feedback.withId(idGenerator::generate);
+		survey.throwIfIsNotValidFeedback(feedback);
+		generateNickName(surveyId, feedback.getReviewer());
+		feedbackSavePort.saveFeedback(feedback);
+	}
+
+	private void generateNickName(Long surveyId, Reviewer reviewer){
+		synchronized(LOCK) {
+			String latestReviewerName = reviewerLatestNameFindPort.getLatestReviewerNameBySurveyId(surveyId)
+					.orElse(null);
+			if(latestReviewerName == null) {
+				reviewer.generateFirstReviewerNickName();
+				return;
+			}
+			reviewer.generateNickName(latestReviewerName);
+		}
+	}
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/RandomFeedbackDtoFixture.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/RandomFeedbackDtoFixture.java
@@ -1,0 +1,100 @@
+package me.nalab.survey.application;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import lombok.Setter;
+import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.dto.FormQuestionFeedbackDtoable;
+import me.nalab.survey.application.common.feedback.dto.ReviewerDto;
+import me.nalab.survey.application.common.feedback.dto.ShortFormQuestionFeedbackDto;
+import me.nalab.survey.domain.survey.ChoiceFormQuestion;
+import me.nalab.survey.domain.survey.FormQuestionable;
+import me.nalab.survey.domain.survey.QuestionType;
+import me.nalab.survey.domain.survey.ShortFormQuestion;
+import me.nalab.survey.domain.survey.Survey;
+
+public class RandomFeedbackDtoFixture {
+
+	@Setter
+	private static BooleanSupplier RANDOM_BOOLEAN_SUPPLIER;
+
+	@Setter
+	private static Supplier<String> RANDOM_STRING_SUPPLIER;
+
+	static {
+		RANDOM_BOOLEAN_SUPPLIER = new BooleanSupplier() {
+			private final Random random = new Random();
+
+			@Override
+			public boolean getAsBoolean() {
+				return random.nextBoolean();
+			}
+		};
+
+		RANDOM_STRING_SUPPLIER = () -> {
+			Random random = new Random();
+			return random.ints('0', (int)'z' + 1)
+				.filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+				.limit(5)
+				.collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+				.toString();
+		};
+	}
+
+	public static FeedbackDto getRandomFeedbackDtoBySurvey(Survey survey) {
+		return FeedbackDto.builder()
+			.surveyId(survey.getId())
+			.isRead(RANDOM_BOOLEAN_SUPPLIER.getAsBoolean())
+			.reviewerDto(getRandomReviewerDto())
+			.formQuestionFeedbackDtoableList(getRandomQuestionFeedbackDtoListBySurvey(survey))
+			.createdAt(survey.getCreatedAt().plusDays(1))
+			.updatedAt(survey.getUpdatedAt().plusDays(1))
+			.build();
+	}
+
+	private static ReviewerDto getRandomReviewerDto() {
+		return ReviewerDto.builder()
+			.collaborationExperience(RANDOM_BOOLEAN_SUPPLIER.getAsBoolean())
+			.position(RANDOM_STRING_SUPPLIER.get())
+			.build();
+	}
+
+	private static List<FormQuestionFeedbackDtoable> getRandomQuestionFeedbackDtoListBySurvey(Survey survey) {
+		List<FormQuestionable> formQuestionableList = survey.getFormQuestionableList();
+		return formQuestionableList.stream().map(q -> {
+			if(q.getQuestionType() == QuestionType.CHOICE) {
+				return getRandomChoiceFormQuestionFeedbackDto((ChoiceFormQuestion)q);
+			}
+			return getRandomShortFormQuestionFeedbackDto((ShortFormQuestion)q);
+		}).collect(Collectors.toList());
+	}
+
+	private static ChoiceFormQuestionFeedbackDto getRandomChoiceFormQuestionFeedbackDto(
+		ChoiceFormQuestion choiceFormQuestion) {
+		Set<Long> selectedIdSet = new HashSet<>();
+		for(int i = 0; i < choiceFormQuestion.getMaxSelectionCount(); i++) {
+			selectedIdSet.add(choiceFormQuestion.getChoiceList().get(i).getId());
+		}
+		return ChoiceFormQuestionFeedbackDto.builder()
+			.questionId(choiceFormQuestion.getId())
+			.isRead(RANDOM_BOOLEAN_SUPPLIER.getAsBoolean())
+			.selectedChoiceIdSet(selectedIdSet)
+			.build();
+	}
+
+	private static ShortFormQuestionFeedbackDto getRandomShortFormQuestionFeedbackDto(
+		ShortFormQuestion shortFormQuestion) {
+		return ShortFormQuestionFeedbackDto.builder()
+			.questionId(shortFormQuestion.getId())
+			.isRead(RANDOM_BOOLEAN_SUPPLIER.getAsBoolean())
+			.replyList(List.of(RANDOM_STRING_SUPPLIER.get()))
+			.build();
+	}
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/TestIdGenerator.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/TestIdGenerator.java
@@ -1,6 +1,5 @@
 package me.nalab.survey.application;
 
-import java.security.SecureRandom;
 import java.util.function.Supplier;
 
 import me.nalab.core.idgenerator.idcore.IdGenerator;

--- a/survey/application/src/test/java/me/nalab/survey/application/TestIdGenerator.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/TestIdGenerator.java
@@ -11,11 +11,12 @@ public class TestIdGenerator implements IdGenerator {
 
 	public TestIdGenerator() {
 		idGenerateAlgorithm = new Supplier<>() {
-			final SecureRandom secureRandom = new SecureRandom();
+			private Long id = 0L;
 
 			@Override
 			public Long get() {
-				return secureRandom.nextLong();
+				id++;
+				return id;
 			}
 		};
 	}

--- a/survey/application/src/test/java/me/nalab/survey/application/service/createfeedback/FeedbackCreateServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/createfeedback/FeedbackCreateServiceTest.java
@@ -1,7 +1,6 @@
 package me.nalab.survey.application.service.createfeedback;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;

--- a/survey/application/src/test/java/me/nalab/survey/application/service/createfeedback/FeedbackCreateServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/createfeedback/FeedbackCreateServiceTest.java
@@ -1,0 +1,100 @@
+package me.nalab.survey.application.service.createfeedback;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.survey.application.RandomFeedbackDtoFixture;
+import me.nalab.survey.application.RandomSurveyDtoFixture;
+import me.nalab.survey.application.TestIdGenerator;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.survey.mapper.SurveyDtoMapper;
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
+import me.nalab.survey.application.port.in.web.createfeedback.FeedbackCreateUseCase;
+import me.nalab.survey.application.port.out.persistence.createfeedback.FeedbackSavePort;
+import me.nalab.survey.application.port.out.persistence.createfeedback.ReviewerLatestNameFindPort;
+import me.nalab.survey.application.port.out.persistence.createfeedback.SurveyFindPort;
+import me.nalab.survey.domain.survey.Survey;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {FeedbackCreateService.class, TestIdGenerator.class})
+class FeedbackCreateServiceTest {
+
+	@Autowired
+	private FeedbackCreateUseCase feedbackCreateUseCase;
+
+	@Autowired
+	private TestIdGenerator testIdGenerator;
+
+	@MockBean
+	private FeedbackSavePort feedbackSavePort;
+
+	@MockBean
+	private ReviewerLatestNameFindPort reviewerLatestNameFindPort;
+
+	@MockBean
+	private SurveyFindPort surveyFindPort;
+
+	@Test
+	@DisplayName("피드백 생성 성공 테스트")
+	void CREATE_FEEDBACK_SUCCESS() {
+		// given
+		RandomSurveyDtoFixture.setRandomIdGenerator(() -> testIdGenerator.generate());
+		Survey survey = SurveyDtoMapper.toSurvey(RandomSurveyDtoFixture.createRandomSurveyDto());
+		FeedbackDto feedbackDto = RandomFeedbackDtoFixture.getRandomFeedbackDtoBySurvey(survey);
+
+		// when
+		when(surveyFindPort.findSurveyBySurveyId(survey.getId())).thenReturn(Optional.of(survey));
+		when(reviewerLatestNameFindPort.getLatestReviewerNameBySurveyId(survey.getId())).thenReturn(Optional.of("A"));
+
+		// then
+		assertDoesNotThrow(() -> feedbackCreateUseCase.createFeedback(survey.getId(), feedbackDto));
+	}
+
+	@Test
+	@DisplayName("피드백 생성 성공 테스트 - first reviewer")
+	void CREATE_FEEDBACK_SUCCESS_FIRST_REVIEWER() {
+		// given
+		RandomSurveyDtoFixture.setRandomIdGenerator(() -> testIdGenerator.generate());
+		Survey survey = SurveyDtoMapper.toSurvey(RandomSurveyDtoFixture.createRandomSurveyDto());
+		FeedbackDto feedbackDto = RandomFeedbackDtoFixture.getRandomFeedbackDtoBySurvey(survey);
+
+		// when
+		when(surveyFindPort.findSurveyBySurveyId(survey.getId())).thenReturn(Optional.of(survey));
+		when(reviewerLatestNameFindPort.getLatestReviewerNameBySurveyId(survey.getId())).thenReturn(Optional.empty());
+
+		// then
+		assertDoesNotThrow(() -> feedbackCreateUseCase.createFeedback(survey.getId(), feedbackDto));
+	}
+
+	@Test
+	@DisplayName("피드백 생성 실패 테스트 - survey를 찾을 수 없음")
+	void CREATE_FEEDBACK_FAIL_CANNOT_FIND_SURVEY() {
+		// given
+		RandomSurveyDtoFixture.setRandomIdGenerator(() -> testIdGenerator.generate());
+		Survey survey = SurveyDtoMapper.toSurvey(RandomSurveyDtoFixture.createRandomSurveyDto());
+		Long surveyId = survey.getId();
+		FeedbackDto feedbackDto = RandomFeedbackDtoFixture.getRandomFeedbackDtoBySurvey(survey);
+
+		// when
+		when(surveyFindPort.findSurveyBySurveyId(anyLong())).thenReturn(Optional.empty());
+		when(reviewerLatestNameFindPort.getLatestReviewerNameBySurveyId(survey.getId())).thenReturn(Optional.empty());
+
+		// then
+		assertThrows(SurveyDoesNotExistException.class,
+			() -> feedbackCreateUseCase.createFeedback(surveyId, feedbackDto));
+	}
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
feedback을 survey에 추가하는 유즈케이스를 개발했습니다.

## 어떻게 해결했나요?
- [x] `FeedbackCreateUseCase` 를 생성했습니다.
- [x] 생성시점에서 리뷰어의 nickname을 설정해주도록 만들었습니다.
- [x] Survey를 찾는 port를 생성했습니다.
- [x] 마지막으로 리뷰한 리뷰어의 이름을 찾는 port를 생성했습니다.
- [x] Survey를 저장하는 port를 생성했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
