### PR TITLE
[fix] : sonarcloud에서 `coverage exclude` 적용안되는 버그 수정

### DIFF
--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -1,7 +1,20 @@
+import java.util.stream.Collectors
+
+var excludeFromCoverage = new ArrayList<String>()
+file('coverage-exclude.luffy').withInputStream(){
+    it -> excludeFromCoverage.addAll(new BufferedReader(new InputStreamReader(it))
+            .lines()
+            .parallel()
+            .map(s -> "**/" + s.substring(7).strip() + ".java")
+            .collect(Collectors.toList()))
+}
+
+
 sonar {
     properties {
         property 'sonar.host.url', 'https://sonarcloud.io'
         property 'sonar.organization', 'depromeet-1'
         property 'sonar.projectKey', 'depromeet_na-lab-server'
+        property 'sonar.coverage.exclusions', excludeFromCoverage.toArray()
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
sonarcloud에서 커버리지에서 제외한 클래스가 제외되지 않는 버그를 수정했습니다.

## 어떻게 해결했나요?
- [x] `coverage-exclude.luffy` 파일을 읽어서 sonarcloud test-coverage에서도 제거하도록 수정했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
