### PR TITLE
[refactor] : 로그인된 유저 조회 API url `users/logined`로 변경

### DIFF
--- a/api/api-mock/src/main/java/me/nalab/api/mock/MockController.java
+++ b/api/api-mock/src/main/java/me/nalab/api/mock/MockController.java
@@ -280,7 +280,7 @@ public class MockController {
 			+ "}";
 	}
 
-	@GetMapping("/users")
+	@GetMapping("/users/logined")
 	@ResponseStatus(HttpStatus.OK)
 	Object getLoginedUser() {
 		return "{\n"


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
로그인된 유저 조회 API를 `/users/logined`로 변경했습니다.

## 어떻게 해결했나요?
- [x] `/users/logined` 로 변경

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
