### PR TITLE
[fix] : 질문 폼의 요약정보 조회 유즈케이스 `jpa-adaptor` FIX

### DIFF
--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/FeedbackCountAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/FeedbackCountAdaptor.java
@@ -1,11 +1,9 @@
 package me.nalab.survey.jpa.adaptor.findfeedbacksummary;
 
-import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
-import me.nalab.core.data.feedback.FeedbackEntity;
 import me.nalab.survey.application.port.out.persistence.feedbacksummary.TotalFeedbackCountPort;
 import me.nalab.survey.application.port.out.persistence.feedbacksummary.UpdatedFeedbackCountPort;
 import me.nalab.survey.jpa.adaptor.findfeedbacksummary.repository.FeedbackCountJpaRepository;
@@ -18,13 +16,11 @@ public class FeedbackCountAdaptor implements TotalFeedbackCountPort, UpdatedFeed
 
 	@Override
 	public int getTotalFeedbackCountBySurveyId(Long surveyId) {
-		List<FeedbackEntity> feedbackEntities = feedbackCountJpaRepository.findBySurveyId(surveyId);
-		return feedbackEntities.size();
+		return feedbackCountJpaRepository.countBySurveyId(surveyId).intValue();
 	}
 
 	@Override
 	public int getUpdatedFeedbackCountBySurveyId(Long surveyId) {
-		List<FeedbackEntity> feedbackEntities = feedbackCountJpaRepository.findBySurveyIdAndIsRead(surveyId, false);
-		return feedbackEntities.size();
+		return feedbackCountJpaRepository.countBySurveyIdAndIsReadFalse(surveyId).intValue();
 	}
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/repository/FeedbackCountJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/repository/FeedbackCountJpaRepository.java
@@ -1,15 +1,13 @@
 package me.nalab.survey.jpa.adaptor.findfeedbacksummary.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import me.nalab.core.data.feedback.FeedbackEntity;
 
 public interface FeedbackCountJpaRepository extends JpaRepository<FeedbackEntity, Long> {
 
-	List<FeedbackEntity> findBySurveyId(Long surveyId);
+	Long countBySurveyId(Long surveyId);
 
-	List<FeedbackEntity> findBySurveyIdAndIsRead(Long surveyId, boolean isRead);
+	Long countBySurveyIdAndIsReadFalse(Long surveyId);
 
 }

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/TestFeedbackCountJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/TestFeedbackCountJpaRepository.java
@@ -1,14 +1,10 @@
 package me.nalab.survey.jpa.adaptor.findfeedbacksummary;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import me.nalab.core.data.feedback.FeedbackEntity;
 
 public interface TestFeedbackCountJpaRepository extends JpaRepository<FeedbackEntity, Long> {
 
-	List<FeedbackEntity> findBySurveyId(Long surveyId);
 
-	List<FeedbackEntity> findBySurveyIdAndIsRead(Long surveyId, boolean isRead);
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`FeedbackCountJpaRepository` 에서 getResultList가 아닌 countBy로 한 번에 counting한 값을 가져오도록 변경하였습니다

## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
