### PR TITLE
[chore] : sonar analyze main 에서 돌아가게 수정

### DIFF
--- a/.github/workflows/accept-analyze.yml
+++ b/.github/workflows/accept-analyze.yml
@@ -1,5 +1,8 @@
 name: acceptance-analyze-with-sonarcloud
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
main push에 대해서, sonar analyze가 수행되지않아, sonar cloud 분석 리포트가 업데이트 되지 않고있어서, sonar analyze가 main에서도 돌아가게 만들었습니다.

## 어떻게 해결했나요?
- [x] accept analyze ci에 push: branches: -main 옵션을 넣었습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
