### PR TITLE
[feat] : 개별 피드백 응답 조회 - `jpa-adaptor` 구현 완료

### DIFF
--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -22,6 +22,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.out.persistence.feedbackreviewers;
 	exports me.nalab.survey.application.service.feedbackreviewers;
 	exports me.nalab.survey.application.common.feedback.mapper;
+	exports me.nalab.survey.application.port.out.persistence.findspecific;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackFindAdaptor.java
@@ -1,0 +1,28 @@
+package me.nalab.survey.jpa.adaptor.findspecific;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.findspecific.repository.FeedbackFindJpaRepository;
+
+@Repository("findspecific.FeedbackFindAdaptor")
+@RequiredArgsConstructor
+public class FeedbackFindAdaptor implements FeedbackFindPort {
+
+	private final FeedbackFindJpaRepository feedbackFindJpaRepository;
+
+	@Override
+	public Optional<Feedback> findFeedback(Long feedbackId) {
+		Optional<FeedbackEntity> feedbackEntity = feedbackFindJpaRepository.findById(feedbackId);
+		if(feedbackEntity.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(FeedbackEntityMapper.toDomain(feedbackEntity.get()));
+	}
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/SurveyFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/SurveyFindAdaptor.java
@@ -1,0 +1,37 @@
+package me.nalab.survey.jpa.adaptor.findspecific;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.survey.application.port.out.persistence.findspecific.SurveyFindPort;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+import me.nalab.survey.jpa.adaptor.findspecific.repository.SurveyFindJpaRepository;
+
+@Repository("findspecific.SurveyFindAdaptor")
+@RequiredArgsConstructor
+public class SurveyFindAdaptor implements SurveyFindPort {
+
+	private final SurveyFindJpaRepository surveyFindJpaRepository;
+
+	@Override
+	public Optional<Survey> findSurvey(Long surveyId) {
+		Optional<SurveyEntity> surveyEntity = surveyFindJpaRepository.findById(surveyId);
+		if(surveyEntity.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(SurveyEntityMapper.toSurvey(surveyEntity.get()));
+	}
+
+	@Override
+	public Optional<Long> findTargetIdBySurveyId(Long surveyId) {
+		Optional<SurveyEntity> surveyEntity = surveyFindJpaRepository.findById(surveyId);
+		if(surveyEntity.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(surveyEntity.get().getTargetId());
+	}
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/repository/FeedbackFindJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/repository/FeedbackFindJpaRepository.java
@@ -1,0 +1,10 @@
+package me.nalab.survey.jpa.adaptor.findspecific.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+@Repository("findspecific.FeedbackFindJpaRepository")
+public interface FeedbackFindJpaRepository extends JpaRepository<FeedbackEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/repository/SurveyFindJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/repository/SurveyFindJpaRepository.java
@@ -1,0 +1,10 @@
+package me.nalab.survey.jpa.adaptor.findspecific.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+@Repository("findspecific.SurveyFindJpaRepository")
+public interface SurveyFindJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackFindAdaptorTest.java
@@ -1,0 +1,59 @@
+package me.nalab.survey.jpa.adaptor.findspecific;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = FeedbackFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class FeedbackFindAdaptorTest {
+
+	@Autowired
+	private FeedbackFindPort feedbackFindPort;
+
+	@Autowired
+	private TestFeedbackFindJpaRepository testFeedbackFindJpaRepository;
+
+	@Test
+	void FIND_FEEDBACK_WITH_SUCCESS() {
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		Feedback feedback = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
+		FeedbackEntity feedbackEntity = FeedbackEntityMapper.toEntity(feedback);
+		testFeedbackFindJpaRepository.save(feedbackEntity);
+
+		Optional<Feedback> resultFeedback = feedbackFindPort.findFeedback(feedback.getId());
+
+		assertTrue(resultFeedback.isPresent());
+		assertEquals(feedback, resultFeedback.get());
+	}
+
+	@Test
+	void FIND_FEEDBACK_WITH_FAIL() {
+
+		Long nonExistentFeedbackId = 999L;
+
+		Optional<Feedback> resultFeedback = feedbackFindPort.findFeedback(nonExistentFeedbackId);
+
+		assertTrue(resultFeedback.isEmpty());
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/SurveyFindAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/SurveyFindAdaptorTest.java
@@ -1,0 +1,82 @@
+package me.nalab.survey.jpa.adaptor.findspecific;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.survey.application.port.out.persistence.findspecific.SurveyFindPort;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = SurveyFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class SurveyFindAdaptorTest {
+
+	@Autowired
+	private SurveyFindPort surveyFindPort;
+
+	@Autowired
+	private TestSurveyFindJpaRepository testSurveyFindJpaRepository;
+
+	@Test
+	void FIND_SURVEY_WITH_SUCCESS() {
+
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		Long surveyId = survey.getId();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(surveyId, survey);
+		testSurveyFindJpaRepository.save(surveyEntity);
+
+		Optional<Survey> resultSurvey = surveyFindPort.findSurvey(surveyId);
+
+		assertTrue(resultSurvey.isPresent());
+		assertEquals(survey, resultSurvey.get());
+	}
+
+	@Test
+	void FIND_SURVEY_WITH_FAIL() {
+
+		Long nonExistentSurveyId = 999L;
+
+		Optional<Survey> resultSurvey = surveyFindPort.findSurvey(nonExistentSurveyId);
+
+		assertTrue(resultSurvey.isEmpty());
+	}
+
+	@Test
+	void FIND_TARGET_ID_BY_SURVEY_ID_WITH_SUCCESS() {
+		// given
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		Long surveyId = survey.getId();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(surveyId, survey);
+		testSurveyFindJpaRepository.save(surveyEntity);
+
+		Optional<Long> resultSurvey = surveyFindPort.findTargetIdBySurveyId(survey.getId());
+
+		// then
+		assertTrue(resultSurvey.isPresent());
+		assertEquals(surveyEntity.getTargetId(), resultSurvey.get());
+	}
+
+	@Test
+	void FIND_TARGET_ID_BY_SURVEY_ID_WITH_FAIL() {
+
+		Long nonExistentSurveyId = 999L;
+
+		Optional<Long> result = surveyFindPort.findTargetIdBySurveyId(nonExistentSurveyId);
+
+		assertTrue(result.isEmpty());
+	}
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/TestFeedbackFindJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/TestFeedbackFindJpaRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.findspecific;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+@Repository("findspecific.TestFeedbackFindJpaRepository")
+public interface TestFeedbackFindJpaRepository extends JpaRepository<FeedbackEntity, Long> {
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/TestSurveyFindJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/TestSurveyFindJpaRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.findspecific;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+@Repository("findspecific.TestSurveyFindJpaRepository")
+public interface TestSurveyFindJpaRepository extends JpaRepository<SurveyEntity, Long> {
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
개별 피드백에 대한 응답 조회 API에 대한 jpa-adaptor 부분을 개발 완료했습니다

- [x] port의 구현체인 `SurveyFindAdaptor`, `FeedbackFindAdaptor` 를 구현하고, 이를 이용하는 repository도 정의하였습니다
- [x] `SurveyFindAdaptor`, `FeedbackFindAdaptor`각각에 대한 테스트를 작성하고, 예외에 대한 테스트도 추가하였습니다


## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
