### PR TITLE
[feat] : feedback find 유즈케이스 `web-adaptor 추가`

### DIFF
--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -30,3 +30,4 @@ exclude me/nalab/survey/application/common/feedback/mapper/FeedbackDtoMapper
 exclude me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper
 exclude me/nalab/survey/web/adaptor/createfeedback/**
 exclude me/nalab/survey/web/adaptor/summaryreviewer/**
+exclude me/nalab/survey/web/adaptor/findfeedback/**

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/findfeedback/FeedbackFindUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/findfeedback/FeedbackFindUseCase.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.port.in.web.findfeedback;
+
+import java.util.List;
+
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+
+/**
+ * Feedback을 찾는 UseCase 입니다.
+ */
+public interface FeedbackFindUseCase {
+
+	/**
+	 * surveyId를 입력으로 받아, surveyId에 해당하는 모든 FeedbackDto를 반환합니다.
+	 *
+	 * @param surveyId Feedback이 저장된 survey의 id
+	 * @return List survey에 저장된 모든 feedback 만약, 어떠한 feedback도 없다면, 빈 List를 반환합니다.
+	 */
+	List<FeedbackDto> findAllFeedbackDtoBySurveyId(Long surveyId);
+
+}

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -15,6 +15,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.out.persistence.createfeedback;
 	exports me.nalab.survey.application.port.in.web.createfeedback;
 	exports me.nalab.survey.application.common.feedback.dto;
