### PR TITLE
[feat] : JWT로 로그인된 유저 조회 기능 추가

### DIFF
--- a/auth/auth-application/src/main/java/me/nalab/auth/application/common/dto/Payload.java
+++ b/auth/auth-application/src/main/java/me/nalab/auth/application/common/dto/Payload.java
@@ -13,6 +13,7 @@ public class Payload {
 
 	public enum Key {
 		USER_ID,
+		TARGET_ID,
 		NICKNAME,
 	}
 }

--- a/auth/auth-application/src/main/java/me/nalab/auth/application/service/JwtLoginedDecryptService.java
+++ b/auth/auth-application/src/main/java/me/nalab/auth/application/service/JwtLoginedDecryptService.java
@@ -7,8 +7,8 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.auth.application.common.dto.Payload;
-import me.nalab.user.application.common.dto.LoginedInfo;
 import me.nalab.auth.application.common.utils.JwtUtils;
+import me.nalab.user.application.common.dto.LoginedInfo;
 import me.nalab.user.application.port.out.persistence.LoginedUserGetByTokenPort;
 
 @Service
@@ -19,7 +19,8 @@ public class JwtLoginedDecryptService implements LoginedUserGetByTokenPort {
 
 	@Override
 	public LoginedInfo decryptToken(String encryptedToken) {
-		Assert.isTrue(encryptedToken != null && !encryptedToken.isBlank(), "encryptedToken 으로 blank나 null 값이 들어올 수 없습니다.");
+		Assert.isTrue(encryptedToken != null && !encryptedToken.isBlank(),
+			"encryptedToken 으로 blank나 null 값이 들어올 수 없습니다.");
 		DecodedJWT decodedJWT = jwtUtils.verify(encryptedToken);
 		String nickName = decodedJWT.getClaim(Payload.Key.NICKNAME.name()).asString();
 		Long userId = decodedJWT.getClaim(Payload.Key.USER_ID.name()).asLong();

--- a/auth/auth-application/src/main/java/me/nalab/auth/application/service/JwtLoginedDecryptService.java
+++ b/auth/auth-application/src/main/java/me/nalab/auth/application/service/JwtLoginedDecryptService.java
@@ -1,0 +1,30 @@
+package me.nalab.auth.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.auth.application.common.dto.Payload;
+import me.nalab.user.application.common.dto.LoginedInfo;
+import me.nalab.auth.application.common.utils.JwtUtils;
+import me.nalab.user.application.port.out.persistence.LoginedUserGetByTokenPort;
+
+@Service
+@RequiredArgsConstructor
+public class JwtLoginedDecryptService implements LoginedUserGetByTokenPort {
+
+	private final JwtUtils jwtUtils;
+
+	@Override
+	public LoginedInfo decryptToken(String encryptedToken) {
+		Assert.isTrue(encryptedToken != null && !encryptedToken.isBlank(), "encryptedToken 으로 blank나 null 값이 들어올 수 없습니다.");
+		DecodedJWT decodedJWT = jwtUtils.verify(encryptedToken);
+		String nickName = decodedJWT.getClaim(Payload.Key.NICKNAME.name()).asString();
+		Long userId = decodedJWT.getClaim(Payload.Key.USER_ID.name()).asLong();
+		Long targetId = decodedJWT.getClaim(Payload.Key.TARGET_ID.name()).asLong();
+		return new LoginedInfo(nickName, userId, targetId);
+	}
+
+}

--- a/auth/auth-application/src/test/java/me/nalab/auth/application/service/JwtLoginedDecryptServiceTest.java
+++ b/auth/auth-application/src/test/java/me/nalab/auth/application/service/JwtLoginedDecryptServiceTest.java
@@ -1,6 +1,7 @@
 package me.nalab.auth.application.service;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.util.Set;
 
@@ -58,7 +59,8 @@ class JwtLoginedDecryptServiceTest {
 		assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
 	}
 
-	private void assertDecryptedInfo(LoginedInfo response, String expectedName, Long expectedUserId, Long expectedTargetId) {
+	private void assertDecryptedInfo(LoginedInfo response, String expectedName, Long expectedUserId,
+		Long expectedTargetId) {
 		Assertions.assertEquals(response.getNickName(), expectedName);
 		Assertions.assertEquals(response.getUserId(), expectedUserId);
 		Assertions.assertEquals(response.getTargetId(), expectedTargetId);

--- a/auth/auth-application/src/test/java/me/nalab/auth/application/service/JwtLoginedDecryptServiceTest.java
+++ b/auth/auth-application/src/test/java/me/nalab/auth/application/service/JwtLoginedDecryptServiceTest.java
@@ -1,0 +1,67 @@
+package me.nalab.auth.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.auth.application.common.dto.Payload;
+import me.nalab.auth.application.common.property.JwtProperties;
+import me.nalab.auth.application.common.utils.JwtUtils;
+import me.nalab.user.application.common.dto.LoginedInfo;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {JwtLoginedDecryptService.class, JwtUtils.class, JwtProperties.class})
+class JwtLoginedDecryptServiceTest {
+
+	@Autowired
+	private JwtLoginedDecryptService jwtLoginedDecryptService;
+
+	@Autowired
+	private JwtUtils jwtUtils;
+
+	@Test
+	@DisplayName("JWT 복호화 성공 테스트")
+	void JWT_DECRYPT_SUCCESS() {
+		// given
+		String nickName = "hello";
+		long userId = 12345;
+		long targetId = 54321;
+		String requestToken = jwtUtils.createAccessToken(
+			Set.of(new Payload(Payload.Key.NICKNAME, nickName), new Payload(Payload.Key.USER_ID, userId + ""),
+				new Payload(Payload.Key.TARGET_ID, targetId + "")));
+
+		// when
+		LoginedInfo response = jwtLoginedDecryptService.decryptToken(requestToken);
+
+		// then
+		assertDecryptedInfo(response, nickName, userId, targetId);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@DisplayName("token이 null이거나 empty면 예외를 던진다.")
+	void THROW_EXCEPTION_WHEN_TOKEN_IS_NULL_OR_EMPTY(String token) {
+		// when
+		Throwable throwable = catchThrowable(() -> jwtLoginedDecryptService.decryptToken(token));
+
+		// then
+		assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	private void assertDecryptedInfo(LoginedInfo response, String expectedName, Long expectedUserId, Long expectedTargetId) {
+		Assertions.assertEquals(response.getNickName(), expectedName);
+		Assertions.assertEquals(response.getUserId(), expectedUserId);
+		Assertions.assertEquals(response.getTargetId(), expectedTargetId);
+	}
+
+}

--- a/user/user-application/src/main/java/me/nalab/user/application/common/dto/LoginedInfo.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/common/dto/LoginedInfo.java
@@ -1,0 +1,12 @@
+package me.nalab.user.application.common.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginedInfo {
+
+	private final String nickName;
+	private final Long targetId;
+	private final Long userId;
+
+}

--- a/user/user-application/src/main/java/me/nalab/user/application/port/out/persistence/LoginedUserGetByTokenPort.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/port/out/persistence/LoginedUserGetByTokenPort.java
@@ -1,0 +1,18 @@
+package me.nalab.user.application.port.out.persistence;
+
+import me.nalab.user.application.common.dto.LoginedInfo;
+
+/**
+ * token을 받아 decrypt된 유저의 정보를 반환하는 유즈케이스
+ */
+public interface LoginedUserGetByTokenPort {
+
+	/**
+	 * 암호화된 유저의 토큰을 받아, 복호화된 유저의 정보를 반환합니다.
+	 *
+	 * @param encryptedToken 암호화된 토큰
+	 * @return 복호화된 정보
+	 */
+	LoginedInfo decryptToken(String encryptedToken);
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
JWT를 복호화해서 로그인된 유저를 추출하는 기능 추가
근데 슬랙에 올라와있는 property 이슈로 막혀있어요 ㅠㅠ 도진님 수정 pr 올라오면 나중에 merge 받고 squash 할깨용

## 어떻게 해결했나요?
- [x] `user-application` 모듈의 out.port에 복호화 포트를 추가했습니다.
- [x] `user-application` 모듈의 out.port에 복호화 포트를 구현하는 JwtLoginedDecryptService 를 `auth-application` 모듈에 추가했습니다.
- [x] 관련 테스트 코드를 추가했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
