### PR TITLE
[feat] : 질문 폼의 모든 리뷰어 목록 조회 `application`,  `jpa-adaptor`, `web-adaptor` 구현 

### DIFF
--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -20,6 +20,7 @@ exclude me/nalab/survey/web/adaptor/createsurvey/SurveyCreateController
 exclude me/nalab/survey/web/adaptor/survey/find/SurveyFindController
 exclude me/nalab/survey/web/adaptor/findid/SurveyIdGetController
 exclude me/nalab/survey/web/adaptor/feedbacksummary/FeedbackSummaryController
+exclude me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersController
 exclude me/nalab/survey/web/adaptor/advice/*
 exclude me/nalab/survey/web/adaptor/advice/ErrorTemplate
 exclude me/nalab/survey/application/common/feedback/dto/ChoiceFormQuestionFeedbackDto

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/feedbackreviewers/FeedbackReviewersFindUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/feedbackreviewers/FeedbackReviewersFindUseCase.java
@@ -1,0 +1,21 @@
+package me.nalab.survey.application.port.in.web.feedbackreviewers;
+
+import java.util.List;
+
+import me.nalab.survey.domain.feedback.Feedback;
+
+/**
+ * 질문 폼의 모든 피드백을 반환하는 인터페이스입니다.
+ */
+public interface FeedbackReviewersFindUseCase {
+
+	/**
+	 * surveyId를 인자로 받고, surveyId의 모든 피드백을 반환합니다.
+	 *
+	 * @param surveyId 조회할 survey의 id
+	 * @return Feedback의 List를 반환합니다
+	 * 없다면, 빈 리스트를 반환합니다.
+	 */
+
+	List<Feedback> findAllFeedback(Long surveyId);
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/feedbackreviewers/FeedbackReviewersFindUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/feedbackreviewers/FeedbackReviewersFindUseCase.java
@@ -2,7 +2,7 @@ package me.nalab.survey.application.port.in.web.feedbackreviewers;
 
 import java.util.List;
 
-import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 
 /**
  * 질문 폼의 모든 피드백을 반환하는 인터페이스입니다.
@@ -17,5 +17,5 @@ public interface FeedbackReviewersFindUseCase {
 	 * 없다면, 빈 리스트를 반환합니다.
 	 */
 
-	List<Feedback> findAllFeedback(Long surveyId);
+	List<FeedbackDto> findAllFeedback(Long surveyId);
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbackreviewers/FeedbacksFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbackreviewers/FeedbacksFindPort.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.port.out.persistence.feedbackreviewers;
+
+import java.util.List;
+
+import me.nalab.survey.domain.feedback.Feedback;
+
+/**
+ * SurveyId에 해당하는 모든 Feedback을 찾는 port 입니다.
+ */
+public interface FeedbacksFindPort {
+
+	/**
+	 * surveyId를 인자로 받아, 모든 Feedback 을 조회합니다.
+	 * 만약, 어떠한 Feedback 도 찾을 수 없다면, 빈 리스트를 반환합니다.
+	 *
+	 * @param surveyId Feedback 을 조회할 survey 의 id
+	 * @return List Survey에 응답한 모든 Feedback
+	 */
+	List<Feedback> findAllFeedback(Long surveyId);
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbackreviewers/FeedbacksFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbackreviewers/FeedbacksFindPort.java
@@ -2,7 +2,7 @@ package me.nalab.survey.application.port.out.persistence.feedbackreviewers;
 
 import java.util.List;
 
-import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.domain.feedback.Feedback;
 
 /**
  * SurveyId에 해당하는 모든 Feedback을 찾는 port 입니다.
@@ -16,5 +16,5 @@ public interface FeedbacksFindPort {
 	 * @param surveyId Feedback 을 조회할 survey 의 id
 	 * @return List Survey에 응답한 모든 Feedback
 	 */
-	List<FeedbackDto> findAllFeedback(Long surveyId);
+	List<Feedback> findAllFeedback(Long surveyId);
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbackreviewers/FeedbacksFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbackreviewers/FeedbacksFindPort.java
@@ -2,7 +2,7 @@ package me.nalab.survey.application.port.out.persistence.feedbackreviewers;
 
 import java.util.List;
 
-import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 
 /**
  * SurveyId에 해당하는 모든 Feedback을 찾는 port 입니다.
@@ -16,5 +16,5 @@ public interface FeedbacksFindPort {
 	 * @param surveyId Feedback 을 조회할 survey 의 id
 	 * @return List Survey에 응답한 모든 Feedback
 	 */
-	List<Feedback> findAllFeedback(Long surveyId);
+	List<FeedbackDto> findAllFeedback(Long surveyId);
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.port.in.web.feedbackreviewers.FeedbackReviewersFindUseCase;
 import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
 import me.nalab.survey.domain.feedback.Feedback;
@@ -16,7 +17,7 @@ public class FeedbackReviewersFindService implements FeedbackReviewersFindUseCas
 	private final FeedbacksFindPort feedbacksFindPort;
 
 	@Override
-	public List<Feedback> findAllFeedback(Long surveyId) {
+	public List<FeedbackDto> findAllFeedback(Long surveyId) {
 		return feedbacksFindPort.findAllFeedback(surveyId);
 	}
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.port.in.web.feedbackreviewers.FeedbackReviewersFindUseCase;
 import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
-import me.nalab.survey.domain.feedback.Feedback;
 
 @Service
 @RequiredArgsConstructor

--- a/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
@@ -1,13 +1,16 @@
 package me.nalab.survey.application.service.feedbackreviewers;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
 import me.nalab.survey.application.port.in.web.feedbackreviewers.FeedbackReviewersFindUseCase;
 import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +20,9 @@ public class FeedbackReviewersFindService implements FeedbackReviewersFindUseCas
 
 	@Override
 	public List<FeedbackDto> findAllFeedback(Long surveyId) {
-		return feedbacksFindPort.findAllFeedback(surveyId);
+		List<Feedback> feedbacks = feedbacksFindPort.findAllFeedback(surveyId);
+		return feedbacks.stream()
+			.map(FeedbackDtoMapper::toDto)
+			.collect(Collectors.toList());
 	}
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
@@ -1,0 +1,22 @@
+package me.nalab.survey.application.service.feedbackreviewers;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.port.in.web.feedbackreviewers.FeedbackReviewersFindUseCase;
+import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackReviewersFindService implements FeedbackReviewersFindUseCase {
+
+	private final FeedbacksFindPort feedbacksFindPort;
+
+	@Override
+	public List<Feedback> findAllFeedback(Long surveyId) {
+		return feedbacksFindPort.findAllFeedback(surveyId);
+	}
+}

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.common.feedback.dto;
 	exports me.nalab.survey.application.port.out.persistence.feedbacksummary;
 	exports me.nalab.survey.application.port.in.web.feedbacksummary;
+	exports me.nalab.survey.application.port.out.persistence.feedbackreviewers;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -18,6 +18,8 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.out.persistence.feedbacksummary;
 	exports me.nalab.survey.application.port.in.web.feedbacksummary;
 	exports me.nalab.survey.application.port.out.persistence.feedbackreviewers;
+	exports me.nalab.survey.application.service.feedbackreviewers;
+	exports me.nalab.survey.application.common.feedback.mapper;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/application/src/test/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindServiceTest.java
@@ -1,0 +1,66 @@
+package me.nalab.survey.application.service.feedbackreviewers;
+
+import static me.nalab.survey.application.RandomFeedbackDtoFixture.getRandomFeedbackDtoBySurvey;
+import static me.nalab.survey.application.RandomSurveyDtoFixture.createRandomSurveyDto;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
+import me.nalab.survey.application.common.survey.dto.SurveyDto;
+import me.nalab.survey.application.common.survey.mapper.SurveyDtoMapper;
+import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+
+class FeedbackReviewersFindServiceTest {
+
+	@Mock
+	private FeedbacksFindPort feedbacksFindPort;
+
+	private FeedbackReviewersFindService feedbackReviewersFindService;
+
+	@BeforeEach
+	void setup() {
+		MockitoAnnotations.openMocks(this);
+		feedbackReviewersFindService = new FeedbackReviewersFindService(feedbacksFindPort);
+	}
+
+	@Test
+	void FEEDBACKREVIEWERS_FIND_WITH_NO_FEEDBACK() {
+
+		Long surveyId = 1L;
+		when(feedbacksFindPort.findAllFeedback(surveyId)).thenReturn(List.of());
+
+		List<Feedback> actualFeedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
+
+		assertEquals(0, actualFeedbacks.size());
+	}
+
+	@Test
+	void FEEDBACKREVIEWERS_FIND_WITH_FEEDBACKS() {
+
+		SurveyDto randomSurveyDto = createRandomSurveyDto();
+		Long surveyId = randomSurveyDto.getId();
+		Survey survey = SurveyDtoMapper.toSurvey(randomSurveyDto);
+		FeedbackDto feedbackDto1 = getRandomFeedbackDtoBySurvey(survey);
+		FeedbackDto feedbackDto2 = getRandomFeedbackDtoBySurvey(survey);
+		Feedback feedback1 = FeedbackDtoMapper.toDomain(survey, feedbackDto1);
+		Feedback feedback2 = FeedbackDtoMapper.toDomain(survey, feedbackDto2);
+		List<Feedback> feedbacks = List.of(feedback1, feedback2);
+
+		when(feedbacksFindPort.findAllFeedback(surveyId)).thenReturn(feedbacks);
+
+		List<Feedback> resultFeedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
+
+		assertEquals(feedbacks, resultFeedbacks);
+	}
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindServiceTest.java
@@ -13,11 +13,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
-import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
 import me.nalab.survey.application.common.survey.dto.SurveyDto;
 import me.nalab.survey.application.common.survey.mapper.SurveyDtoMapper;
 import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
-import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.survey.Survey;
 
 class FeedbackReviewersFindServiceTest {
@@ -39,7 +37,7 @@ class FeedbackReviewersFindServiceTest {
 		Long surveyId = 1L;
 		when(feedbacksFindPort.findAllFeedback(surveyId)).thenReturn(List.of());
 
-		List<Feedback> actualFeedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
+		List<FeedbackDto> actualFeedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
 
 		assertEquals(0, actualFeedbacks.size());
 	}
@@ -52,13 +50,11 @@ class FeedbackReviewersFindServiceTest {
 		Survey survey = SurveyDtoMapper.toSurvey(randomSurveyDto);
 		FeedbackDto feedbackDto1 = getRandomFeedbackDtoBySurvey(survey);
 		FeedbackDto feedbackDto2 = getRandomFeedbackDtoBySurvey(survey);
-		Feedback feedback1 = FeedbackDtoMapper.toDomain(survey, feedbackDto1);
-		Feedback feedback2 = FeedbackDtoMapper.toDomain(survey, feedbackDto2);
-		List<Feedback> feedbacks = List.of(feedback1, feedback2);
+		List<FeedbackDto> feedbacks = List.of(feedbackDto1, feedbackDto2);
 
 		when(feedbacksFindPort.findAllFeedback(surveyId)).thenReturn(feedbacks);
 
-		List<Feedback> resultFeedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
+		List<FeedbackDto> resultFeedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
 
 		assertEquals(feedbacks, resultFeedbacks);
 	}

--- a/survey/application/src/test/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindServiceTest.java
@@ -13,9 +13,11 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
 import me.nalab.survey.application.common.survey.dto.SurveyDto;
 import me.nalab.survey.application.common.survey.mapper.SurveyDtoMapper;
 import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.survey.Survey;
 
 class FeedbackReviewersFindServiceTest {
@@ -37,9 +39,9 @@ class FeedbackReviewersFindServiceTest {
 		Long surveyId = 1L;
 		when(feedbacksFindPort.findAllFeedback(surveyId)).thenReturn(List.of());
 
-		List<FeedbackDto> actualFeedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
+		List<FeedbackDto> resultFeedbackDtos = feedbackReviewersFindService.findAllFeedback(surveyId);
 
-		assertEquals(0, actualFeedbacks.size());
+		assertEquals(0, resultFeedbackDtos.size());
 	}
 
 	@Test
@@ -48,15 +50,19 @@ class FeedbackReviewersFindServiceTest {
 		SurveyDto randomSurveyDto = createRandomSurveyDto();
 		Long surveyId = randomSurveyDto.getId();
 		Survey survey = SurveyDtoMapper.toSurvey(randomSurveyDto);
-		FeedbackDto feedbackDto1 = getRandomFeedbackDtoBySurvey(survey);
-		FeedbackDto feedbackDto2 = getRandomFeedbackDtoBySurvey(survey);
-		List<FeedbackDto> feedbacks = List.of(feedbackDto1, feedbackDto2);
+		Feedback feedback1 = FeedbackDtoMapper.toDomain(survey, getRandomFeedbackDtoBySurvey(survey));
+		Feedback feedback2 = FeedbackDtoMapper.toDomain(survey, getRandomFeedbackDtoBySurvey(survey));
+		List<Feedback> feedbacks = List.of(feedback1, feedback2);
+		List<FeedbackDto> expectedFeedbacks = List.of(
+			FeedbackDtoMapper.toDto(feedback1),
+			FeedbackDtoMapper.toDto(feedback2)
+		);
 
 		when(feedbacksFindPort.findAllFeedback(surveyId)).thenReturn(feedbacks);
 
 		List<FeedbackDto> resultFeedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
 
-		assertEquals(feedbacks, resultFeedbacks);
+		assertEquals(expectedFeedbacks, resultFeedbacks);
 	}
 
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptor.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
 import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
@@ -19,10 +21,13 @@ public class FeedbacksReviewersAdaptor implements FeedbacksFindPort {
 	private final FeedbackFindJpaRepository feedbackReviewerFindJpaRepository;
 
 	@Override
-	public List<Feedback> findAllFeedback(Long surveyId) {
+	public List<FeedbackDto> findAllFeedback(Long surveyId) {
 		List<FeedbackEntity> feedbackEntities = feedbackReviewerFindJpaRepository.findBySurveyId(surveyId);
-		return feedbackEntities.stream()
+		List<Feedback> feedbacks = feedbackEntities.stream()
 			.map(FeedbackEntityMapper::toDomain)
+			.collect(Collectors.toList());
+		return feedbacks.stream()
+			.map(FeedbackDtoMapper::toDto)
 			.collect(Collectors.toList());
 	}
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptor.java
@@ -21,13 +21,10 @@ public class FeedbacksReviewersAdaptor implements FeedbacksFindPort {
 	private final FeedbackFindJpaRepository feedbackReviewerFindJpaRepository;
 
 	@Override
-	public List<FeedbackDto> findAllFeedback(Long surveyId) {
+	public List<Feedback> findAllFeedback(Long surveyId) {
 		List<FeedbackEntity> feedbackEntities = feedbackReviewerFindJpaRepository.findBySurveyId(surveyId);
-		List<Feedback> feedbacks = feedbackEntities.stream()
+		return feedbackEntities.stream()
 			.map(FeedbackEntityMapper::toDomain)
-			.collect(Collectors.toList());
-		return feedbacks.stream()
-			.map(FeedbackDtoMapper::toDto)
 			.collect(Collectors.toList());
 	}
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptor.java
@@ -1,0 +1,28 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.feedbackreviewers.repository.FeedbackFindJpaRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedbacksReviewersAdaptor implements FeedbacksFindPort {
+
+	private final FeedbackFindJpaRepository feedbackReviewerFindJpaRepository;
+
+	@Override
+	public List<Feedback> findAllFeedback(Long surveyId) {
+		List<FeedbackEntity> feedbackEntities = feedbackReviewerFindJpaRepository.findBySurveyId(surveyId);
+		return feedbackEntities.stream()
+			.map(FeedbackEntityMapper::toDomain)
+			.collect(Collectors.toList());
+	}
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptor.java
@@ -7,8 +7,6 @@ import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.core.data.feedback.FeedbackEntity;
-import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
-import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
 import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/repository/FeedbackFindJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/repository/FeedbackFindJpaRepository.java
@@ -1,0 +1,14 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+@Repository("feedbackreviewers.FeedbackFindJpaRepository")
+public interface FeedbackFindJpaRepository extends JpaRepository<FeedbackEntity, Long> {
+
+	List<FeedbackEntity> findBySurveyId(Long surveyId);
+}

--- a/survey/jpa-adaptor/src/main/java/module-info.java
+++ b/survey/jpa-adaptor/src/main/java/module-info.java
@@ -12,4 +12,5 @@ module luffy.survey.jpa.adaptor.main {
 	requires spring.data.commons;
 
 	requires spring.tx;
+	requires spring.beans;
 }

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptorTest.java
@@ -13,8 +13,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 import me.nalab.core.data.feedback.FeedbackEntity;
-import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
-import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.survey.Survey;
 import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptorTest.java
@@ -50,17 +50,15 @@ class FeedbacksReviewersAdaptorTest {
 
 		Feedback feedback1 = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
 		FeedbackEntity feedbackEntity1 = FeedbackEntityMapper.toEntity(feedback1);
-		FeedbackDto feedbackDto1 = FeedbackDtoMapper.toDto(feedback1);
 		Feedback feedback2 = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
 		FeedbackEntity feedbackEntity2 = FeedbackEntityMapper.toEntity(feedback2);
-		FeedbackDto feedbackDto2 = FeedbackDtoMapper.toDto(feedback2);
 		testFeedbackFindJpaRepository.saveAndFlush(feedbackEntity1);
 		testFeedbackFindJpaRepository.saveAndFlush(feedbackEntity2);
 
-		List<FeedbackDto> expected = List.of(feedbackDto1, feedbackDto2);
+		List<Feedback> expected = List.of(feedback1, feedback2);
 
 		// when
-		List<FeedbackDto> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
+		List<Feedback> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
 
 		// then
 		assertEquals(expected.size(), resultFeedbacks.size());
@@ -79,7 +77,7 @@ class FeedbacksReviewersAdaptorTest {
 		testSurveyCreateJpaRepository.saveAndFlush(SurveyEntityMapper.toSurveyEntity(targetId, survey));
 
 		// when
-		List<FeedbackDto> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
+		List<Feedback> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
 
 		// then
 		assertEquals(expected, resultFeedbacks.size());

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptorTest.java
@@ -1,0 +1,83 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = FeedbacksReviewersAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class FeedbacksReviewersAdaptorTest {
+
+	@Autowired
+	private FeedbacksReviewersAdaptor feedbacksReviewersAdaptor;
+
+	@Autowired
+	private TestSurveyCreateJpaRepository testSurveyCreateJpaRepository;
+
+	@Autowired
+	private TestFeedbackFindJpaRepository testFeedbackFindJpaRepository;
+
+	@Test
+	@DisplayName("질문 폼에 피드백이 있는 경우")
+	void FIND_FEEDBACKREVIEWERS_WITH_FEEDBACKS() {
+
+		// given
+		Long targetId = 10L;
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		Long surveyId = survey.getId();
+		testSurveyCreateJpaRepository.saveAndFlush(SurveyEntityMapper.toSurveyEntity(targetId, survey));
+
+		Feedback feedback1 = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
+		FeedbackEntity feedbackEntity1 = FeedbackEntityMapper.toEntity(feedback1);
+		Feedback feedback2 = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
+		FeedbackEntity feedbackEntity2 = FeedbackEntityMapper.toEntity(feedback2);
+		testFeedbackFindJpaRepository.saveAndFlush(feedbackEntity1);
+		testFeedbackFindJpaRepository.saveAndFlush(feedbackEntity2);
+
+		List<Feedback> expected = List.of(feedback1, feedback2);
+
+		// when
+		List<Feedback> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
+
+		// then
+		assertEquals(resultFeedbacks.size(), expected.size());
+
+	}
+
+	@Test
+	@DisplayName("질문 폼에 피드백이 없는 경우")
+	void FIND_FEEDBACKREVIEWERS_WITH_NO_FEEDBACKS() {
+
+		// given
+		Long targetId = 10L;
+		int expected = 0;
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		Long surveyId = survey.getId();
+		testSurveyCreateJpaRepository.saveAndFlush(SurveyEntityMapper.toSurveyEntity(targetId, survey));
+
+		// when
+		List<Feedback> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
+
+		// then
+		assertEquals(expected, resultFeedbacks.size());
+	}
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/FeedbacksReviewersAdaptorTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.survey.Survey;
 import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
@@ -48,18 +50,20 @@ class FeedbacksReviewersAdaptorTest {
 
 		Feedback feedback1 = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
 		FeedbackEntity feedbackEntity1 = FeedbackEntityMapper.toEntity(feedback1);
+		FeedbackDto feedbackDto1 = FeedbackDtoMapper.toDto(feedback1);
 		Feedback feedback2 = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
 		FeedbackEntity feedbackEntity2 = FeedbackEntityMapper.toEntity(feedback2);
+		FeedbackDto feedbackDto2 = FeedbackDtoMapper.toDto(feedback2);
 		testFeedbackFindJpaRepository.saveAndFlush(feedbackEntity1);
 		testFeedbackFindJpaRepository.saveAndFlush(feedbackEntity2);
 
-		List<Feedback> expected = List.of(feedback1, feedback2);
+		List<FeedbackDto> expected = List.of(feedbackDto1, feedbackDto2);
 
 		// when
-		List<Feedback> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
+		List<FeedbackDto> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
 
 		// then
-		assertEquals(resultFeedbacks.size(), expected.size());
+		assertEquals(expected.size(), resultFeedbacks.size());
 
 	}
 
@@ -75,7 +79,7 @@ class FeedbacksReviewersAdaptorTest {
 		testSurveyCreateJpaRepository.saveAndFlush(SurveyEntityMapper.toSurveyEntity(targetId, survey));
 
 		// when
-		List<Feedback> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
+		List<FeedbackDto> resultFeedbacks = feedbacksReviewersAdaptor.findAllFeedback(surveyId);
 
 		// then
 		assertEquals(expected, resultFeedbacks.size());

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/TestFeedbackFindJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/TestFeedbackFindJpaRepository.java
@@ -1,0 +1,12 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+public interface TestFeedbackFindJpaRepository extends JpaRepository<FeedbackEntity, Long> {
+
+	List<FeedbackEntity> findBySurveyId(Long surveyId);
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/TestSurveyCreateJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/TestSurveyCreateJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyCreateJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersController.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersController.java
@@ -1,0 +1,29 @@
+package me.nalab.survey.web.adaptor.feedbackreviewers;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.service.feedbackreviewers.FeedbackReviewersFindService;
+import me.nalab.survey.web.adaptor.feedbackreviewers.response.FeedbackReviewersResponse;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class FeedbackReviewersController {
+
+	private final FeedbackReviewersFindService feedbackReviewersFindService;
+
+	@GetMapping("/reviewers")
+	public ResponseEntity<FeedbackReviewersResponse> getFeedbackReviewers(@RequestParam("survey-id") Long surveyId) {
+		List<FeedbackDto> feedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
+		FeedbackReviewersResponse feedbackReviewersResponse = FeedbackReviewersResponseMapper.toFeedbackReviewersResponse(feedbacks);
+		return ResponseEntity.ok(feedbackReviewersResponse);
+	}
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapper.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapper.java
@@ -19,7 +19,7 @@ class FeedbackReviewersResponseMapper {
 				.feedbackId(it.getId())
 				.createdAt(it.getCreatedAt())
 				.reviewer(ReviewerResponse.builder()
-					.nickname(it.getReviewerDto().getNickName())
+					.nickName(it.getReviewerDto().getNickName())
 					.collaborationExperience(it.getReviewerDto().isCollaborationExperience())
 					.position(it.getReviewerDto().getPosition())
 					.build())

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapper.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapper.java
@@ -1,0 +1,31 @@
+package me.nalab.survey.web.adaptor.feedbackreviewers;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.web.adaptor.feedbackreviewers.response.FeedbackReviewer;
+import me.nalab.survey.web.adaptor.feedbackreviewers.response.FeedbackReviewersResponse;
+import me.nalab.survey.web.adaptor.feedbackreviewers.response.ReviewerResponse;
+
+class FeedbackReviewersResponseMapper {
+
+	private FeedbackReviewersResponseMapper() {
+		throw new UnsupportedOperationException("Cannot invoke constructor \"FeedbackReviewersResponseMapper()\"");
+	}
+	static FeedbackReviewersResponse toFeedbackReviewersResponse(List<FeedbackDto> feedbacks) {
+		List<FeedbackReviewer> feedbackReviewers = feedbacks.stream()
+			.map(it -> FeedbackReviewer.builder()
+				.feedbackId(it.getId())
+				.createdAt(it.getCreatedAt())
+				.reviewer(ReviewerResponse.builder()
+					.nickname(it.getReviewerDto().getNickName())
+					.collaborationExperience(it.getReviewerDto().isCollaborationExperience())
+					.position(it.getReviewerDto().getPosition())
+					.build())
+				.isRead(it.isRead())
+				.build())
+			.collect(Collectors.toList());
+		return FeedbackReviewersResponse.builder().feedbacks(feedbackReviewers).build();
+	}
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/FeedbackReviewer.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/FeedbackReviewer.java
@@ -1,0 +1,30 @@
+package me.nalab.survey.web.adaptor.feedbackreviewers.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+public class FeedbackReviewer {
+
+	@JsonProperty("feedback_id")
+	private Long feedbackId;
+
+	@JsonProperty("created_at")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime createdAt;
+
+	private ReviewerResponse reviewer;
+
+	@JsonProperty("is_read")
+	private Boolean isRead;
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/FeedbackReviewersResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/FeedbackReviewersResponse.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.web.adaptor.feedbackreviewers.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+public class FeedbackReviewersResponse {
+
+	private final List<FeedbackReviewer> feedbacks;
+}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/ReviewerResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/ReviewerResponse.java
@@ -13,7 +13,8 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class ReviewerResponse {
 
-	private String nickname;
+	@JsonProperty("nickname")
+	private String nickName;
 
 	@JsonProperty("collaboration_experience")
 	private Boolean collaborationExperience;

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/ReviewerResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/ReviewerResponse.java
@@ -1,0 +1,22 @@
+package me.nalab.survey.web.adaptor.feedbackreviewers.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+public class ReviewerResponse {
+
+	private String nickname;
+
+	@JsonProperty("collaboration_experience")
+	private Boolean collaborationExperience;
+
+	private String position;
+}

--- a/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapperTest.java
+++ b/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapperTest.java
@@ -31,7 +31,7 @@ class FeedbackReviewersResponseMapperTest {
 			() -> assertThat(response.getFeedbacks()).hasSize(1),
 			() -> assertThat(feedbackReviewer.getFeedbackId()).isEqualTo(1L),
 			() -> assertThat(feedbackReviewer.getIsRead()).isTrue(),
-			() -> assertThat(feedbackReviewer.getReviewer().getNickname()).isEqualTo("sujin"),
+			() -> assertThat(feedbackReviewer.getReviewer().getNickName()).isEqualTo("sujin"),
 			() -> assertThat(feedbackReviewer.getReviewer().getCollaborationExperience()).isTrue(),
 			() -> assertThat(feedbackReviewer.getReviewer().getPosition()).isEqualTo("developer")
 		);

--- a/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapperTest.java
+++ b/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapperTest.java
@@ -1,0 +1,69 @@
+package me.nalab.survey.web.adaptor.feedbackreviewers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.dto.ReviewerDto;
+import me.nalab.survey.application.common.feedback.dto.ShortFormQuestionFeedbackDto;
+import me.nalab.survey.web.adaptor.feedbackreviewers.response.FeedbackReviewer;
+import me.nalab.survey.web.adaptor.feedbackreviewers.response.FeedbackReviewersResponse;
+
+class FeedbackReviewersResponseMapperTest {
+
+	@Test
+	void feedbackReviewersResponseMapperTest() {
+
+		FeedbackDto feedbackDto = getFeedbackDto();
+
+		FeedbackReviewersResponse response = FeedbackReviewersResponseMapper.toFeedbackReviewersResponse(
+			List.of(feedbackDto));
+		FeedbackReviewer feedbackReviewer = response.getFeedbacks().get(0);
+
+		assertAll(
+			() -> assertThat(response.getFeedbacks().size()).isEqualTo(1),
+			() -> assertThat(feedbackReviewer.getFeedbackId()).isEqualTo(1L),
+			() -> assertThat(feedbackReviewer.getIsRead()).isTrue(),
+			() -> assertThat(feedbackReviewer.getReviewer().getNickname()).isEqualTo("sujin"),
+			() -> assertThat(feedbackReviewer.getReviewer().getCollaborationExperience()).isTrue(),
+			() -> assertThat(feedbackReviewer.getReviewer().getPosition()).isEqualTo("developer")
+		);
+
+	}
+
+	private static FeedbackDto getFeedbackDto() {
+		return FeedbackDto.builder()
+			.id(1L)
+			.surveyId(3L)
+			.formQuestionFeedbackDtoableList(
+				List.of(ChoiceFormQuestionFeedbackDto.builder()
+						.id(1L)
+						.questionId(1L)
+						.isRead(true)
+						.selectedChoiceIdSet(new HashSet<>(1, 2))
+						.build(),
+					ShortFormQuestionFeedbackDto.builder()
+						.id(2L)
+						.questionId(2L)
+						.isRead(true)
+						.replyList(List.of("reply1", "reply2"))
+						.build()))
+			.isRead(true)
+			.reviewerDto(ReviewerDto.builder()
+				.id(34L)
+				.nickName("sujin")
+				.collaborationExperience(true)
+				.position("developer")
+				.build())
+			.createdAt(LocalDateTime.of(2023, 5, 26, 6, 46, 0))
+			.updatedAt(LocalDateTime.of(2023, 5, 26, 6, 46, 0))
+			.build();
+	}
+}

--- a/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapperTest.java
+++ b/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapperTest.java
@@ -28,7 +28,7 @@ class FeedbackReviewersResponseMapperTest {
 		FeedbackReviewer feedbackReviewer = response.getFeedbacks().get(0);
 
 		assertAll(
-			() -> assertThat(response.getFeedbacks().size()).isEqualTo(1),
+			() -> assertThat(response.getFeedbacks()).hasSize(1),
 			() -> assertThat(feedbackReviewer.getFeedbackId()).isEqualTo(1L),
 			() -> assertThat(feedbackReviewer.getIsRead()).isTrue(),
 			() -> assertThat(feedbackReviewer.getReviewer().getNickname()).isEqualTo("sujin"),


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
- [x] in port 에서 질문 폼의 리뷰어 목록 조회 유즈케이스의 interface인 `FeedbackReviewersFindUseCase` 정의하고, 이의 구현체 를 만들었습니다
- [x] 그리고 이의 테스트를 구현하였습니다 - 테스트는 리뷰가 없는 경우 / 있는 경우 로 나누었습니다 
- [x] out persistence 에서 port 인터페이스를 정의하였습니다
---

- [x] port의 구현체인 `FeedbacksReviewersAdaptor` 를 구현하고, 이를 이용하는 repository도 정의하였습니다
- [x] `FeedbacksReviewersAdaptor` 에 대한 테스트를 작성하고, 피드백(리뷰) 있는 경우 / 없는 경우로 나눴습니다
---

- [x] 질문 폼의 모든 리뷰어 조회에 `web-adaptor` 를 추가하고, controller를 만들었습니다
- [x] Response 객체를 만들고, controller에서 mapper를 통해 이를 변환하도록 하였습니다.
- [x] mapper에 대한 테스트코드를 작성했습니다.
## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
