### PR TITLE
[fix] : sonar cloud에서 exclude 안되는 문제

### DIFF
--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -30,8 +30,8 @@ exclude me/nalab/survey/application/common/feedback/dto/ReviewerDto
 exclude me/nalab/survey/application/common/feedback/dto/ShortFormQuestionFeedbackDto
 exclude me/nalab/survey/application/common/feedback/mapper/FeedbackDtoMapper
 exclude me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper
-exclude me/nalab/survey/web/adaptor/createfeedback/**
-exclude me/nalab/survey/web/adaptor/summaryreviewer/**
-exclude me/nalab/survey/web/adaptor/findfeedback/**
-exclude me/nalab/survey/web/adaptor/findspecific/**
+exclude me/nalab/survey/web/adaptor/createfeedback/*
+exclude me/nalab/survey/web/adaptor/summaryreviewer/*
+exclude me/nalab/survey/web/adaptor/findfeedback/*
+exclude me/nalab/survey/web/adaptor/findspecific/*
 exclude me/nalab/core/idgenerator/tsid/engine/TsidEngine

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -1,20 +1,19 @@
 import java.util.stream.Collectors
 
-var excludeFromCoverage = new ArrayList<String>()
+StringBuilder excludeBuilder = new StringBuilder()
 file('coverage-exclude.luffy').withInputStream(){
-    it -> excludeFromCoverage.addAll(new BufferedReader(new InputStreamReader(it))
+    it -> new BufferedReader(new InputStreamReader(it))
             .lines()
             .parallel()
-            .map(s -> "**/" + s.substring(7).strip() + ".java")
-            .collect(Collectors.toList()))
+            .map(s -> '**/' + s.substring(7).strip() + '.java')
+            .forEach(s -> excludeBuilder.append('\'').append(s).append('\','))
 }
-
 
 sonar {
     properties {
         property 'sonar.host.url', 'https://sonarcloud.io'
         property 'sonar.organization', 'depromeet-1'
         property 'sonar.projectKey', 'depromeet_na-lab-server'
-        property 'sonar.coverage.exclusions', excludeFromCoverage.toArray()
+        property 'sonar.coverage.exclusions', "\"" + excludeBuilder.toString() + "\""
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
sonar cloud에서 exclude 안되는 문제를 해결...🙏 했습니다.

저희 exclude가 계속 안고쳐져서.. main 브랜치에서 커버리지 `69퍼`로 ci fail이 뜨더군요..(실제 커버리지는 95%) exclude.luffy에 넣으면 자동으로 sonar 커버리지에서 제외되도록 만들고 있는데.. 정 안되면 sonarcloud에 수동으로 해야할거 같습니다 

이거도 다른 브랜치 기능에 영향을 미치지는 않아서.. `squash merge` 하겠습니다.

## 어떻게 해결했나요?
- [x] 기존의 exclude정보를 Array 형태로 값을 전달하는것을 String 형태로 연결해서 전달하도록 변경했습니다.
- [x] class 명 표현식에 `**` 이 쓰이는것을 `*`로 쓰이도록 수정했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
