### PR TITLE
[chore] : Docker image publisher 생성

### DIFF
--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -1,9 +1,9 @@
 name: Docker image publisher
 
 on:
-  release:
-    types: 
-      - published
+  push:
+    branches: 
+      - release
     
 jobs:
   docker:

--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -46,6 +46,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          build-args: DB_URL=${{ secrets.DB_URL }}, DB_USERNAME=${{ secrets.DB_USERNAME }}, DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          build-args: [DB_URL=${{ secrets.DB_URL }}, DB_USERNAME=${{ secrets.DB_USERNAME }}, DB_PASSWORD=${{ secrets.DB_PASSWORD }}]
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -46,9 +46,9 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          build-args: 
-            - DB_URL=${{ secrets.DB_URL }} 
-            - DB_USERNAME=${{ secrets.DB_USERNAME }} 
-            - DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          build-args: |
+            DB_URL=${{ secrets.DB_URL }} 
+            DB_USERNAME=${{ secrets.DB_USERNAME }} 
+            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -2,9 +2,9 @@ name: Docker image publisher
 
 on:
   release:
-    tags:
-      - 'v*'
-
+    types: 
+      - published
+    
 jobs:
   docker:
     name: Push Docker image to Docker Hub

--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -1,12 +1,9 @@
 name: Docker image publisher
 
 on:
-  push:
+  release:
     tags:
       - 'v*'
-  pull_request: # 테스트용
-    branches:
-      - main
 
 jobs:
   docker:

--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -46,6 +46,9 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          build-args: DB_URL=${{ secrets.DB_URL }} DB_USERNAME=${{ secrets.DB_USERNAME }} DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          build-args: 
+            - DB_URL=${{ secrets.DB_URL }} 
+            - DB_USERNAME=${{ secrets.DB_USERNAME }} 
+            - DB_PASSWORD=${{ secrets.DB_PASSWORD }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -46,6 +46,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          build-args: [DB_URL=${{ secrets.DB_URL }}, DB_USERNAME=${{ secrets.DB_USERNAME }}, DB_PASSWORD=${{ secrets.DB_PASSWORD }}]
+          build-args: DB_URL=${{ secrets.DB_URL }} DB_USERNAME=${{ secrets.DB_USERNAME }} DB_PASSWORD=${{ secrets.DB_PASSWORD }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -1,0 +1,51 @@
+name: Docker image publisher
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request: # 테스트용
+    branches:
+      - main
+
+jobs:
+  docker:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Setup opnenjdk-11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Execute Gradle build
+        run: ./gradlew clean build
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.4.0
+        with:
+          images: samillmu/luffy
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          build-args: DB_URL=${{ secrets.DB_URL }}, DB_USERNAME=${{ secrets.DB_USERNAME }}, DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-labeler.yml
+++ b/.github/workflows/release-labeler.yml
@@ -1,0 +1,23 @@
+name: Release labeler
+
+on:
+  pull_request:
+    branches:
+      - release
+    types:
+      - opened
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: add label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: 🔖 release


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Docker image를 생성하고, Docker hub에 등록하는 workflow를 만들었습니다.
release PR의 경우 release 라벨이 붙도록 설정했습니다.

## 어떻게 해결했나요?
- [x] release가 publish되면, 해당 시점의 `default branch` 를 빌드해서, 도커 허브에 올리도록 만들었습니다. 
		추후에, `default branch`는 `main`에서 `release`로 변경해야할거 같아요
- [x] 위 과정에서, docker hub의 이미지에 등록되는 태그가 release에 등록되는 태그와 똑같도록 만들었습니다. 
		ex. `release tag v0.0.1` -> `samillmu/luffy:v0.0.1`
- [x] release branch로 가는 PR은 `🔖 release` 라벨이 붙도록 만들었습니다. 

## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
저희 release로 버전관리 하는거로 알고 있어서, release에 publish 되는 시점에 아래 flow처럼 만들려고 합니다..! 한번만 확인해주세요
`새로운 release 생성 및 태그 등록` -> `docker hub에 이미지 등록 CI` -> `code deploy CI` -> `실행`

## 참고자료
[github publish image to dockerhub and github package](https://docs.github.com/ko/actions/publishing-packages/publishing-docker-images)
[docker metadata action](https://github.com/marketplace/actions/docker-metadata-action)
[docker build and push action](https://github.com/marketplace/actions/build-and-push-docker-images)
[docker login action](https://github.com/marketplace/actions/docker-login)
[이 PR 테스트 과정에서 등록된 우리의 docker image](https://hub.docker.com/repository/docker/samillmu/luffy/general)