### PR TITLE
fix jpa auditing

### DIFF
--- a/core/data/src/main/java/me/nalab/core/data/common/TimeBaseEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/common/TimeBaseEntity.java
@@ -4,9 +4,8 @@ import java.time.LocalDateTime;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
-
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,12 +17,23 @@ import lombok.experimental.SuperBuilder;
 @MappedSuperclass
 public abstract class TimeBaseEntity {
 
-	@CreatedDate
-	@Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
+	@Column(name = "created_at", columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
 	protected LocalDateTime createdAt;
 
-	@LastModifiedDate
-	@Column(name = "updated_at", columnDefinition = "TIMESTAMP", nullable = false)
+	@Column(name = "updated_at", columnDefinition = "TIMESTAMP(6)", nullable = false)
 	protected LocalDateTime updatedAt;
+
+	@PrePersist
+ 	void prePersist() {
+		var now = LocalDateTime.now();
+
+		createdAt = createdAt != null ? createdAt : now;
+		updatedAt = updatedAt != null ? updatedAt : now;
+	}
+
+	@PreUpdate
+	void preUpdate() {
+		updatedAt = updatedAt != null ? updatedAt : LocalDateTime.now();
+	}
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?

- createdAt, updatedAt 자동 값 넣는 기능 구현

## 어떻게 해결했나요?

- 동작하지 않는 jpa auditing을 제거하고 javax.persistence의 callBack을 이용하여 구현

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료

- [javax.persistence의 callBack](https://docs.jboss.org/hibernate/orm/6.2/userguide/html_single/Hibernate_User_Guide.html#events-jpa-callbacks)