### PR TITLE
[feat] : feedback find 유즈케이스 `jpa adaptor 추가`

### DIFF
--- a/core/data/src/main/java/me/nalab/core/data/feedback/FeedbackEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/feedback/FeedbackEntity.java
@@ -35,7 +35,7 @@ public class FeedbackEntity extends TimeBaseEntity {
 	@JoinColumn(name = "survey_id", nullable = false)
 	private Long surveyId;
 
-	@JoinColumn(name = "is_read", nullable = false)
+	@Column(name = "is_read", nullable = false)
 	private boolean isRead;
 
 	@OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/FeedbackFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/FeedbackFindPort.java
@@ -1,0 +1,21 @@
+package me.nalab.survey.application.port.out.persistence.findfeedback;
+
+import java.util.List;
+
+import me.nalab.survey.domain.feedback.Feedback;
+
+/**
+ * 저장되어있는 모든 Feedback 을 조회하는 인터페이스 입니다.
+ */
+public interface FeedbackFindPort {
+
+	/**
+	 * surveyId를 인자로받아, 저장되어있는 모든 Feedback을 조회합니다.
+	 * 만약, 어떠한 저장되어있는 Feedback을 찾을 수 없다면, 빈 List를 반환합니다.
+	 *
+	 * @param surveyId Feedback 을 조회할 survey의 id
+	 * @return List 조회된 Feedback의 list
+	 */
+	List<Feedback> findAllFeedbackBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/SurveyExistCheckPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/SurveyExistCheckPort.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.application.port.out.persistence.findfeedback;
+
+/**
+ * 저장된 Survey가 존재하는지 확인하는 port 입니다.
+ */
+public interface SurveyExistCheckPort {
+
+	/**
+	 * surveyId를 인자로 받아, 저장되어있는 Survey가 있는지 확인합니다.
+	 * 있다면, true를 반환하고, 없다면 false를 반환합니다.
+	 *
+	 * @param surveyId 저장되어있는지 확인할 survey의 Id
+	 * @return boolean 있다면 true / 없다면 false
+	 */
+	boolean isExistSurveyBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -15,6 +15,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.out.persistence.createfeedback;
 	exports me.nalab.survey.application.port.in.web.createfeedback;
 	exports me.nalab.survey.application.common.feedback.dto;
+	exports me.nalab.survey.application.port.out.persistence.findfeedback;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/FeedbackFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/FeedbackFindAdaptor.java
@@ -1,0 +1,27 @@
+package me.nalab.survey.jpa.adaptor.findfeedback;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.findfeedback.FeedbackFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.findfeedback.repository.FeedbackFindRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedbackFindAdaptor implements FeedbackFindPort {
+
+	private final FeedbackFindRepository feedbackFindRepository;
+
+	@Override
+	public List<Feedback> findAllFeedbackBySurveyId(Long surveyId) {
+		List<FeedbackEntity> feedbackEntityList = feedbackFindRepository.findAllFeedbackEntityBySurveyId(surveyId);
+		return feedbackEntityList.stream().map(FeedbackEntityMapper::toDomain).collect(Collectors.toList());
+	}
+
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/repository/FeedbackFindRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/repository/FeedbackFindRepository.java
@@ -1,0 +1,16 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+public interface FeedbackFindRepository extends JpaRepository<FeedbackEntity, Long> {
+
+	@Query("select f from FeedbackEntity as f where f.surveyId = :surveyId")
+	List<FeedbackEntity> findAllFeedbackEntityBySurveyId(@Param("surveyId") Long surveyId);
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/FeedbackFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/FeedbackFindAdaptorTest.java
@@ -1,0 +1,97 @@
+package me.nalab.survey.jpa.adaptor.findfeedback;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.findfeedback.FeedbackFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = FeedbackFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class FeedbackFindAdaptorTest {
+
+	@Autowired
+	private FeedbackFindPort feedbackFindPort;
+
+	@Autowired
+	private TestFeedbackJpaRepository testFeedbackJpaRepository;
+
+	@Autowired
+	private TestSurveyJpaRepository testSurveyJpaRepository;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Test
+	@DisplayName("Feedback 조회 성공 테스트")
+	void FIND_FEEDBACK_LIST_SUCCESS() {
+		// given
+		TargetEntity targetEntity = getDefaultTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+		FeedbackEntity feedbackEntity = FeedbackEntityMapper.toEntity(
+			RandomFeedbackFixture.getRandomFeedbackBySurvey(survey));
+		List<Feedback> expected = List.of(FeedbackEntityMapper.toDomain(feedbackEntity));
+
+		testTargetJpaRepository.save(targetEntity);
+		testSurveyJpaRepository.save(surveyEntity);
+		testFeedbackJpaRepository.save(feedbackEntity);
+
+		// when
+		List<Feedback> feedbackList = feedbackFindPort.findAllFeedbackBySurveyId(survey.getId());
+
+		// then
+		assertIterableEquals(expected, feedbackList);
+	}
+
+	@Test
+	@DisplayName("Feedback 조회 성공 테스트 - Empty feedback list")
+	void FIND_FEEDBACK_LIST_SUCCESS_EMPTY_FEEDBACK() {
+		// given
+		TargetEntity targetEntity = getDefaultTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		testTargetJpaRepository.save(targetEntity);
+		testSurveyJpaRepository.save(surveyEntity);
+
+		// when
+		List<Feedback> feedbackList = feedbackFindPort.findAllFeedbackBySurveyId(survey.getId());
+
+		// then
+		assertTrue(feedbackList.isEmpty());
+	}
+
+	private TargetEntity getDefaultTargetEntity() {
+		return TargetEntity.builder()
+			.id(101L)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.nickname("test target")
+			.build();
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/TestFeedbackJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/TestFeedbackJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.findfeedback;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+public interface TestFeedbackJpaRepository extends JpaRepository<FeedbackEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/TestSurveyJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/TestSurveyJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.findfeedback;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/TestTargetJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/TestTargetJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.findfeedback;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TestTargetJpaRepository extends JpaRepository<TargetEntity, Long> {
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
feedback find 유즈케이스의 jpa adaptor를 추가했습니다.

## 어떻게 해결했나요?
- [x] out.port 구현체 FeedbackFindAdaptor를 생성했습니다.
- [x] 관련 테스트 케이스를 추가했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
