### PR TITLE
[feat] : surveyId에 해당하는 feedback 정보 조회 유즈케이스

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/findfeedback/FeedbackFindUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/findfeedback/FeedbackFindUseCase.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.port.in.web.findfeedback;
+
+import java.util.List;
+
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+
+/**
+ * Feedback을 찾는 UseCase 입니다.
+ */
+public interface FeedbackFindUseCase {
+
+	/**
+	 * surveyId를 입력으로 받아, surveyId에 해당하는 모든 FeedbackDto를 반환합니다.
+	 *
+	 * @param surveyId Feedback이 저장된 survey의 id
+	 * @return List survey에 저장된 모든 feedback 만약, 어떠한 feedback도 없다면, 빈 List를 반환합니다.
+	 */
+	List<FeedbackDto> findAllFeedbackDtoBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/FeedbackFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/FeedbackFindPort.java
@@ -1,0 +1,21 @@
+package me.nalab.survey.application.port.out.persistence.findfeedback;
+
+import java.util.List;
+
+import me.nalab.survey.domain.feedback.Feedback;
+
+/**
+ * 저장되어있는 모든 Feedback 을 조회하는 인터페이스 입니다.
+ */
+public interface FeedbackFindPort {
+
+	/**
+	 * surveyId를 인자로받아, 저장되어있는 모든 Feedback을 조회합니다.
+	 * 만약, 어떠한 저장되어있는 Feedback을 찾을 수 없다면, 빈 List를 반환합니다.
+	 *
+	 * @param surveyId Feedback 을 조회할 survey의 id
+	 * @return List 조회된 Feedback의 list
+	 */
+	List<Feedback> findAllFeedbackBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/SurveyExistCheckPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/SurveyExistCheckPort.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.application.port.out.persistence.findfeedback;
+
+/**
+ * 저장된 Survey가 존재하는지 확인하는 port 입니다.
+ */
+public interface SurveyExistCheckPort {
+
+	/**
+	 * surveyId를 인자로 받아, 저장되어있는 Survey가 있는지 확인합니다.
+	 * 있다면, true를 반환하고, 없다면 false를 반환합니다.
+	 *
+	 * @param surveyId 저장되어있는지 확인할 survey의 Id
+	 * @return boolean 있다면 true / 없다면 false
+	 */
+	boolean isExistSurveyBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/findfeedback/FeedbackFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/findfeedback/FeedbackFindService.java
@@ -1,0 +1,40 @@
+package me.nalab.survey.application.service.findfeedback;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
+import me.nalab.survey.application.port.in.web.findfeedback.FeedbackFindUseCase;
+import me.nalab.survey.application.port.out.persistence.findfeedback.FeedbackFindPort;
+import me.nalab.survey.application.port.out.persistence.findfeedback.SurveyExistCheckPort;
+import me.nalab.survey.domain.feedback.Feedback;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackFindService implements FeedbackFindUseCase {
+
+	private final SurveyExistCheckPort surveyExistCheckPort;
+	private final FeedbackFindPort feedbackFindPort;
+
+	@Override
+	public List<FeedbackDto> findAllFeedbackDtoBySurveyId(Long surveyId) {
+		throwIfSurveyDoesNotExist(surveyId);
+		List<Feedback> feedbackList = feedbackFindPort.findAllFeedbackBySurveyId(surveyId);
+		Collections.sort(feedbackList);
+		return feedbackList.stream().map(FeedbackDtoMapper::toDto).collect(Collectors.toList());
+	}
+
+	private void throwIfSurveyDoesNotExist(Long surveyId) {
+		if(surveyExistCheckPort.isExistSurveyBySurveyId(surveyId)) {
+			return;
+		}
+		throw new SurveyDoesNotExistException(surveyId);
+	}
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/service/findfeedback/FeedbackFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/findfeedback/FeedbackFindServiceTest.java
@@ -1,0 +1,101 @@
+package me.nalab.survey.application.service.findfeedback;
+
+import static me.nalab.survey.application.RandomFeedbackDtoFixture.getRandomFeedbackDtoBySurvey;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.survey.application.RandomSurveyDtoFixture;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
+import me.nalab.survey.application.common.survey.mapper.SurveyDtoMapper;
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
+import me.nalab.survey.application.port.in.web.findfeedback.FeedbackFindUseCase;
+import me.nalab.survey.application.port.out.persistence.findfeedback.FeedbackFindPort;
+import me.nalab.survey.application.port.out.persistence.findfeedback.SurveyExistCheckPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = FeedbackFindService.class)
+class FeedbackFindServiceTest {
+
+	@Autowired
+	private FeedbackFindUseCase feedbackFindUseCase;
+
+	@MockBean
+	private FeedbackFindPort feedbackFindPort;
+
+	@MockBean
+	private SurveyExistCheckPort surveyExistCheckPort;
+
+	@ParameterizedTest
+	@MethodSource("feedbackFindSources")
+	@DisplayName("Feedback 조회 성공 테스트 - survey가 존재")
+	void FIND_FEEDBACK(Survey survey, List<FeedbackDto> feedbackDtoList) {
+		// given
+		List<Feedback> feedbackList = feedbackDtoList.stream()
+			.map(f -> FeedbackDtoMapper.toDomain(survey, f))
+			.collect(Collectors.toList());
+
+		// when
+		when(surveyExistCheckPort.isExistSurveyBySurveyId(anyLong())).thenReturn(true);
+		when(feedbackFindPort.findAllFeedbackBySurveyId(anyLong())).thenReturn(feedbackList);
+
+		List<FeedbackDto> result = feedbackFindUseCase.findAllFeedbackDtoBySurveyId(survey.getId());
+
+		// then
+		assertIsSorted(result);
+	}
+
+	@Test
+	@DisplayName("Feedback 조회 실패 테스트 - survey가 없을때")
+	void FIND_FEEDBACK_FAIL_NO_SURVEY() {
+		// when
+		when(surveyExistCheckPort.isExistSurveyBySurveyId(anyLong())).thenReturn(false);
+
+		// then
+		assertThrows(SurveyDoesNotExistException.class, () -> feedbackFindUseCase.findAllFeedbackDtoBySurveyId(1L));
+	}
+
+	private void assertIsSorted(List<FeedbackDto> result) {
+		FeedbackDto before = null;
+		for(FeedbackDto current : result) {
+			if(before == null) {
+				before = current;
+				continue;
+			}
+			assertTrue(before.getUpdatedAt().isAfter(current.getUpdatedAt()));
+		}
+	}
+
+	private static Stream<Arguments> feedbackFindSources() {
+		Survey survey = SurveyDtoMapper.toSurvey(RandomSurveyDtoFixture.createRandomSurveyDto());
+		return Stream.of(
+			Arguments.of(survey,
+				Arrays.asList(getRandomFeedbackDtoBySurvey(survey), getRandomFeedbackDtoBySurvey(survey),
+					getRandomFeedbackDtoBySurvey(survey))), // feedback이 여러개
+			Arguments.of(survey, Collections.singletonList(getRandomFeedbackDtoBySurvey(survey))), // feedback이 하나
+			Arguments.of(survey, List.of()) // feedback이 없을때
+		);
+	}
+
+}

--- a/survey/domain/src/main/java/me/nalab/survey/domain/feedback/Feedback.java
+++ b/survey/domain/src/main/java/me/nalab/survey/domain/feedback/Feedback.java
@@ -17,7 +17,7 @@ import me.nalab.survey.domain.survey.spi.FeedbackValidable;
 @Getter
 @EqualsAndHashCode
 @ToString
-public class Feedback implements IdGeneratable, FeedbackValidable<FormQuestionFeedbackable> {
+public class Feedback implements IdGeneratable, FeedbackValidable<FormQuestionFeedbackable>, Comparable<Feedback> {
 
 	private Long id;
 	private Long surveyId;
@@ -47,6 +47,23 @@ public class Feedback implements IdGeneratable, FeedbackValidable<FormQuestionFe
 	@Override
 	public List<FormQuestionFeedbackable> getAllQuestionFeedbackValidable() {
 		return formQuestionFeedbackableList;
+	}
+
+	@Override
+	public int compareTo(Feedback feedback) {
+		if(updatedAt.isAfter(feedback.getUpdatedAt())) {
+			return -1;
+		}
+		if(updatedAt.isBefore(feedback.getUpdatedAt())) {
+			return 1;
+		}
+		if(createdAt.isAfter(feedback.getCreatedAt())) {
+			return -1;
+		}
+		if(createdAt.isBefore(feedback.getCreatedAt())) {
+			return 1;
+		}
+		return 0;
 	}
 
 }

--- a/survey/domain/src/test/java/me/nalab/survey/domain/feedback/FeedbackDomainTest.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/feedback/FeedbackDomainTest.java
@@ -4,8 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -153,6 +156,40 @@ class FeedbackDomainTest {
 		assertThrows(IdAlreadyGeneratedException.class, () -> reviewer.withId(LONG_SUPPLIER));
 		assertThrows(IdAlreadyGeneratedException.class, () -> shortFormQuestionFeedback.withId(LONG_SUPPLIER));
 		assertThrows(IdAlreadyGeneratedException.class, () -> choiceFormQuestionFeedback.withId(LONG_SUPPLIER));
+	}
+
+	@Test
+	@DisplayName("feedback domain 정렬 테스트")
+	void FEEDBACK_DOMAIN_SORTING_SUCCESS() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime year1Ago = LocalDateTime.now().minusYears(1);
+		LocalDateTime year2Ago = LocalDateTime.now().minusYears(2);
+
+		List<Feedback> feedbackList = Arrays.asList(Feedback.builder().createdAt(year1Ago).updatedAt(year1Ago).build(),
+			Feedback.builder().createdAt(year2Ago).updatedAt(year2Ago).build(),
+			Feedback.builder().createdAt(year1Ago).updatedAt(year1Ago).build(),
+			Feedback.builder().createdAt(year2Ago).updatedAt(year2Ago).build(),
+			Feedback.builder().createdAt(now).updatedAt(now).build(),
+			Feedback.builder().createdAt(year1Ago).updatedAt(now).build());
+
+		// when
+		Collections.sort(feedbackList);
+
+		// then
+		assertIsSorted(feedbackList);
+	}
+
+	private void assertIsSorted(List<Feedback> feedbackList) {
+		Feedback before = null;
+		for(Feedback current : feedbackList) {
+			if(before == null) {
+				before = current;
+				continue;
+			}
+			assertTrue(before.getUpdatedAt().isAfter(current.getUpdatedAt()) || before.getCreatedAt()
+				.isAfter(current.getCreatedAt()));
+		}
 	}
 
 	private Feedback getFeedback(Survey survey, String name, boolean isCollaborated, String position) {


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
surveyId에 해당하는 feedback 정보 조회 유즈케이스를 추가했습니다.

## 어떻게 해결했나요?
- [x] feedback domain이 updatedAt -> createdAt 순으로 정렬되도록 `Comparable`를 구현했습니다.
- [x] surveyid에 해당하는 survey를 찾을 수 없다면, 예외를 던지도록 만들었습니다. 
- [x] `in port` 와 구현체를 생성했습니다.
- [x] `out port` 를 정의했습니다.
- [x] 관련 테스트케이스를 추가했습니다. 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
