### PR TITLE
[feat] : 개별 피드백 응답 조회 - `Application` 구현 완료

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/exception/FeedbackDoesNotExistException.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/exception/FeedbackDoesNotExistException.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.application.exception;
+
+import lombok.Getter;
+
+public class FeedbackDoesNotExistException extends RuntimeException {
+
+	@Getter
+	private final Long feedbackId;
+
+	public FeedbackDoesNotExistException(Long feedbackId) {
+		super("Cannot find any feedbackId \"" + feedbackId);
+		this.feedbackId = feedbackId;
+	}
+
+	@Override
+	public synchronized Throwable fillInStackTrace() {
+		return this;
+	}
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/exception/SurveyDoesNotHasTargetException.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/exception/SurveyDoesNotHasTargetException.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.application.exception;
+
+import lombok.Getter;
+
+public class SurveyDoesNotHasTargetException extends RuntimeException {
+
+	@Getter
+	private final Long surveyId;
+
+	public SurveyDoesNotHasTargetException(Long surveyId) {
+		super("Cannot find any targetId from survey \"" + surveyId + "\"");
+		this.surveyId = surveyId;
+	}
+
+	@Override
+	public synchronized Throwable fillInStackTrace() {
+		return this;
+	}
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/findspecific/SpecificFindUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/findspecific/SpecificFindUseCase.java
@@ -1,0 +1,26 @@
+package me.nalab.survey.application.port.in.web.findspecific;
+
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.survey.dto.SurveyDto;
+
+/**
+ * 개별 Feedback의 구체 정보를 반환하는 UseCase 입니다.
+ */
+public interface SpecificFindUseCase {
+
+	/**
+	 * feedbackId를 입력으로 받아, feedbackId에 해당하는 FeedbackDto를 반환합니다.
+	 *
+	 * @param feedbackId Feedback의 id
+	 * @return FeedbackDto, Feedback을 FeedbackDto로 변환한 Dto type 을 반환합니다.
+	 */
+	FeedbackDto findFeedbackByFeedbackId(Long feedbackId);
+
+	/**
+	 * surveyId를 입력으로 받아, surveyId에 해당하는 SurveyDto를 반환합니다.
+	 *
+	 * @param surveyId survey의 id
+	 * @return SurveyDto, Survey를 SurveyDto로 변환한 Dto type 을 반환합니다.
+	 */
+	SurveyDto findSurveyBySurveyId(Long surveyId);
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findspecific/FeedbackFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findspecific/FeedbackFindPort.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.application.port.out.persistence.findspecific;
+
+import java.util.Optional;
+
+import me.nalab.survey.domain.feedback.Feedback;
+
+/**
+ * feedbackId를 받아 Feedback을 찾는 역할을 하는 인터페이스 입니다.
+ */
+public interface FeedbackFindPort {
+
+	/**
+	 * feedbackId에 해당하는 Feedback을 조회합니다.
+	 *
+	 * @param feedbackId feedback을 조회할 feedback의 ID
+	 * @return Optional 만약, 어떠한 feedbackId도 없을 경우, Optional.empty() 를 반환해야 합니다.
+	 */
+	Optional<Feedback> findFeedback(Long feedbackId);
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findspecific/SurveyFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findspecific/SurveyFindPort.java
@@ -1,0 +1,27 @@
+package me.nalab.survey.application.port.out.persistence.findspecific;
+
+import java.util.Optional;
+
+import me.nalab.survey.domain.survey.Survey;
+
+/**
+ * surveyId를 받아 Survey를 찾는 역할을 하는 인터페이스 입니다.
+ */
+public interface SurveyFindPort {
+
+	/**
+	 * surveyId에 해당하는 Survey를 조회합니다.
+	 *
+	 * @param surveyId survey를 조회할 Survey의 ID
+	 * @return Optional 만약, 어떠한 surveyId도 없을 경우, Optional.empty() 를 반환해야 합니다.
+	 */
+	Optional<Survey> findSurvey(Long surveyId);
+
+	/**
+	 * surveyId에 해당하는 Target의 id를 조회합니다.
+	 *
+	 * @param surveyId survey의 ID
+	 * @return Optional 만약, 어떠한 targetId도 없을 경우, Optional.empty() 를 반환해야 합니다.
+	 */
+	Optional<Long> findTargetIdBySurveyId(Long surveyId);
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/findspecific/SpecificFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/findspecific/SpecificFindService.java
@@ -1,0 +1,44 @@
+package me.nalab.survey.application.service.findspecific;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
+import me.nalab.survey.application.common.survey.dto.SurveyDto;
+import me.nalab.survey.application.common.survey.mapper.SurveyDtoMapper;
+import me.nalab.survey.application.exception.FeedbackDoesNotExistException;
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
+import me.nalab.survey.application.exception.SurveyDoesNotHasTargetException;
+import me.nalab.survey.application.port.in.web.findspecific.SpecificFindUseCase;
+import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackFindPort;
+import me.nalab.survey.application.port.out.persistence.findspecific.SurveyFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+
+@Service
+@RequiredArgsConstructor
+public class SpecificFindService implements SpecificFindUseCase {
+
+	private final FeedbackFindPort feedbackFindPort;
+	private final SurveyFindPort surveyFindPort;
+
+	@Override
+	public FeedbackDto findFeedbackByFeedbackId(Long feedbackId) {
+		Feedback feedback = feedbackFindPort.findFeedback(feedbackId).orElseThrow(() -> {
+			throw new FeedbackDoesNotExistException(feedbackId);
+		});
+		return FeedbackDtoMapper.toDto(feedback);
+	}
+
+	@Override
+	public SurveyDto findSurveyBySurveyId(Long surveyId) {
+		Survey survey = surveyFindPort.findSurvey(surveyId).orElseThrow(() -> {
+			throw new SurveyDoesNotExistException(surveyId);
+		});
+		Long targetId = surveyFindPort.findTargetIdBySurveyId(surveyId).orElseThrow(() -> {
+			throw new SurveyDoesNotHasTargetException(surveyId);
+		});
+		return SurveyDtoMapper.toSurveyDto(targetId, survey);
+	}
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/service/findspecific/SpecificFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/findspecific/SpecificFindServiceTest.java
@@ -1,0 +1,110 @@
+package me.nalab.survey.application.service.findspecific;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import me.nalab.survey.application.RandomFeedbackDtoFixture;
+import me.nalab.survey.application.RandomSurveyDtoFixture;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
+import me.nalab.survey.application.common.survey.dto.SurveyDto;
+import me.nalab.survey.application.common.survey.mapper.SurveyDtoMapper;
+import me.nalab.survey.application.exception.FeedbackDoesNotExistException;
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
+import me.nalab.survey.application.exception.SurveyDoesNotHasTargetException;
+import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackFindPort;
+import me.nalab.survey.application.port.out.persistence.findspecific.SurveyFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+
+class SpecificFindServiceTest {
+
+	private SpecificFindService specificFindService;
+
+	@Mock
+	private FeedbackFindPort feedbackFindPort;
+
+	@Mock
+	private SurveyFindPort surveyFindPort;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		specificFindService = new SpecificFindService(feedbackFindPort, surveyFindPort);
+	}
+
+	@Test
+	void FIND_FEEDBACK_BY_FEEDBACKID_WITH_EXISTING_FEEDBACK_ID() {
+		SurveyDto surveyDto = RandomSurveyDtoFixture.createRandomSurveyDto();
+		Survey survey = SurveyDtoMapper.toSurvey(surveyDto);
+		FeedbackDto feedbackDto = RandomFeedbackDtoFixture.getRandomFeedbackDtoBySurvey(survey);
+		Feedback feedback = FeedbackDtoMapper.toDomain(survey, feedbackDto);
+		Long feedbackId = feedback.getId();
+		when(feedbackFindPort.findFeedback(feedbackId)).thenReturn(Optional.of(feedback));
+
+		FeedbackDto resultFeedbackDto = specificFindService.findFeedbackByFeedbackId(feedbackId);
+
+		assertAll(
+			() -> assertEquals(feedbackDto.getId(), resultFeedbackDto.getId()),
+			() -> assertEquals(feedbackDto.getSurveyId(), resultFeedbackDto.getSurveyId()),
+			() -> assertEquals(feedbackDto.getReviewerDto(), resultFeedbackDto.getReviewerDto()),
+			() -> assertEquals(feedbackDto.getFormQuestionFeedbackDtoableList(),
+				resultFeedbackDto.getFormQuestionFeedbackDtoableList())
+		);
+	}
+
+	@Test
+	void FIND_FEEDBACK_BY_FEEDBACKID_WITH_NON_EXISTING_FEEDBACK_ID() {
+
+		Long feedbackId = 1L;
+		when(feedbackFindPort.findFeedback(feedbackId)).thenReturn(Optional.empty());
+
+		assertThrows(FeedbackDoesNotExistException.class,
+			() -> specificFindService.findFeedbackByFeedbackId(feedbackId));
+	}
+
+	@Test
+	void FIND_SURVEY_WITH_EXISTING_SURVEY_ID() {
+		SurveyDto surveyDto = RandomSurveyDtoFixture.createRandomSurveyDto();
+		Survey survey = SurveyDtoMapper.toSurvey(surveyDto);
+		Long targetId = surveyDto.getTargetId();
+		Long surveyId = survey.getId();
+		when(surveyFindPort.findSurvey(surveyId)).thenReturn(Optional.of(survey));
+		when(surveyFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.of(targetId));
+
+		SurveyDto resultSurveyDto = specificFindService.findSurveyBySurveyId(surveyId);
+
+		assertEquals(surveyId, resultSurveyDto.getId());
+		assertEquals(targetId, resultSurveyDto.getTargetId());
+	}
+
+	@Test
+	void FIND_SURVEY_BY_SURVEY_ID_WITH_NON_EXISTING_SURVEY_ID() {
+		Long surveyId = 1L;
+
+		when(surveyFindPort.findSurvey(surveyId)).thenReturn(Optional.empty());
+
+		assertThrows(SurveyDoesNotExistException.class,
+			() -> specificFindService.findSurveyBySurveyId(surveyId));
+	}
+
+	@Test
+	void FIND_SURVEY_BY_SURVEY_ID_WITH_NON_EXISTING_TARGET_ID() {
+		Long surveyId = 1L;
+		SurveyDto surveyDto = RandomSurveyDtoFixture.createRandomSurveyDto();
+		Survey survey = SurveyDtoMapper.toSurvey(surveyDto);
+
+		when(surveyFindPort.findSurvey(surveyId)).thenReturn(Optional.of(survey));
+		when(surveyFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.empty());
+
+		assertThrows(SurveyDoesNotHasTargetException.class,
+			() -> specificFindService.findSurveyBySurveyId(surveyId));
+	}
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
개별 피드백에 대한 응답 조회 API에 대한 application 부분을 개발 완료했습니다

- [x] in port 에서 **개별 피드백 응답 조회** 유즈케이스의 interface인 `SpecificFindUseCase` 정의하고, 이의 구현체 를 만들었습니다
- [x] 구현체에서 발생할 수 있는 예외 클래스를 작성했습니다 - `FeedbackDoesNotExistException,` `SurveyDoesNotHasTargetException`
- [x] 그리고 이의 테스트를 구현하였습니다 - 테스트는 예외 케이스까지 모두 검증하였습니다
- [x] out persistence 에서 port 인터페이스를 정의하였습니다

## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
