### PR TITLE
[feat] : TSID id generator 추가

### DIFF
--- a/core/id-generator/id-generator-starter/build.gradle
+++ b/core/id-generator/id-generator-starter/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
     api project(':core:id-generator:id-core')
-    implementation project(':core:id-generator:mock-id-generator')
+    implementation project(':core:id-generator:tsid')
 }

--- a/core/id-generator/id-generator-starter/src/main/java/me/nalab/core/idgenerator/starter/IdGeneratorConfigurer.java
+++ b/core/id-generator/id-generator-starter/src/main/java/me/nalab/core/idgenerator/starter/IdGeneratorConfigurer.java
@@ -4,14 +4,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import me.nalab.core.idgenerator.idcore.IdGenerator;
-import me.nalab.core.idgenerator.mock.MockIdGenerator;
+import me.nalab.core.idgenerator.tsid.TsidGenerator;
+import me.nalab.core.idgenerator.tsid.engine.TsidEngine;
 
 @Configuration
 class IdGeneratorConfigurer {
 
 	@Bean
-	IdGenerator randomIdGenerator(){
-		return new MockIdGenerator();
+	IdGenerator tsidIdGenerator(){
+		return new TsidGenerator(TsidEngine.threadEngine());
 	}
 
 }

--- a/core/id-generator/id-generator-starter/src/main/java/module-info.java
+++ b/core/id-generator/id-generator-starter/src/main/java/module-info.java
@@ -1,7 +1,10 @@
 module luffy.core.id.generator.id.generator.starter.main {
+
 	requires transitive luffy.core.id.generator.id.core.main;
-	requires luffy.core.id.generator.mock.id.generator.main;
+	requires luffy.core.id.generator.tsid.main;
 
 	requires spring.boot;
 	requires spring.boot.autoconfigure;
+	requires spring.context;
+
 }

--- a/core/id-generator/tsid/build.gradle
+++ b/core/id-generator/tsid/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':core:id-generator:id-core')
+
+    api 'com.github.f4b6a3:tsid-creator:5.2.4' // MIT LICENSE
+
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+}

--- a/core/id-generator/tsid/src/main/java/me/nalab/core/idgenerator/tsid/TsidGenerator.java
+++ b/core/id-generator/tsid/src/main/java/me/nalab/core/idgenerator/tsid/TsidGenerator.java
@@ -1,0 +1,22 @@
+package me.nalab.core.idgenerator.tsid;
+
+import java.util.function.Supplier;
+
+import com.github.f4b6a3.tsid.TsidFactory;
+
+import me.nalab.core.idgenerator.idcore.IdGenerator;
+
+public class TsidGenerator implements IdGenerator {
+
+	private final Supplier<TsidFactory> tsidFactorySupplier;
+
+	public TsidGenerator(Supplier<TsidFactory> tsidFactorySupplier) {
+		this.tsidFactorySupplier = tsidFactorySupplier;
+	}
+
+	@Override
+	public long generate() {
+		return tsidFactorySupplier.get().create().toLong();
+	}
+
+}

