### PR TITLE
[feat] : Login된 유저 조회 컨트롤러 추가

### DIFF
--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -42,3 +42,4 @@ exclude me/nalab/survey/web/adaptor/findspecific/*
 exclude me/nalab/user/application/common/dto/*
 exclude me/nalab/user/jpa/adaptor/**/common/mapper
 exclude me/nalab/auth/application/common/**/*
+exclude me/nalab/user/web/adaptor/logined/*

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,7 @@ include 'survey:jpa-adaptor'
 
 include 'auth'
 include 'auth:mock'
+include 'auth:auth-application'
 
 include 'core:id-generator'
 include 'core:id-generator:id-core'
@@ -42,5 +43,4 @@ include 'user'
 include 'user:user-domain'
 include 'user:user-jpa-adapter'
 include 'user:user-application'
-include 'auth:auth-application'
-
+include 'user:user-web-adaptor'

--- a/user/user-application/src/main/java/me/nalab/user/application/common/dto/LoginedInfo.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/common/dto/LoginedInfo.java
@@ -1,0 +1,12 @@
+package me.nalab.user.application.common.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginedInfo {
+
+	private final String nickName;
+	private final Long targetId;
+	private final Long userId;
+
+}

--- a/user/user-application/src/main/java/me/nalab/user/application/port/in/LoginedUserGetByTokenUseCase.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/port/in/LoginedUserGetByTokenUseCase.java
@@ -1,0 +1,18 @@
+package me.nalab.user.application.port.in;
+
+import me.nalab.user.application.common.dto.LoginedInfo;
+
+/**
+ * token을 받아 로그인된 유저의 정보를 반환하는 유즈케이스 입니다.
+ */
+public interface LoginedUserGetByTokenUseCase {
+
+	/**
+	 * 암호화된 유저의 토큰을 받아, 복호화된 유저의 정보를 반환합니다.
+	 *
+	 * @param encryptedToken 암호화된 토큰
+	 * @return 복호화된 정보
+	 */
+	LoginedInfo decryptToken(String encryptedToken);
+
+}

--- a/user/user-web-adaptor/build.gradle
+++ b/user/user-web-adaptor/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation project(':user:user-application');
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+}

--- a/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/LoginedUserGetController.java
+++ b/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/LoginedUserGetController.java
@@ -18,7 +18,7 @@ public class LoginedUserGetController {
 
 	private final LoginedUserGetByTokenUseCase loginedUserGetByTokenUseCase;
 
-	@GetMapping("/users")
+	@GetMapping("/users/logined")
 	public LoginedInfoResponse getLoginedUserByToken(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
 		LoginedInfo loginedInfo = loginedUserGetByTokenUseCase.decryptToken(token);
 

--- a/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/LoginedUserGetController.java
+++ b/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/LoginedUserGetController.java
@@ -1,0 +1,28 @@
+package me.nalab.user.web.adaptor.logined;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.user.application.common.dto.LoginedInfo;
+import me.nalab.user.application.port.in.LoginedUserGetByTokenUseCase;
+import me.nalab.user.web.adaptor.logined.response.LoginedInfoResponse;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class LoginedUserGetController {
+
+	private final LoginedUserGetByTokenUseCase loginedUserGetByTokenUseCase;
+
+	@GetMapping("/users")
+	public LoginedInfoResponse getLoginedUserByToken(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+		LoginedInfo loginedInfo = loginedUserGetByTokenUseCase.decryptToken(token);
+
+		return new LoginedInfoResponse(loginedInfo.getTargetId(), loginedInfo.getNickName());
+	}
+
+}

--- a/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/response/LoginedInfoResponse.java
+++ b/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/response/LoginedInfoResponse.java
@@ -1,0 +1,15 @@
+package me.nalab.user.web.adaptor.logined.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+public class LoginedInfoResponse {
+
+	@JsonProperty("target_id")
+	private final long targetId;
+	@JsonProperty("nickname")
+	private final String nickName;
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
login 된 유저를 조회하는 컨트롤러를 추가했습니다.

## 어떻게 해결했나요?
- [x] `GET /v1/users` 으로 요청이 오면, logined 된 유저를 반환하도록 만들었습니다.
- [x] 관련 response dto를 만들었습니다.
- [x] 컨트롤러는 컨벤션에 따라 테스트 커버리지에서 제외했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