+	exports me.nalab.survey.application.port.in.web.findfeedback;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/FeedbackFindController.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/FeedbackFindController.java
@@ -1,0 +1,35 @@
+package me.nalab.survey.web.adaptor.findfeedback;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.survey.dto.SurveyDto;
+import me.nalab.survey.application.port.in.web.findfeedback.FeedbackFindUseCase;
+import me.nalab.survey.application.port.in.web.survey.find.SurveyFindUseCase;
+import me.nalab.survey.web.adaptor.findfeedback.response.QuestionFeedbackResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1")
+public class FeedbackFindController {
+
+	private final SurveyFindUseCase surveyFindUseCase;
+	private final FeedbackFindUseCase feedbackFindUseCase;
+
+	@GetMapping("/feedbacks")
+	@ResponseStatus(HttpStatus.OK)
+	public QuestionFeedbackResponse findFeedback(@RequestParam("survey-id") Long surveyId) {
+		SurveyDto surveyDto = surveyFindUseCase.findSurvey(surveyId);
+		List<FeedbackDto> feedbackDto = feedbackFindUseCase.findAllFeedbackDtoBySurveyId(surveyId);
+		return ResponseMapper.toQuestionFeedbackResponse(surveyDto, feedbackDto);
+	}
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/ResponseMapper.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/ResponseMapper.java
@@ -1,0 +1,128 @@
+package me.nalab.survey.web.adaptor.findfeedback;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.dto.ReviewerDto;
+import me.nalab.survey.application.common.feedback.dto.ShortFormQuestionFeedbackDto;
+import me.nalab.survey.application.common.survey.dto.ChoiceDto;
+import me.nalab.survey.application.common.survey.dto.ChoiceFormQuestionDto;
+import me.nalab.survey.application.common.survey.dto.QuestionDtoType;
+import me.nalab.survey.application.common.survey.dto.ShortFormQuestionDto;
+import me.nalab.survey.application.common.survey.dto.SurveyDto;
+import me.nalab.survey.web.adaptor.findfeedback.response.QuestionFeedbackResponse;
+import me.nalab.survey.web.adaptor.findfeedback.response.feedback.ChoiceFeedbackResponse;
+import me.nalab.survey.web.adaptor.findfeedback.response.feedback.ReviewerResponse;
+import me.nalab.survey.web.adaptor.findfeedback.response.feedback.ShortFeedbackResponse;
+import me.nalab.survey.web.adaptor.findfeedback.response.survey.ChoiceSurveyResponse;
+import me.nalab.survey.web.adaptor.findfeedback.response.survey.ShortSurveyResponse;
+
+final class ResponseMapper {
+
+	private ResponseMapper() {
+		throw new UnsupportedOperationException("Cannot invoke constructor \"ResponseMapper()\"");
+	}
+
+	static QuestionFeedbackResponse toQuestionFeedbackResponse(SurveyDto surveyDto, List<FeedbackDto> feedbackDtoList) {
+		return QuestionFeedbackResponse.builder()
+			.abstractSurveyResponse(surveyDto.getFormQuestionDtoableList().stream().map(
+				f -> {
+					if(f.getQuestionDtoType() == QuestionDtoType.CHOICE) {
+						return toChoiceSurveyResponse((ChoiceFormQuestionDto)f, feedbackDtoList);
+					}
+					return toShortSurveyResponse((ShortFormQuestionDto)f, feedbackDtoList);
+				}
+			).collect(Collectors.toList())).build();
+	}
+
+	private static ChoiceSurveyResponse toChoiceSurveyResponse(ChoiceFormQuestionDto choiceFormQuestionDto,
+		List<FeedbackDto> feedbackDto) {
+		return ChoiceSurveyResponse.builder()
+			.questionId(choiceFormQuestionDto.getId())
+			.order(choiceFormQuestionDto.getOrder())
+			.type(choiceFormQuestionDto.getQuestionDtoType().name().toLowerCase())
+			.title(choiceFormQuestionDto.getTitle())
+			.choiceResponseList(toChoiceQuestionResponse(choiceFormQuestionDto.getChoiceDtoList()))
+			.choiceFeedbackResponseList(toChoiceFeedbackResponse(choiceFormQuestionDto.getId(), feedbackDto))
+			.build();
+	}
+
+	private static List<ChoiceSurveyResponse.QuestionResponse> toChoiceQuestionResponse(List<ChoiceDto> choiceDtoList) {
+		return choiceDtoList.stream().map(
+			c -> ChoiceSurveyResponse.QuestionResponse.builder()
+				.choiceId(c.getId())
+				.order(c.getOrder())
+				.content(c.getContent())
+				.build()).collect(Collectors.toList()
+		);
+	}
+
+	private static List<ChoiceFeedbackResponse> toChoiceFeedbackResponse(Long questionId,
+		List<FeedbackDto> feedbackDtoList) {
+		List<ChoiceFeedbackResponse> choiceFeedbackResponseList = new ArrayList<>();
+		feedbackDtoList.forEach(f -> addChoiceFeedbackResponse(choiceFeedbackResponseList, questionId, f));
+		return choiceFeedbackResponseList;
+	}
+
+	private static void addChoiceFeedbackResponse(List<ChoiceFeedbackResponse> choiceFeedbackResponseList,
+		Long questionId, FeedbackDto feedbackDto) {
+		feedbackDto.getFormQuestionFeedbackDtoableList().stream()
+			.filter(q -> q.getQuestionId().equals(questionId))
+			.forEach(cq -> {
+				Set<Long> selectedChoiceIdSet = ((ChoiceFormQuestionFeedbackDto)cq).getSelectedChoiceIdSet();
+				choiceFeedbackResponseList.add(
+					ChoiceFeedbackResponse.builder()
+						.id(feedbackDto.getId())
+						.choiceIdSet(selectedChoiceIdSet)
+						.createdAt(feedbackDto.getCreatedAt())
+						.read(feedbackDto.isRead())
+						.reviewerResponse(toReviewerResponse(feedbackDto.getReviewerDto()))
+						.build()
+				);
+			});
+	}
+
+	private static ReviewerResponse toReviewerResponse(ReviewerDto reviewerDto) {
+		return ReviewerResponse.builder()
+			.id(reviewerDto.getId())
+			.nickName(reviewerDto.getNickName())
+			.collaborationExperience(reviewerDto.isCollaborationExperience())
+			.position(reviewerDto.getPosition())
+			.build();
+	}
+
+	private static ShortSurveyResponse toShortSurveyResponse(ShortFormQuestionDto shortFormQuestionDto,
+		List<FeedbackDto> feedbackDtoList) {
+		return ShortSurveyResponse.builder()
+			.questionId(shortFormQuestionDto.getId())
+			.order(shortFormQuestionDto.getOrder())
+			.type(shortFormQuestionDto.getQuestionDtoType().name().toLowerCase())
+			.title(shortFormQuestionDto.getTitle())
+			.shortFeedbackResponseList(toShortFeedbackResponse(shortFormQuestionDto.getId(), feedbackDtoList))
+			.build();
+	}
+
+	private static List<ShortFeedbackResponse> toShortFeedbackResponse(Long questionId,
+		List<FeedbackDto> feedbackDtoList) {
+		List<ShortFeedbackResponse> choiceFeedbackResponseList = new ArrayList<>();
+		feedbackDtoList.forEach(f -> addShortFeedbackResponse(choiceFeedbackResponseList, questionId, f));
+		return choiceFeedbackResponseList;
+	}
+
+	private static void addShortFeedbackResponse(List<ShortFeedbackResponse> shortFeedbackResponseList, Long questionId,
+		FeedbackDto feedbackDto) {
+		feedbackDto.getFormQuestionFeedbackDtoableList().stream().filter(q -> q.getQuestionId().equals(questionId))
+			.forEach(sq -> {
+				shortFeedbackResponseList.add(
+					ShortFeedbackResponse.builder()
+						.replyList(((ShortFormQuestionFeedbackDto)sq).getReplyList())
+						.build()
+				);
+			});
+	}
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/QuestionFeedbackResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/QuestionFeedbackResponse.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.web.adaptor.findfeedback.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import me.nalab.survey.web.adaptor.findfeedback.response.survey.AbstractSurveyResponse;
+
+@Getter
+@Builder
+@ToString
+public class QuestionFeedbackResponse {
+
+	@JsonProperty("question_feedback")
+	private final List<AbstractSurveyResponse> abstractSurveyResponse;
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/AbstractFeedbackResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/AbstractFeedbackResponse.java
@@ -1,0 +1,24 @@
+package me.nalab.survey.web.adaptor.findfeedback.response.feedback;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@ToString
+@SuperBuilder
+public class AbstractFeedbackResponse {
+
+	private final Long id;
+	@JsonProperty("created_at")
+	private final LocalDateTime createdAt;
+	@JsonProperty("is_read")
+	private final boolean read;
+	@JsonProperty("reviewer")
+	private final ReviewerResponse reviewerResponse;
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ChoiceFeedbackResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ChoiceFeedbackResponse.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.web.adaptor.findfeedback.response.feedback;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@ToString
+@SuperBuilder
+public class ChoiceFeedbackResponse extends AbstractFeedbackResponse {
+
+	@JsonProperty("choice_id")
+	private final Set<Long> choiceIdSet;
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ReviewerResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ReviewerResponse.java
@@ -1,0 +1,21 @@
+package me.nalab.survey.web.adaptor.findfeedback.response.feedback;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class ReviewerResponse {
+
+	private final Long id;
+	@JsonProperty("nickname")
+	private final String nickName;
+	@JsonProperty("collaboration_experience")
+	private final boolean collaborationExperience;
+	private final String position;
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ShortFeedbackResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ShortFeedbackResponse.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.web.adaptor.findfeedback.response.feedback;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@ToString
+@SuperBuilder
+public class ShortFeedbackResponse {
+
+	@JsonProperty("reply")
+	List<String> replyList;
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/AbstractSurveyResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/AbstractSurveyResponse.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.web.adaptor.findfeedback.response.survey;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@ToString
+@SuperBuilder
+public class AbstractSurveyResponse {
+
+	@JsonProperty("question_id")
+	private final Long questionId;
+	private final Integer order;
+	private final String type;
+	private final String title;
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/ChoiceSurveyResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/ChoiceSurveyResponse.java
@@ -1,0 +1,33 @@
+package me.nalab.survey.web.adaptor.findfeedback.response.survey;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import me.nalab.survey.web.adaptor.findfeedback.response.feedback.ChoiceFeedbackResponse;
+
+@Getter
+@ToString
+@SuperBuilder
+public class ChoiceSurveyResponse extends AbstractSurveyResponse {
+
+	@JsonProperty("choices")
+	private final List<QuestionResponse> choiceResponseList;
+
+	@JsonProperty("feedbacks")
+	private final List<ChoiceFeedbackResponse> choiceFeedbackResponseList;
+
+	@Builder
+	@ToString
+	public static final class QuestionResponse {
+		@JsonProperty("choice_id")
+		private final Long choiceId;
+		private final Integer order;
+		private final String content;
+	}
+
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/ShortSurveyResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/ShortSurveyResponse.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.web.adaptor.findfeedback.response.survey;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import me.nalab.survey.web.adaptor.findfeedback.response.feedback.ShortFeedbackResponse;
+
+@Getter
+@ToString
+@SuperBuilder
+public class ShortSurveyResponse extends AbstractSurveyResponse {
+
+	@JsonProperty("feedbacks")
+	private final List<ShortFeedbackResponse> shortFeedbackResponseList;
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
feedback find 유즈케이스에 `web-adaptor` 를 추가했습니다.

## 어떻게 해결했나요?
- [x] application dto와 repsonse를 변환하는 매퍼를 만들었습니다.
- [x] `GET /v1/feedbacks?survey-id={survey-id}` 입력을 받는 컨트롤러를 만들었습니다.
- [x] Response객체를 만들었습니다. 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
