### PR TITLE
[feat] : feedback create jpa-adaptor 생성

### DIFF
--- a/core/data/src/main/java/me/nalab/core/data/feedback/ChoiceFormFeedbackEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/feedback/ChoiceFormFeedbackEntity.java
@@ -23,7 +23,7 @@ import lombok.experimental.SuperBuilder;
 public class ChoiceFormFeedbackEntity extends FormFeedbackEntity {
 
 	@ElementCollection
-	@CollectionTable(name = "select", joinColumns = @JoinColumn(name = "form_feedback_id"))
+	@CollectionTable(name = "selects", joinColumns = @JoinColumn(name = "form_feedback_id"))
 	@Column(name = "selects")
 	private Set<Long> selectSet;
 

--- a/core/data/src/main/java/me/nalab/core/data/feedback/FeedbackEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/feedback/FeedbackEntity.java
@@ -38,7 +38,7 @@ public class FeedbackEntity extends TimeBaseEntity {
 	@JoinColumn(name = "is_read", nullable = false)
 	private boolean isRead;
 
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
 	@JoinColumn(name = "reviewer_id")
 	private ReviewerEntity reviewer;
 

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/FeedbackSavePort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/FeedbackSavePort.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.application.port.out.persistence.createfeedback;
+
+import me.nalab.survey.domain.feedback.Feedback;
+
+/**
+ * Survey에 Feedback을 저장하는 인터페이스 입니다.
+ */
+public interface FeedbackSavePort {
+
+	/**
+	 * Feedback domain을 인자로 받아, 저장합니다.
+	 *
+	 * @param feedback 생성할 feedback domain
+	 */
+	void saveFeedback(Feedback feedback);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/ReviewerLatestNameFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/ReviewerLatestNameFindPort.java
@@ -1,0 +1,18 @@
+package me.nalab.survey.application.port.out.persistence.createfeedback;
+
+import java.util.Optional;
+
+/**
+ * 마지막으로 리뷰를 작성한 리뷰어의 이름을 찾는 인터페이스 입니다.
+ */
+public interface ReviewerLatestNameFindPort {
+
+	/**
+	 * 마지막으로 리뷰를한 리뷰어의 nickname을 조회합니다.
+	 *
+	 * @param surveyId 리뷰어의 정보를 찾을 survey의 id입니다.
+	 * @return Optional 마지막으로 리뷰한 리뷰어의 닉네임 입니다. 없다면, Optional.empty를 반환해야합니다.
+	 */
+	Optional<String> getLatestReviewerNameBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/SurveyFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/createfeedback/SurveyFindPort.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.port.out.persistence.createfeedback;
+
+import java.util.Optional;
+
+import me.nalab.survey.domain.survey.Survey;
+
+/**
+ * Survey를 조회하는 인터페이스 입니다.
+ */
+public interface SurveyFindPort {
+
+	/**
+	 * survey의 id를 파라미터로 받아, Survey를 반환합니다.
+	 *
+	 * @param surveyId 조회할 survey의 id 입니다.
+	 * @return Optional 조회된 Survey domain 입니다. 없다면 Optional.empty()를 반환해야합니다.
+	 */
+	Optional<Survey> findSurveyBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.in.web.getid;
 	exports me.nalab.survey.application.exception;
 	exports me.nalab.survey.application.port.out.persistence.findid;
+	exports me.nalab.survey.application.port.out.persistence.createfeedback;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/domain/src/main/java/me/nalab/survey/domain/feedback/Feedback.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/feedback/Feedback.java
@@ -34,6 +34,9 @@ public class Feedback implements IdGeneratable, FeedbackValidable<FormQuestionFe
 		}
 		id = idSupplier.getAsLong();
 		formQuestionFeedbackableList.forEach(f -> f.withId(idSupplier));
+		if(reviewer != null) {
+			reviewer.withId(idSupplier);
+		}
 	}
 
 	@Override

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper.java
@@ -1,5 +1,6 @@
 package me.nalab.survey.jpa.adaptor.common.mapper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -74,7 +75,7 @@ public final class FeedbackEntityMapper {
 		return FeedbackEntity.builder()
 			.id(feedback.getId())
 			.surveyId(feedback.getSurveyId())
-			.reviewer(getReviewerEntity(feedback.getReviewer()))
+			.reviewer(getReviewerEntity(feedback.getReviewer(), feedback.getCreatedAt()))
 			.formFeedbackEntityList(getFormFeedbackEntityList(feedback))
 			.createdAt(feedback.getCreatedAt())
 			.updatedAt(feedback.getUpdatedAt())
@@ -82,12 +83,14 @@ public final class FeedbackEntityMapper {
 			.build();
 	}
 
-	private static ReviewerEntity getReviewerEntity(Reviewer reviewer) {
+	private static ReviewerEntity getReviewerEntity(Reviewer reviewer, LocalDateTime now) {
 		return ReviewerEntity.builder()
 			.id(reviewer.getId())
 			.nickName(reviewer.getNickName())
 			.position(reviewer.getPosition())
 			.collaborationExperience(reviewer.isCollaborationExperience())
+			.createdAt(now)
+			.updatedAt(now)
 			.build();
 	}
 

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/FeedbackSaveAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/FeedbackSaveAdaptor.java
@@ -1,0 +1,24 @@
+package me.nalab.survey.jpa.adaptor.createfeedback;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.createfeedback.FeedbackSavePort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.createfeedback.repository.FeedbackCreateJpaRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedbackSaveAdaptor implements FeedbackSavePort {
+
+	private final FeedbackCreateJpaRepository feedbackCreateJpaRepository;
+
+	@Override
+	public void saveFeedback(Feedback feedback) {
+		FeedbackEntity feedbackEntity = FeedbackEntityMapper.toEntity(feedback);
+		feedbackCreateJpaRepository.save(feedbackEntity);
+	}
+
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/ReviewerLatestNameFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/ReviewerLatestNameFindAdaptor.java
@@ -1,0 +1,34 @@
+package me.nalab.survey.jpa.adaptor.createfeedback;
+
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.stereotype.Repository;
+
+import me.nalab.survey.application.port.out.persistence.createfeedback.ReviewerLatestNameFindPort;
+
+@Repository
+public class ReviewerLatestNameFindAdaptor implements ReviewerLatestNameFindPort {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Override
+	public Optional<String> getLatestReviewerNameBySurveyId(Long surveyId) {
+		try {
+			String latestName = entityManager.createQuery(
+					"select f.reviewer.nickName from FeedbackEntity as f where f.surveyId = :surveyId order by f.reviewer.createdAt desc",
+					String.class)
+				.setParameter("surveyId", surveyId)
+				.setMaxResults(1)
+				.getSingleResult();
+			return Optional.of(latestName);
+		} catch(NoResultException noResultException) {
+			return Optional.empty();
+		}
+	}
+
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/SurveyFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/SurveyFindAdaptor.java
@@ -1,0 +1,33 @@
+package me.nalab.survey.jpa.adaptor.createfeedback;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.survey.application.port.out.persistence.createfeedback.SurveyFindPort;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+import me.nalab.survey.jpa.adaptor.createfeedback.repository.SurveyFindJpaRepository;
+
+@Repository("createfeedback.SurveyFindAdaptor")
+public class SurveyFindAdaptor implements SurveyFindPort {
+
+	private final SurveyFindJpaRepository surveyFindJpaRepository;
+
+	SurveyFindAdaptor(@Qualifier("createfeedback.SurveyFindJpaRepository") SurveyFindJpaRepository surveyFindJpaRepository) {
+		this.surveyFindJpaRepository = surveyFindJpaRepository;
+	}
+
+	@Override
+	public Optional<Survey> findSurveyBySurveyId(Long surveyId) {
+		SurveyEntity surveyEntity = surveyFindJpaRepository.findById(surveyId)
+			.orElse(null);
+		if(surveyEntity == null) {
+			return Optional.empty();
+		}
+		return Optional.of(SurveyEntityMapper.toSurvey(surveyEntity));
+	}
+
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/repository/FeedbackCreateJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/repository/FeedbackCreateJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.createfeedback.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+public interface FeedbackCreateJpaRepository extends JpaRepository<FeedbackEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/repository/SurveyFindJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/createfeedback/repository/SurveyFindJpaRepository.java
@@ -1,0 +1,13 @@
+package me.nalab.survey.jpa.adaptor.createfeedback.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+@Repository("createfeedback.SurveyFindJpaRepository")
+public interface SurveyFindJpaRepository extends JpaRepository<SurveyEntity, Long> {
+
+
+
+}

--- a/survey/jpa-adaptor/src/main/java/module-info.java
+++ b/survey/jpa-adaptor/src/main/java/module-info.java
@@ -9,7 +9,9 @@ module luffy.survey.jpa.adaptor.main {
 	requires lombok;
 	requires java.persistence;
 	requires spring.context;
+	requires spring.boot;
 	requires spring.data.commons;
 
 	requires spring.tx;
+	requires spring.beans;
 }

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/RandomFeedbackFixture.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/RandomFeedbackFixture.java
@@ -1,0 +1,119 @@
+package me.nalab.survey.jpa.adaptor;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import lombok.Setter;
+import me.nalab.survey.domain.feedback.ChoiceFormQuestionFeedback;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
+import me.nalab.survey.domain.feedback.Reviewer;
+import me.nalab.survey.domain.feedback.ShortFormQuestionFeedback;
+import me.nalab.survey.domain.survey.ChoiceFormQuestion;
+import me.nalab.survey.domain.survey.FormQuestionable;
+import me.nalab.survey.domain.survey.QuestionType;
+import me.nalab.survey.domain.survey.ShortFormQuestion;
+import me.nalab.survey.domain.survey.Survey;
+
+public class RandomFeedbackFixture {
+
+	@Setter
+	private static Supplier<Long> randomIdGenerator;
+
+	@Setter
+	private static BooleanSupplier randomBooleanGenerator;
+
+	@Setter
+	private static Supplier<String> randomStringGenerator;
+
+	static {
+		randomIdGenerator = new Supplier<>() {
+			private Long id = 0L;
+
+			@Override
+			public Long get() {
+				id++;
+				return id;
+			}
+		};
+
+		randomBooleanGenerator = new BooleanSupplier() {
+			private final Random random = new Random();
+
+			@Override
+			public boolean getAsBoolean() {
+				return random.nextBoolean();
+			}
+		};
+
+		randomStringGenerator = () -> {
+			Random random = new Random();
+			return random.ints('0', (int)'z' + 1)
+				.filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+				.limit(5)
+				.collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+				.toString();
+		};
+	}
+
+	public static Feedback getRandomFeedbackBySurvey(Survey survey) {
+		return Feedback.builder()
+			.id(randomIdGenerator.get())
+			.surveyId(survey.getId())
+			.isRead(randomBooleanGenerator.getAsBoolean())
+			.reviewer(getRandomReviewer())
+			.formQuestionFeedbackableList(getRandomQuestionFeedbackListBySurvey(survey))
+			.createdAt(survey.getCreatedAt().plusDays(1))
+			.updatedAt(survey.getUpdatedAt().plusDays(1))
+			.build();
+	}
+
+	private static Reviewer getRandomReviewer() {
+		return Reviewer.builder()
+			.id(randomIdGenerator.get())
+			.nickName(randomStringGenerator.get())
+			.collaborationExperience(randomBooleanGenerator.getAsBoolean())
+			.position(randomStringGenerator.get())
+			.build();
+	}
+
+	private static List<FormQuestionFeedbackable> getRandomQuestionFeedbackListBySurvey(Survey survey) {
+		List<FormQuestionable> formQuestionableList = survey.getFormQuestionableList();
+		return formQuestionableList.stream().map(q -> {
+			if(q.getQuestionType() == QuestionType.CHOICE) {
+				return getRandomChoiceFormQuestionFeedback((ChoiceFormQuestion)q);
+			}
+			return getRandomShortFormQuestionFeedback((ShortFormQuestion)q);
+		}).collect(Collectors.toList());
+	}
+
+	private static ChoiceFormQuestionFeedback getRandomChoiceFormQuestionFeedback(
+		ChoiceFormQuestion choiceFormQuestion) {
+		Set<Long> selectedIdSet = new HashSet<>();
+		for(int i = 0; i < choiceFormQuestion.getMaxSelectionCount(); i++) {
+			selectedIdSet.add(choiceFormQuestion.getChoiceList().get(i).getId());
+		}
+		return ChoiceFormQuestionFeedback.builder()
+			.id(choiceFormQuestion.getId())
+			.questionId(choiceFormQuestion.getId())
+			.isRead(randomBooleanGenerator.getAsBoolean())
+			.selectedChoiceIdSet(selectedIdSet)
+			.build();
+	}
+
+	private static ShortFormQuestionFeedback getRandomShortFormQuestionFeedback(
+		ShortFormQuestion shortFormQuestion) {
+		return ShortFormQuestionFeedback.builder()
+			.id(shortFormQuestion.getId())
+			.questionId(shortFormQuestion.getId())
+			.isRead(randomBooleanGenerator.getAsBoolean())
+			.replyList(List.of(randomStringGenerator.get()))
+			.build();
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/FeedbackSaveAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/FeedbackSaveAdaptorTest.java
@@ -1,0 +1,75 @@
+package me.nalab.survey.jpa.adaptor.createfeedback;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.createfeedback.FeedbackSavePort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = FeedbackSaveAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class FeedbackSaveAdaptorTest {
+
+	@Autowired
+	private FeedbackSavePort feedbackSavePort;
+
+	@Autowired
+	private TestSurveyJpaRepository testSurveyJpaRepository;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Autowired
+	private TestFeedbackJpaRepository testFeedbackJpaRepository;
+
+	@Test
+	@DisplayName("FeedbackEntity 저장 성공 테스트")
+	void SAVE_FEEDBACK_ENTITY_SUCCESS() {
+		// given
+		TargetEntity targetEntity = getDefaultTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+		Feedback feedback = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
+
+		testTargetJpaRepository.saveAndFlush(targetEntity);
+		testSurveyJpaRepository.saveAndFlush(surveyEntity);
+
+		// when
+		feedbackSavePort.saveFeedback(feedback);
+		FeedbackEntity feedbackEntity = testFeedbackJpaRepository.findAll().get(0);
+
+		// then
+		assertEquals(feedback, FeedbackEntityMapper.toDomain(feedbackEntity));
+	}
+
+	private TargetEntity getDefaultTargetEntity() {
+		return TargetEntity.builder()
+			.id(101L)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.nickname("test target")
+			.build();
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/ReviewerLatestNameFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/ReviewerLatestNameFindAdaptorTest.java
@@ -1,0 +1,115 @@
+package me.nalab.survey.jpa.adaptor.createfeedback;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.createfeedback.ReviewerLatestNameFindPort;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = ReviewerLatestNameFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class ReviewerLatestNameFindAdaptorTest {
+
+	@Autowired
+	private ReviewerLatestNameFindPort reviewerLatestNameFindPort;
+
+	@Autowired
+	private TestSurveyJpaRepository testSurveyJpaRepository;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Autowired
+	private TestFeedbackJpaRepository testFeedbackJpaRepository;
+
+	@Test
+	@DisplayName("마지막으로 저장된 Reviewer name 조회 성공 테스트 - 리뷰어가 있을때")
+	void FIND_LATEST_REVIEWER_NAME_SUCCESS() {
+		// given
+		TargetEntity targetEntity = getDefaultTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		List<FeedbackEntity> feedbackEntityList = List.of(
+			FeedbackEntityMapper.toEntity(RandomFeedbackFixture.getRandomFeedbackBySurvey(survey)),
+			FeedbackEntityMapper.toEntity(RandomFeedbackFixture.getRandomFeedbackBySurvey(survey)),
+			FeedbackEntityMapper.toEntity(RandomFeedbackFixture.getRandomFeedbackBySurvey(survey))
+		);
+
+		String expectedReviewerName = getLatestReviewerName(feedbackEntityList);
+
+		testTargetJpaRepository.saveAndFlush(targetEntity);
+		testSurveyJpaRepository.saveAndFlush(surveyEntity);
+		testFeedbackJpaRepository.saveAll(feedbackEntityList);
+
+		// when
+		Optional<String> reviewerName = reviewerLatestNameFindPort.getLatestReviewerNameBySurveyId(survey.getId());
+
+		// then
+		assertTrue(reviewerName.isPresent());
+		assertEquals(expectedReviewerName, reviewerName.get());
+	}
+
+	@Test
+	@DisplayName("마지막으로 저장된 Reviewer name 조회 성공 테스트 - 리뷰어가 없을때")
+	void FIND_LATEST_REVIEWER_NAME_SUCCESS_FIRST_REVIEWER() {
+		// given
+		TargetEntity targetEntity = getDefaultTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		testTargetJpaRepository.saveAndFlush(targetEntity);
+		testSurveyJpaRepository.saveAndFlush(surveyEntity);
+
+		// when
+		Optional<String> reviewerName = reviewerLatestNameFindPort.getLatestReviewerNameBySurveyId(survey.getId());
+
+		// then
+		assertTrue(reviewerName.isEmpty());
+	}
+
+	private TargetEntity getDefaultTargetEntity() {
+		return TargetEntity.builder()
+			.id(101L)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.nickname("test target")
+			.build();
+	}
+
+	private String getLatestReviewerName(List<FeedbackEntity> feedbackEntityList) {
+		LocalDateTime latest = null;
+		String latestName = null;
+		for(FeedbackEntity feedbackEntity : feedbackEntityList) {
+			if(latest == null || feedbackEntity.getCreatedAt().isAfter(latest)) {
+				latest = feedbackEntity.getReviewer().getCreatedAt();
+				latestName = feedbackEntity.getReviewer().getNickName();
+			}
+		}
+		return latestName;
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/SurveyFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/SurveyFindAdaptorTest.java
@@ -1,0 +1,82 @@
+package me.nalab.survey.jpa.adaptor.createfeedback;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.createfeedback.SurveyFindPort;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = SurveyFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class SurveyFindAdaptorTest {
+
+	@Autowired
+	private SurveyFindPort surveyFindPort;
+
+	@Autowired
+	private TestSurveyJpaRepository testSurveyJpaRepository;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Autowired
+	private TestFeedbackJpaRepository testFeedbackJpaRepository;
+
+	@Test
+	@DisplayName("Survey 조회 성공 테스트")
+	void FIND_SURVEY_SUCCESS() {
+		// given
+		TargetEntity targetEntity = getDefaultTargetEntity();
+		Survey expectedSurvey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), expectedSurvey);
+
+		testTargetJpaRepository.saveAndFlush(targetEntity);
+		testSurveyJpaRepository.saveAndFlush(surveyEntity);
+
+		// when
+		Optional<Survey> result = surveyFindPort.findSurveyBySurveyId(expectedSurvey.getId());
+
+		// then
+		assertTrue(result.isPresent());
+		assertEquals(expectedSurvey, result.get());
+	}
+
+	@Test
+	@DisplayName("Survey 조회 성공 테스트 - Survey가 없을 때")
+	void FIND_SURVEY_SUCCESS_EMPTY(){
+		// when
+		Optional<Survey> result = surveyFindPort.findSurveyBySurveyId(1L);
+
+		// then
+		assertTrue(result.isEmpty());
+	}
+
+	private TargetEntity getDefaultTargetEntity() {
+		return TargetEntity.builder()
+			.id(101L)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.nickname("test target")
+			.build();
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/TestFeedbackJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/TestFeedbackJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.createfeedback;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+public interface TestFeedbackJpaRepository extends JpaRepository<FeedbackEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/TestSurveyJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/TestSurveyJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.createfeedback;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/TestTargetJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/createfeedback/TestTargetJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.createfeedback;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TestTargetJpaRepository extends JpaRepository<TargetEntity, Long> {
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
feedback을 생성하는 jpa-adaptor를 만들었습니다.

## 어떻게 해결했나요?
- [x] `FeedbackSaveJpaAdaptor` 구현
- [x] `ReviewerLatestNameFindAdaptor` 구현
- [x] `SurveyFindAdaptor` 구현 
- [x] `feedback` 도메인에서 id 세팅시, id가 모든 도메인에 전파되도록 수정 
- [x] `select` 예약어가 테이블 칼럼명으로 되어있는 버그 수정 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