--- a/core/id-generator/tsid/src/main/java/me/nalab/core/idgenerator/tsid/engine/TsidEngine.java
+++ b/core/id-generator/tsid/src/main/java/me/nalab/core/idgenerator/tsid/engine/TsidEngine.java
@@ -10,6 +10,10 @@ public final class TsidEngine {
 	private static final TsidFactory DEFAULT_ENGINE = TsidFactory.newInstance256();
 	private static final HashMap<Long, TsidFactory> THREAD_ENGINE = new HashMap<>();
 
+	private TsidEngine() {
+		throw new UnsupportedOperationException("Cannot invoke constructor \"TsidEngine()\"");
+	}
+
 	public static Supplier<TsidFactory> defaultEngine() {
 		return () -> DEFAULT_ENGINE;
 	}

--- a/core/id-generator/tsid/src/main/java/me/nalab/core/idgenerator/tsid/engine/TsidEngine.java
+++ b/core/id-generator/tsid/src/main/java/me/nalab/core/idgenerator/tsid/engine/TsidEngine.java
@@ -9,6 +9,7 @@ public final class TsidEngine {
 
 	private static final TsidFactory DEFAULT_ENGINE = TsidFactory.newInstance256();
 	private static final HashMap<Long, TsidFactory> THREAD_ENGINE = new HashMap<>();
+	private static final ThreadEngineSupplier THREAD_ENGINE_SUPPLIER = new ThreadEngineSupplier();
 
 	private TsidEngine() {
 		throw new UnsupportedOperationException("Cannot invoke constructor \"TsidEngine()\"");
@@ -19,14 +20,10 @@ public final class TsidEngine {
 	}
 
 	public static Supplier<TsidFactory> threadEngine() {
-		return ThreadEngineSupplier.instance();
+		return THREAD_ENGINE_SUPPLIER;
 	}
 
 	private static final class ThreadEngineSupplier implements Supplier<TsidFactory> {
-
-		private static ThreadEngineSupplier instance() {
-			return SingletonHelper.INSTANCE;
-		}
 
 		@Override
 		public TsidFactory get() {
@@ -40,10 +37,6 @@ public final class TsidEngine {
 				return;
 			}
 			THREAD_ENGINE.put(threadId, TsidFactory.newInstance256((int)threadId));
-		}
-
-		private static final class SingletonHelper {
-			private static final ThreadEngineSupplier INSTANCE = new ThreadEngineSupplier();
 		}
 
 	}

--- a/core/id-generator/tsid/src/main/java/me/nalab/core/idgenerator/tsid/engine/TsidEngine.java
+++ b/core/id-generator/tsid/src/main/java/me/nalab/core/idgenerator/tsid/engine/TsidEngine.java
@@ -1,0 +1,47 @@
+package me.nalab.core.idgenerator.tsid.engine;
+
+import java.util.HashMap;
+import java.util.function.Supplier;
+
+import com.github.f4b6a3.tsid.TsidFactory;
+
+public final class TsidEngine {
+
+	private static final TsidFactory DEFAULT_ENGINE = TsidFactory.newInstance256();
+	private static final HashMap<Long, TsidFactory> THREAD_ENGINE = new HashMap<>();
+
+	public static Supplier<TsidFactory> defaultEngine() {
+		return () -> DEFAULT_ENGINE;
+	}
+
+	public static Supplier<TsidFactory> threadEngine() {
+		return ThreadEngineSupplier.instance();
+	}
+
+	private static final class ThreadEngineSupplier implements Supplier<TsidFactory> {
+
+		private static ThreadEngineSupplier instance() {
+			return SingletonHelper.INSTANCE;
+		}
+
+		@Override
+		public TsidFactory get() {
+			long threadId = Thread.currentThread().getId() % 256;
+			createNewTsidFactoryIfAbsent(threadId);
+			return THREAD_ENGINE.get(threadId);
+		}
+
+		private void createNewTsidFactoryIfAbsent(long threadId) {
+			if(THREAD_ENGINE.containsKey(threadId)) {
+				return;
+			}
+			THREAD_ENGINE.put(threadId, TsidFactory.newInstance256((int)threadId));
+		}
+
+		private static final class SingletonHelper {
+			private static final ThreadEngineSupplier INSTANCE = new ThreadEngineSupplier();
+		}
+
+	}
+
+}

--- a/core/id-generator/tsid/src/main/java/module-info.java
+++ b/core/id-generator/tsid/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module luffy.core.id.generator.tsid.main {
+
+	exports me.nalab.core.idgenerator.tsid.engine;
+	exports me.nalab.core.idgenerator.tsid;
+
+	requires luffy.core.id.generator.id.core.main;
+	requires com.github.f4b6a3.tsid;
+
+}

--- a/core/id-generator/tsid/src/test/java/me/nalab/core/idgenerator/tsid/DefaultTsidActor.java
+++ b/core/id-generator/tsid/src/test/java/me/nalab/core/idgenerator/tsid/DefaultTsidActor.java
@@ -1,0 +1,21 @@
+package me.nalab.core.idgenerator.tsid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultTsidActor {
+
+	private final TsidGenerator tsidGenerator;
+
+	@Autowired
+	public DefaultTsidActor(@Qualifier("defaultTsidGenerator") TsidGenerator tsidGenerator) {
+		this.tsidGenerator = tsidGenerator;
+	}
+
+	public long act() {
+		return tsidGenerator.generate();
+	}
+
+}

--- a/core/id-generator/tsid/src/test/java/me/nalab/core/idgenerator/tsid/ThreadTsidActor.java
+++ b/core/id-generator/tsid/src/test/java/me/nalab/core/idgenerator/tsid/ThreadTsidActor.java
@@ -1,0 +1,21 @@
+package me.nalab.core.idgenerator.tsid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThreadTsidActor {
+
+	private final TsidGenerator tsidGenerator;
+
+	@Autowired
+	public ThreadTsidActor(@Qualifier("threadTsidGenerator") TsidGenerator tsidGenerator) {
+		this.tsidGenerator = tsidGenerator;
+	}
+
+	public long act() {
+		return tsidGenerator.generate();
+	}
+
+}

--- a/core/id-generator/tsid/src/test/java/me/nalab/core/idgenerator/tsid/TsidConfigurer.java
+++ b/core/id-generator/tsid/src/test/java/me/nalab/core/idgenerator/tsid/TsidConfigurer.java
@@ -1,0 +1,21 @@
+package me.nalab.core.idgenerator.tsid;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import me.nalab.core.idgenerator.tsid.engine.TsidEngine;
+
+@Configuration
+public class TsidConfigurer {
+
+	@Bean("defaultTsidGenerator")
+	TsidGenerator defaultTsidGenerator() {
+		return new TsidGenerator(TsidEngine.defaultEngine());
+	}
+
+	@Bean("threadTsidGenerator")
+	TsidGenerator threadTsidGenerator() {
+		return new TsidGenerator(TsidEngine.threadEngine());
+	}
+
+}

--- a/core/id-generator/tsid/src/test/java/me/nalab/core/idgenerator/tsid/TsidPerformanceTest.java
+++ b/core/id-generator/tsid/src/test/java/me/nalab/core/idgenerator/tsid/TsidPerformanceTest.java
@@ -1,0 +1,110 @@
+package me.nalab.core.idgenerator.tsid;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/*
+	bench 1.    Test1 : 142 / Test2 : 121
+	bench 2.    Test1 : 140 / Test2 : 129
+	bench 3.    Test1 : 143 / Test2 : 121
+	bench 4.    Test1 : 137 / Test2 : 121
+	bench 5.    Test1 : 166 / Test2 : 125
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {TsidConfigurer.class, ThreadTsidActor.class, DefaultTsidActor.class})
+class TsidPerformanceTest {
+
+	@Autowired
+	private ThreadTsidActor threadTsidActor;
+
+	@Autowired
+	private DefaultTsidActor defaultTsidActor;
+
+	private static final Logger LOGGER = Logger.getLogger(TsidPerformanceTest.class.getSimpleName());
+
+	@Test
+	@DisplayName("[TEST 1] : Default Tsid Generator 성능, id 중복 테스트")
+	void DEFAULT_TSID_ACTOR_PERFORMANCE_AND_DUPLICATION_MEASURE() {
+		// given
+		int expectedGeneratedId = 10000;
+		ExecutorService executorService = Executors.newFixedThreadPool(255);
+		List<Callable<Long>> defaultTsidRunnerList = getDefaultTsidRunner(expectedGeneratedId);
+
+		// when & then
+		Instant beforeTime = Instant.now();
+
+		Awaitility.waitAtMost(Duration.ofMillis(10000))
+			.until(() -> generateId(executorService, defaultTsidRunnerList).size(),
+				Matchers.equalTo(expectedGeneratedId));
+
+		Instant afterTime = Instant.now();
+
+		// measure
+		LOGGER.info(() -> "[TEST 1] : " + Duration.between(beforeTime, afterTime).toMillis());
+	}
+
+	@Test
+	@DisplayName("[TEST 2] : THREAD Tsid Generator 성능, id 중복 테스트")
+	void THREAD_TSID_ACTOR_PERFORMANCE_AND_DUPLICATION_MEASURE() {
+		// given
+		int expectedGeneratedId = 10000;
+		ExecutorService executorService = Executors.newFixedThreadPool(255);
+		List<Callable<Long>> defaultTsidRunnerList = getThreadTsidRunner(expectedGeneratedId);
+
+		// when & then
+		Instant beforeTime = Instant.now();
+
+		Awaitility.waitAtMost(Duration.ofMillis(10000))
+			.until(() -> generateId(executorService, defaultTsidRunnerList).size(),
+				Matchers.equalTo(expectedGeneratedId));
+
+		Instant afterTime = Instant.now();
+
+		// measure
+		LOGGER.info(() -> "[TEST 2] : " + Duration.between(beforeTime, afterTime).toMillis());
+	}
+
+	private List<Callable<Long>> getDefaultTsidRunner(int size) {
+		List<Callable<Long>> ans = new ArrayList<>();
+		for(int i = 0; i < size; i++) {
+			ans.add(defaultTsidActor::act);
+		}
+		return ans;
+	}
+
+	private List<Callable<Long>> getThreadTsidRunner(int size) {
+		List<Callable<Long>> ans = new ArrayList<>();
+		for(int i = 0; i < size; i++) {
+			ans.add(threadTsidActor::act);
+		}
+		return ans;
+	}
+
+	private Set<Long> generateId(ExecutorService executorService, List<Callable<Long>> callableList) throws Exception {
+		Set<Long> ans = new HashSet<>();
+		List<Future<Long>> futureList = executorService.invokeAll(callableList);
+		for(Future<Long> future : futureList) {
+			ans.add(future.get());
+		}
+		return ans;
+	}
+
+}

--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -32,3 +32,4 @@ exclude me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper
 exclude me/nalab/survey/web/adaptor/createfeedback/**
 exclude me/nalab/survey/web/adaptor/summaryreviewer/**
 exclude me/nalab/survey/web/adaptor/findfeedback/**
+exclude me/nalab/core/idgenerator/tsid/engine/TsidEngine

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,8 +29,8 @@ include 'auth:mock'
 
 include 'core:id-generator'
 include 'core:id-generator:id-core'
+include 'core:id-generator:tsid'
 include 'core:id-generator:mock-id-generator'
 include 'core:id-generator:id-generator-starter'
 
 include 'core:exception-handler'
-


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Id Generator로 `TSID(Time Sorted Id Generator)` 를 추가했습니다.

`TSID?`
twitter의 snowflake 알고리즘과 ulid를 기반으로 만들어 졌다고 하는데요
`(__________) (_____) (________)`
`( timestamp ) ( node ) (sequential)` 
로 이루어져있고(snowflake랑 차이는 모르겠음), 벤치마킹과 스타가 준수하길래 이거로 가져왔습니다.

## 어떻게 해결했나요?
- [x] 256개의 스레드에 대해서, 동시성 문제가 발생하지 않도록 만들었습니다. 
		(1024, 4096 까지 가능은 한데, 그럼 성능이 내려가서 256으로 만들었어요 나중에 저희 서비스가 동접 256뚫으면 늘리면 될듯? 합니다)
- [x] 10000개의 클라이언트, 255개의 thread에 대해서, 퍼포먼스, 동시성 테스트를 진행했습니다.
- [x] 현재 default로 설정되어있는 mock id generator를 제거하고, tsid generator를 연결했습니다. 
		(이제, 모든 테스트가 이 generator 기반으로 돌아갑니다.) 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
[TSID library](https://github.com/f4b6a3/tsid-creator)