### PR TITLE
[refactor] : merge label이 PR 최초 생성시점에만 동작하도록 수정

### DIFF
--- a/.github/workflows/rebase-labeler.yml
+++ b/.github/workflows/rebase-labeler.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
 
 jobs:
   add_label:

--- a/.github/workflows/squash-labeler.yml
+++ b/.github/workflows/squash-labeler.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - '**/base-**'
+    types:
+      - opened
 
 jobs:
   add_label:


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`rebase merge`, `squash merge` 라벨이 재 오픈, 수정시에 계속 생성되는 문제를 수정했습니다.

## 어떻게 해결했나요?
- [x] `rebase merge`가 PR 최초 오픈시에만 생성되도록 수정
- [x] `squash merge`가 PR 최초 오픈시에만 생성되도록 수정

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
