### PR TITLE
[feat] : 질문 폼의 모든 리뷰어 조회- 인수테스트 작성

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
@@ -49,6 +49,16 @@ public abstract class AbstractFeedbackTestSupporter extends AbstractSurveyTestSu
 		);
 	}
 
+	protected ResultActions findReviewers(String token, String surveyId) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.get(API_VERSION + "/reviewers")
+			.queryParam("survey-id", surveyId)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header(HttpHeaders.AUTHORIZATION, token)
+		);
+	}
+
 
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -52,7 +52,7 @@ public final class FeedbackAcceptanceValidator {
 			content().contentType(MediaType.APPLICATION_JSON),
 			jsonPath("$.feedbacks").isArray(),
 			jsonPath("$.feedbacks[0].feedback_id").isNumber(),
-			jsonPath("$.feedbacks[0].created_at").isNotEmpty(),
+			jsonPath("$.feedbacks[0].created_at").isString(),
 			jsonPath("$.feedbacks[0].reviewer.nickname").isString(),
 			jsonPath("$.feedbacks[0].reviewer.collaboration_experience").isBoolean(),
 			jsonPath("$.feedbacks[0].reviewer.position").isString(),

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -37,4 +37,27 @@ public final class FeedbackAcceptanceValidator {
 		);
 	}
 
+	public static void assertIsReviewersNotFound(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.feedbacks").isArray(),
+			jsonPath("$.feedbacks").isEmpty()
+		);
+	}
+
+	public static void assertIsReviewersFound(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.feedbacks").isArray(),
+			jsonPath("$.feedbacks[0].feedback_id").isNumber(),
+			jsonPath("$.feedbacks[0].created_at").isNotEmpty(),
+			jsonPath("$.feedbacks[0].reviewer.nickname").isString(),
+			jsonPath("$.feedbacks[0].reviewer.collaboration_experience").isBoolean(),
+			jsonPath("$.feedbacks[0].reviewer.position").isString(),
+			jsonPath("$.feedbacks[0].is_read").isBoolean()
+		);
+	}
+
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
@@ -1,0 +1,167 @@
+package me.nalab.luffy.api.acceptance.test.feedback.findreviewers;
+
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.assertIsReviewersFound;
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.assertIsReviewersNotFound;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.feedback.AbstractFeedbackTestSupporter;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.AbstractQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ChoiceQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.FeedbackCreateRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ReviewerRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ShortQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.ChoiceFormQuestionResponse;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.ShortFormQuestionResponse;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.SurveyFindResponse;
+import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	private static final ObjectMapper OBJECT_MAPPER;
+
+	static {
+		OBJECT_MAPPER = new ObjectMapper();
+		OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+	}
+
+	@Test
+	@DisplayName("질문 폼에 피드백이 하나도 없는 경우")
+	void FEEDBACKS_WITH_NO_REVIEWER_TEST() throws Exception {
+
+		// given
+		String token = "token";
+		Long targetId = targetInitializer.saveTargetAndGetId("sujin", LocalDateTime.now());
+		applicationEventPublisher.publishEvent(
+			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());
+
+		String surveyId = createSurveyAndGetSurveyId(token, RequestSample.DEFAULT_JSON).toString();
+
+		// when
+		ResultActions resultActions = findReviewers(token, surveyId);
+
+		// then
+		assertIsReviewersNotFound(resultActions);
+
+	}
+
+	@Test
+	@DisplayName("질문 폼에 피드백이 있는 경우")
+	void FEEDBACKS_WITH_REVIEWERS_TEST() throws Exception {
+
+		// given
+		String token = "token";
+		Long targetId = targetInitializer.saveTargetAndGetId("sujin", LocalDateTime.now());
+		applicationEventPublisher.publishEvent(
+			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());
+
+		Long surveyId = createSurveyAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+		SurveyFindResponse surveyFindResponse = findSurveyAndGetSurveyResponse(surveyId);
+
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "developer");
+		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
+
+		// when
+		ResultActions resultActions = findReviewers(token, surveyId.toString());
+
+		// then
+		assertIsReviewersFound(resultActions);
+	}
+
+	private Long createSurveyAndGetSurveyId(String token, String content) throws Exception {
+
+		String stringResponse = createSurvey(token, content).andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		JSONObject jsonObject = new JSONObject(stringResponse);
+		return jsonObject.getLong("survey_id");
+	}
+
+	private SurveyFindResponse findSurveyAndGetSurveyResponse(Long surveyId) throws Exception {
+		ResultActions resultActions = findSurvey(surveyId);
+		return OBJECT_MAPPER.readValue(
+			resultActions.andReturn().getResponse().getContentAsString(),
+			SurveyFindResponse.class);
+	}
+
+	private FeedbackCreateRequest getFeedbackCreateRequest(SurveyFindResponse surveyFindResponse,
+		boolean collaborationExperience, String position) {
+		return FeedbackCreateRequest.builder()
+			.reviewerRequest(getReviewerRequest(collaborationExperience, position))
+			.abstractQuestionFeedbackRequests(getQuestionFeedbackRequestList(surveyFindResponse))
+			.build();
+	}
+
+	private ReviewerRequest getReviewerRequest(boolean collaborationExperience, String position) {
+		return ReviewerRequest.builder()
+			.collaborationExperience(collaborationExperience)
+			.position(position)
+			.build();
+	}
+
+	private List<AbstractQuestionFeedbackRequest> getQuestionFeedbackRequestList(
+		SurveyFindResponse surveyFindResponse) {
+
+		return surveyFindResponse.getQuestion().stream()
+			.map(q -> {
+				if(q instanceof ShortFormQuestionResponse) {
+					return getShortQuestionFeedbackRequest((ShortFormQuestionResponse)q);
+				}
+				return getChoiceQuestionFeedbackRequest((ChoiceFormQuestionResponse)q);
+			})
+			.collect(Collectors.toList());
+	}
+
+	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
+		ShortFormQuestionResponse shortFormQuestionResponse) {
+		return ShortQuestionFeedbackRequest.builder()
+			.questionId(shortFormQuestionResponse.getQuestionId())
+			.replyList(List.of("mocking", "words", "hello!"))
+			.type("short")
+			.build();
+	}
+
+	private ChoiceQuestionFeedbackRequest getChoiceQuestionFeedbackRequest(
+		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
+		return ChoiceQuestionFeedbackRequest.builder()
+			.type("choice")
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.build();
+	}
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
@@ -91,7 +91,7 @@ class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 		Long surveyId = createSurveyAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
 		SurveyFindResponse surveyFindResponse = findSurveyAndGetSurveyResponse(surveyId);
 
-		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "developer");
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "programmer");
 		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
 
 		// when


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문 폼의 모든 리뷰어 조회 API에 대한 인수테스트를 작성했습니다

- [x]  /feedback/findreviewers 패키지에 **질문 폼의 모든 리뷰어 조회** `인수테스트` 클래스를 생성했습니다
- [x] `FeedbackAcceptanceValidator` 에 요청로직에 대한 validation 로직을 추가했습니다 -> `assertIsReviewersNotFound`, `assertIsReviewersFound`
* 피드백이 하나도 없는 경우일때 , 피드백이 하나라도 있는 경우일 때 두 가지로 나누어서 검증을 하였습니다

- [x] `AbstractFeedbackTestSupporter` 에 요청로직을 추가했습니다 -> `findReviewers` 


## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
