### PR TITLE
[test] : 질문 폼의 피드백 요약 인수테스트 작성

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -28,6 +29,17 @@ public abstract class AbstractFeedbackTestSupporter extends AbstractSurveyTestSu
 			.content(content)
 		);
 	}
+
+	protected ResultActions findFeedbackSummary(String token, String surveyId) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.get(API_VERSION + "/feedbacks/summary")
+			.queryParam("survey-id", surveyId)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header(HttpHeaders.AUTHORIZATION, token)
+		);
+	}
+
 
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -1,7 +1,10 @@
 package me.nalab.luffy.api.acceptance.test.feedback;
 
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 public final class FeedbackAcceptanceValidator {
@@ -12,6 +15,15 @@ public final class FeedbackAcceptanceValidator {
 
 	public static void assertIsFeedbackCreated(ResultActions resultActions) throws Exception {
 		resultActions.andExpectAll(status().isCreated());
+	}
+
+	public static void assertIsFeedbackSummaryFound(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.all_feedback_count").isNumber(),
+			jsonPath("$.new_feedback_count").isNumber()
+		);
 	}
 
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummary/FeedbackFindSummaryAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummary/FeedbackFindSummaryAcceptanceTest.java
@@ -1,0 +1,163 @@
+package me.nalab.luffy.api.acceptance.test.feedback.findsummary;
+
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.assertIsFeedbackSummaryFound;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.feedback.AbstractFeedbackTestSupporter;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.AbstractQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ChoiceQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.FeedbackCreateRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ReviewerRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ShortQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.ChoiceFormQuestionResponse;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.ShortFormQuestionResponse;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.SurveyFindResponse;
+import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+class FeedbackFindSummaryAcceptanceTest extends AbstractFeedbackTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	private static final ObjectMapper OBJECT_MAPPER;
+
+	static {
+		OBJECT_MAPPER = new ObjectMapper();
+		OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+	}
+
+	@Test
+	@DisplayName("질문 폼의 전체 피드백 수와 읽지 않은 피드백 수 조회 - 피드백이 없는 경우")
+	void FEEFBACK_SUMMARY_FIND_SUCCESS_TEST_WITH_NO_FEEDBACK() throws Exception {
+
+		// given
+		String token = "token";
+		Long targetId = targetInitializer.saveTargetAndGetId("sujin", LocalDateTime.now());
+		applicationEventPublisher.publishEvent(
+			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());
+		Long surveyId = createSurveyAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+
+		// when
+		ResultActions resultActions = findFeedbackSummary(token, surveyId.toString());
+
+		// then
+		assertIsFeedbackSummaryFound(resultActions);
+	}
+
+	@Test
+	@DisplayName("질문 폼의 전체 피드백 수와 읽지 않은 피드백 수 조회 - 피드백이 있는 경우")
+	void FEEFBACK_SUMMARY_FIND_SUCCESS_TEST_WITH_FEEDBACK() throws Exception {
+
+		// given
+		String token = "token";
+		Long targetId = targetInitializer.saveTargetAndGetId("sujin", LocalDateTime.now());
+		applicationEventPublisher.publishEvent(
+			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());
+
+		Long surveyId = createSurveyAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+
+		SurveyFindResponse surveyFindResponse = getSurveyFindResponse(surveyId);
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "developer");
+		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
+
+		// when
+		ResultActions resultActions = findFeedbackSummary(token, surveyId.toString());
+
+		// then
+		assertIsFeedbackSummaryFound(resultActions);
+	}
+
+	private Long createSurveyAndGetSurveyId(String token, String content) throws Exception {
+
+		String stringResponse = createSurvey(token, content).andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		JSONObject jsonObject = new JSONObject(stringResponse);
+		return jsonObject.getLong("survey_id");
+	}
+
+	private SurveyFindResponse getSurveyFindResponse(Long surveyId) throws Exception {
+		ResultActions resultActions = findSurvey(surveyId);
+		return OBJECT_MAPPER.readValue(resultActions.andReturn().getResponse().getContentAsString(),
+			SurveyFindResponse.class);
+	}
+
+	private FeedbackCreateRequest getFeedbackCreateRequest(SurveyFindResponse surveyFindResponse,
+		boolean collaborationExperience, String position) {
+		return FeedbackCreateRequest.builder()
+			.reviewerRequest(getReviewerRequest(collaborationExperience, position))
+			.abstractQuestionFeedbackRequests(getQuestionFeedbackRequestList(surveyFindResponse))
+			.build();
+	}
+
+	private ReviewerRequest getReviewerRequest(boolean collaborationExperience, String position) {
+		return ReviewerRequest.builder()
+			.collaborationExperience(collaborationExperience)
+			.position(position)
+			.build();
+	}
+
+	private List<AbstractQuestionFeedbackRequest> getQuestionFeedbackRequestList(
+		SurveyFindResponse surveyFindResponse) {
+
+		return surveyFindResponse.getQuestion().stream()
+			.map(q -> {
+				if(q instanceof ShortFormQuestionResponse) {
+					return getShortQuestionFeedbackRequest((ShortFormQuestionResponse)q);
+				}
+				return getChoiceQuestionFeedbackRequest((ChoiceFormQuestionResponse)q);
+			})
+			.collect(Collectors.toList());
+	}
+
+	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
+		ShortFormQuestionResponse shortFormQuestionResponse) {
+		return ShortQuestionFeedbackRequest.builder()
+			.questionId(shortFormQuestionResponse.getQuestionId())
+			.replyList(List.of("mocking", "words", "hello!"))
+			.type("short")
+			.build();
+	}
+
+	private ChoiceQuestionFeedbackRequest getChoiceQuestionFeedbackRequest(
+		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
+		return ChoiceQuestionFeedbackRequest.builder()
+			.type("choice")
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.build();
+	}
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문 폼의 피드백 요약 (해당 전체 피드백 수와 읽지 않은 피드백의 수) API에 대한 인수테스트를 작성했습니다

- [x]  /feedback/findsummary 패키지에 질문 폼의 피드백 요약 `인수테스트` 클래스를 생성했습니다
- [x] `FeedbackAcceptanceValidator` 에 요청로직에 대한 validation 로직을 추가했습니다 -> `assertIsFeedbackSummaryFound`
- [x] `AbstractFeedbackTestSupporter` 에 요청로직을 추가했습니다 -> `findFeedbackSummary` 

## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
