### PR TITLE
[feat] : 개별 피드백 응답 조회 - `인수테스트` 작성

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
@@ -69,6 +69,15 @@ public abstract class AbstractFeedbackTestSupporter extends AbstractSurveyTestSu
 		);
 	}
 
+	protected ResultActions findSpecific(String token, Long feedbackId) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.get("/v1/feedbacks/" + feedbackId)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header(HttpHeaders.AUTHORIZATION, token)
+		);
+	}
+
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -103,4 +103,22 @@ public final class FeedbackAcceptanceValidator {
 		);
 	}
 
+	public static void assertIsSpecificFound(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.feedback_id").isNumber(),
+			jsonPath("$.created_at").isString(),
+			jsonPath("$.reviewer.nickname").isString(),
+			jsonPath("$.reviewer.collaboration_experience").isBoolean(),
+			jsonPath("$.reviewer.position").isString(),
+			jsonPath("$.question").isArray(),
+			jsonPath("$.question[0].question_id").isNumber(),
+			jsonPath("$.question[0].type").isString(),
+			jsonPath("$.question[0].title").isString(),
+			jsonPath("$.question[0].order").isNumber(),
+			jsonPath("$.question[0].is_read").isBoolean()
+		);
+	}
+
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
@@ -1,0 +1,156 @@
+package me.nalab.luffy.api.acceptance.test.feedback.findspecific;
+
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.assertIsSpecificFound;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.feedback.AbstractFeedbackTestSupporter;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.AbstractQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ChoiceQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.FeedbackCreateRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ReviewerRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ShortQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.ChoiceFormQuestionResponse;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.ShortFormQuestionResponse;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.SurveyFindResponse;
+import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+public class SpecificFindAcceptanceTest extends AbstractFeedbackTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	private static final ObjectMapper OBJECT_MAPPER;
+
+	static {
+		OBJECT_MAPPER = new ObjectMapper();
+		OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+	}
+
+	@Test
+	@DisplayName("개별 피드백 상세 응답 조회 테스트")
+	void FIND_SPECIFIC_FEEDBACK_SUCCESS_TEST() throws Exception {
+
+		// given
+		String token = "token";
+		Long targetId = targetInitializer.saveTargetAndGetId("sujin", LocalDateTime.now());
+		applicationEventPublisher.publishEvent(
+			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());
+
+		Long surveyId = createSurveyAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+		SurveyFindResponse surveyFindResponse = getSurveyFindResponse(surveyId);
+
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "programmer");
+		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
+
+		Long feedbackId = findFeedbackAndGetRandomFeedbackId(token, surveyId);
+
+		// when
+		ResultActions resultActions = findSpecific(token, feedbackId);
+
+		// then
+		assertIsSpecificFound(resultActions);
+	}
+
+	private Long findFeedbackAndGetRandomFeedbackId(String token, Long surveyId) throws Exception {
+		String stringResponse = findFeedback(token, surveyId).andReturn()
+			.getResponse()
+			.getContentAsString();
+		JSONObject jsonObject = new JSONObject(stringResponse);
+		return jsonObject.getJSONArray("question_feedback").getJSONObject(0).getJSONArray("feedbacks")
+			.getJSONObject(0).getLong("feedback_id");
+	}
+
+	private Long createSurveyAndGetSurveyId(String token, String content) throws Exception {
+
+		String stringResponse = createSurvey(token, content).andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		JSONObject jsonObject = new JSONObject(stringResponse);
+		return jsonObject.getLong("survey_id");
+	}
+
+	private SurveyFindResponse getSurveyFindResponse(Long surveyId) throws Exception {
+		ResultActions resultActions = findSurvey(surveyId);
+		return OBJECT_MAPPER.readValue(resultActions.andReturn().getResponse().getContentAsString(),
+			SurveyFindResponse.class);
+	}
+
+	public static FeedbackCreateRequest getFeedbackCreateRequest(SurveyFindResponse surveyFindResponse,
+		boolean collaborationExperience, String position) {
+		return FeedbackCreateRequest.builder()
+			.reviewerRequest(getReviewerRequest(collaborationExperience, position))
+			.abstractQuestionFeedbackRequests(getQuestionFeedbackRequestList(surveyFindResponse))
+			.build();
+	}
+
+	private static ReviewerRequest getReviewerRequest(boolean collaborationExperience, String position) {
+		return ReviewerRequest.builder()
+			.collaborationExperience(collaborationExperience)
+			.position(position)
+			.build();
+	}
+
+	private static List<AbstractQuestionFeedbackRequest> getQuestionFeedbackRequestList(
+		SurveyFindResponse surveyFindResponse) {
+
+		return surveyFindResponse.getQuestion().stream()
+			.map(q -> {
+				if(q instanceof ShortFormQuestionResponse) {
+					return getShortQuestionFeedbackRequest((ShortFormQuestionResponse)q);
+				}
+				return getChoiceQuestionFeedbackRequest((ChoiceFormQuestionResponse)q);
+			})
+			.collect(Collectors.toList());
+	}
+
+	private static ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
+		ShortFormQuestionResponse shortFormQuestionResponse) {
+		return ShortQuestionFeedbackRequest.builder()
+			.questionId(shortFormQuestionResponse.getQuestionId())
+			.replyList(List.of("mocking", "words", "hello!"))
+			.type("short")
+			.build();
+	}
+
+	private static ChoiceQuestionFeedbackRequest getChoiceQuestionFeedbackRequest(
+		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
+		return ChoiceQuestionFeedbackRequest.builder()
+			.type("choice")
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.build();
+	}
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?

개별 피드백에 대한 응답 조회 API에 대한 인수테스트를 작성했습니다

- [x]  /feedback/findspecific 패키지에 **개별 피드백 응답 조회** `인수테스트` 클래스를 생성했습니다
- [x] `FeedbackAcceptanceValidator` 에 요청로직에 대한 validation 로직을 추가했습니다 -> `assertIsSpecificFound`
- [x] `AbstractFeedbackTestSupporter` 에 요청로직을 추가했습니다 -> `findSpecific`


## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
