### PR TITLE
[refactor] : 중간 코드 리팩토링

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/feedbacksummary/FeedbackSummaryFindUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/feedbacksummary/FeedbackSummaryFindUseCase.java
@@ -9,11 +9,11 @@ public interface FeedbackSummaryFindUseCase {
 	 * surveyId에 해당하는 survey의 전체 피드백의 수를
 	 * 반환합니다
 	 */
-	int getTotalFeedbackCount(Long surveyId);
+	long getTotalFeedbackCount(Long surveyId);
 
 	/**
 	 * surveyId에 해당하는 survey의 읽지 않은 피드백의 수를
 	 * 반환합니다
 	 */
-	int getUpdatedFeedbackCount(Long surveyId);
+	long getUpdatedFeedbackCount(Long surveyId);
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbacksummary/TotalFeedbackCountPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbacksummary/TotalFeedbackCountPort.java
@@ -9,7 +9,7 @@ public interface TotalFeedbackCountPort {
 	 * surveyId에 해당하는 전체 Feedback의 수를 반환합니다.
 	 *
 	 * @param surveyId Survey의 ID
-	 * @return int 만약, 어떠한 피드백도 없을 경우, 0을 반환해야 합니다.
+	 * @return long 만약, 어떠한 피드백도 없을 경우, 0을 반환해야 합니다.
 	 */
-	int getTotalFeedbackCountBySurveyId(Long surveyId);
+	long getTotalFeedbackCountBySurveyId(Long surveyId);
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbacksummary/UpdatedFeedbackCountPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbacksummary/UpdatedFeedbackCountPort.java
@@ -9,7 +9,7 @@ public interface UpdatedFeedbackCountPort {
 	 * surveyId에 해당하는 읽지 않은 Feedback의 수를 반환합니다.
 	 *
 	 * @param surveyId Survey의 ID
-	 * @return int 만약, 읽지 않은 피드백도 없을 경우, 0을 반환해야 합니다.
+	 * @return long 만약, 읽지 않은 피드백도 없을 경우, 0을 반환해야 합니다.
 	 */
-	int getUpdatedFeedbackCountBySurveyId(Long surveyId);
+	long getUpdatedFeedbackCountBySurveyId(Long surveyId);
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindService.java
@@ -15,12 +15,12 @@ public class FeedbackSummaryFindService implements FeedbackSummaryFindUseCase {
 	private final UpdatedFeedbackCountPort updatedFeedbackCountPort;
 
 	@Override
-	public int getTotalFeedbackCount(Long surveyId) {
+	public long getTotalFeedbackCount(Long surveyId) {
 		return totalFeedbackCountPort.getTotalFeedbackCountBySurveyId(surveyId);
 	}
 
 	@Override
-	public int getUpdatedFeedbackCount(Long surveyId) {
+	public long getUpdatedFeedbackCount(Long surveyId) {
 		return updatedFeedbackCountPort.getUpdatedFeedbackCountBySurveyId(surveyId);
 	}
 }

--- a/survey/application/src/test/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindServiceTest.java
@@ -32,10 +32,10 @@ class FeedbackSummaryFindServiceTest {
 	void FEEDBACK_SUMMARY_FIND_SERVICE_SUCCESS_TEST() {
 
 		Long surveyId = 1L;
-		int expectedCount = 10;
+		long expectedCount = 10L;
 		when(totalFeedbackCountPort.getTotalFeedbackCountBySurveyId(surveyId)).thenReturn(expectedCount);
 
-		int actualCount = feedbackSummaryFindService.getTotalFeedbackCount(surveyId);
+		long actualCount = feedbackSummaryFindService.getTotalFeedbackCount(surveyId);
 
 		assertEquals(expectedCount, actualCount);
 		verify(totalFeedbackCountPort).getTotalFeedbackCountBySurveyId(surveyId);
@@ -45,10 +45,10 @@ class FeedbackSummaryFindServiceTest {
 	void FEEDBACK_SUMMARY_FIND_SERVICE_FAIL_TEST() {
 
 		Long surveyId = 1L;
-		int expectedCount = 5;
+		long expectedCount = 5L;
 		when(updatedFeedbackCountPort.getUpdatedFeedbackCountBySurveyId(surveyId)).thenReturn(expectedCount);
 
-		int actualCount = feedbackSummaryFindService.getUpdatedFeedbackCount(surveyId);
+		long actualCount = feedbackSummaryFindService.getUpdatedFeedbackCount(surveyId);
 
 		assertEquals(expectedCount, actualCount);
 		verify(updatedFeedbackCountPort).getUpdatedFeedbackCountBySurveyId(surveyId);

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/FeedbackCountAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/FeedbackCountAdaptor.java
@@ -15,12 +15,12 @@ public class FeedbackCountAdaptor implements TotalFeedbackCountPort, UpdatedFeed
 	private final FeedbackCountJpaRepository feedbackCountJpaRepository;
 
 	@Override
-	public int getTotalFeedbackCountBySurveyId(Long surveyId) {
-		return feedbackCountJpaRepository.countBySurveyId(surveyId).intValue();
+	public long getTotalFeedbackCountBySurveyId(Long surveyId) {
+		return feedbackCountJpaRepository.countBySurveyId(surveyId);
 	}
 
 	@Override
-	public int getUpdatedFeedbackCountBySurveyId(Long surveyId) {
-		return feedbackCountJpaRepository.countBySurveyIdAndIsReadFalse(surveyId).intValue();
+	public long getUpdatedFeedbackCountBySurveyId(Long surveyId) {
+		return feedbackCountJpaRepository.countBySurveyIdAndIsReadFalse(surveyId);
 	}
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/repository/FeedbackCountJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/repository/FeedbackCountJpaRepository.java
@@ -6,8 +6,8 @@ import me.nalab.core.data.feedback.FeedbackEntity;
 
 public interface FeedbackCountJpaRepository extends JpaRepository<FeedbackEntity, Long> {
 
-	Long countBySurveyId(Long surveyId);
+	long countBySurveyId(Long surveyId);
 
-	Long countBySurveyIdAndIsReadFalse(Long surveyId);
+	long countBySurveyIdAndIsReadFalse(Long surveyId);
 
 }

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/FeedbackCountAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/FeedbackCountAdaptorTest.java
@@ -43,7 +43,7 @@ class FeedbackCountAdaptorTest {
 	void FIND_TOTAL_FEEDBACK_COUNT_TEST_WITH_NO_FEEDBACK() {
 
 		Long surveyId = 1L;
-		int resultCount = feedbackCountAdaptor.getTotalFeedbackCountBySurveyId(surveyId);
+		long resultCount = feedbackCountAdaptor.getTotalFeedbackCountBySurveyId(surveyId);
 		assertEquals(0, resultCount);
 	}
 
@@ -54,9 +54,9 @@ class FeedbackCountAdaptorTest {
 		Long surveyId = 1L;
 		createAndSaveSurveyWithFeedback(surveyId);
 
-		int resultCount = feedbackCountAdaptor.getTotalFeedbackCountBySurveyId(surveyId);
+		long resultCount = feedbackCountAdaptor.getTotalFeedbackCountBySurveyId(surveyId);
 
-		assertEquals(2, resultCount);
+		assertEquals(2L, resultCount);
 	}
 
 	@Test
@@ -64,7 +64,7 @@ class FeedbackCountAdaptorTest {
 	void FIND_UPDATED_FEEDBACK_COUNT_TEST_WITH_NO_FEEDBACK() {
 
 		Long surveyId = 1L;
-		int resultCount = feedbackCountAdaptor.getUpdatedFeedbackCountBySurveyId(surveyId);
+		long resultCount = feedbackCountAdaptor.getUpdatedFeedbackCountBySurveyId(surveyId);
 		assertEquals(0, resultCount);
 	}
 
@@ -75,7 +75,7 @@ class FeedbackCountAdaptorTest {
 		Long surveyId = 1L;
 		createAndSaveSurveyWithFeedback(surveyId);
 
-		int resultCount = feedbackCountAdaptor.getUpdatedFeedbackCountBySurveyId(surveyId);
+		long resultCount = feedbackCountAdaptor.getUpdatedFeedbackCountBySurveyId(surveyId);
 
 		assertEquals(0, resultCount);
 	}
@@ -86,9 +86,9 @@ class FeedbackCountAdaptorTest {
 		Long surveyId = 1L;
 		createAndSaveSurveyWithUpdatedFeedback(surveyId);
 
-		int resultCount = feedbackCountAdaptor.getUpdatedFeedbackCountBySurveyId(surveyId);
+		long resultCount = feedbackCountAdaptor.getUpdatedFeedbackCountBySurveyId(surveyId);
 
-		assertEquals(1, resultCount);
+		assertEquals(1L, resultCount);
 	}
 
 	private void createAndSaveSurveyWithFeedback(Long surveyId) {


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문 폼 요약정보 application 쪽 포트인 `TotalFeedbackCountPort` 와 `UpdatedFeedbackCountPort` 의 반환타입을 int -> long 타입으로 바꿨습니다!
이유는 jpa에서 countBy 가 long을 반환하기 때문입니다.
바뀐 부분이 두 모듈에서 있고, web-adpator쪽에서도 변경된 사항을 기반으로 개발을 해야할 것 같아 따로 올렸습니다..!!
이후 web-adaptor쪽에서 response로 매핑할 때에 int로 변환할 예정입니다

## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
