### PR TITLE
[feat] : 리뷰어 개별 응답 목록에서 피드백 읽음처리 기능 추가 (#186)

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/findspecific/SpecificFindUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/findspecific/SpecificFindUseCase.java
@@ -17,6 +17,13 @@ public interface SpecificFindUseCase {
 	FeedbackDto findFeedbackByFeedbackId(Long feedbackId);
 
 	/**
+	 * feedbackId를 입력으로 받아, 해당 Feedback의 isRead를 true로 변경합니다.
+	 *
+	 * @param feedbackId Feedback의 id
+	 */
+	void updateFeedbackIsReadByFeedbackId(Long feedbackId);
+
+	/**
 	 * surveyId를 입력으로 받아, surveyId에 해당하는 SurveyDto를 반환합니다.
 	 *
 	 * @param surveyId survey의 id

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findspecific/FeedbackUpdatePort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findspecific/FeedbackUpdatePort.java
@@ -1,5 +1,7 @@
 package me.nalab.survey.application.port.out.persistence.findspecific;
 
+import java.util.Optional;
+
 /**
  * 개별 피드백 조회 시 해당 피드백의 isRead 를 true로 변경하는 인터페이스 입니다.
  */
@@ -9,6 +11,7 @@ public interface FeedbackUpdatePort {
 	 * feedbackID에 해당하는 Feedback의 isRead를 true로 변환합니다.
 	 *
 	 * @param feedbackId Feedback의 ID
+	 * @return Optional 만약, feedbackId가 없는 경우, Optional.empty() 를 반환해야 합니다.
 	 */
-	void updateFeedbackIsReadByFeedbackId(Long feedbackId);
+	Optional<Long> updateFeedbackIsReadByFeedbackId(Long feedbackId);
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findspecific/FeedbackUpdatePort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/findspecific/FeedbackUpdatePort.java
@@ -1,0 +1,14 @@
+package me.nalab.survey.application.port.out.persistence.findspecific;
+
+/**
+ * 개별 피드백 조회 시 해당 피드백의 isRead 를 true로 변경하는 인터페이스 입니다.
+ */
+public interface FeedbackUpdatePort {
+
+	/**
+	 * feedbackID에 해당하는 Feedback의 isRead를 true로 변환합니다.
+	 *
+	 * @param feedbackId Feedback의 ID
+	 */
+	void updateFeedbackIsReadByFeedbackId(Long feedbackId);
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/findspecific/SpecificFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/findspecific/SpecificFindService.java
@@ -13,6 +13,7 @@ import me.nalab.survey.application.exception.SurveyDoesNotHasTargetException;
 import me.nalab.survey.application.port.in.web.findspecific.SpecificFindUseCase;
 import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackFindPort;
 import me.nalab.survey.application.port.out.persistence.findspecific.SurveyFindPort;
+import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackUpdatePort;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.survey.Survey;
 
@@ -23,12 +24,19 @@ public class SpecificFindService implements SpecificFindUseCase {
 	private final FeedbackFindPort feedbackFindPort;
 	private final SurveyFindPort surveyFindPort;
 
+	private final FeedbackUpdatePort feedbackUpdatePort;
+
 	@Override
 	public FeedbackDto findFeedbackByFeedbackId(Long feedbackId) {
 		Feedback feedback = feedbackFindPort.findFeedback(feedbackId).orElseThrow(() -> {
 			throw new FeedbackDoesNotExistException(feedbackId);
 		});
 		return FeedbackDtoMapper.toDto(feedback);
+	}
+
+	@Override
+	public void updateFeedbackIsReadByFeedbackId(Long feedbackId) {
+		feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(feedbackId);
 	}
 
 	@Override

--- a/survey/application/src/main/java/me/nalab/survey/application/service/findspecific/SpecificFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/findspecific/SpecificFindService.java
@@ -36,9 +36,9 @@ public class SpecificFindService implements SpecificFindUseCase {
 
 	@Override
 	public void updateFeedbackIsReadByFeedbackId(Long feedbackId) {
-		feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(feedbackId).orElseThrow(() -> {
+		if (feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(feedbackId).isEmpty()) {
 			throw new FeedbackDoesNotExistException(feedbackId);
-		});
+		}
 	}
 
 	@Override

--- a/survey/application/src/main/java/me/nalab/survey/application/service/findspecific/SpecificFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/findspecific/SpecificFindService.java
@@ -36,7 +36,9 @@ public class SpecificFindService implements SpecificFindUseCase {
 
 	@Override
 	public void updateFeedbackIsReadByFeedbackId(Long feedbackId) {
-		feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(feedbackId);
+		feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(feedbackId).orElseThrow(() -> {
+			throw new FeedbackDoesNotExistException(feedbackId);
+		});
 	}
 
 	@Override

--- a/survey/application/src/test/java/me/nalab/survey/application/service/findspecific/SpecificFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/findspecific/SpecificFindServiceTest.java
@@ -117,9 +117,20 @@ class SpecificFindServiceTest {
 	@Test
 	void UPDATE_FEEDBACK_IS_READ_BY_FEEDBACK_ID() {
 		Long feedbackId = 1L;
+		when(feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(feedbackId)).thenReturn(Optional.of(feedbackId));
 
 		specificFindService.updateFeedbackIsReadByFeedbackId(feedbackId);
 
 		verify(feedbackUpdatePort).updateFeedbackIsReadByFeedbackId(feedbackId);
+	}
+
+	@Test
+	void UPDATE_FEEDBACK_IS_READ_BY_NON_EXISTING_FEEDBACK_ID() {
+		Long feedbackId = 1L;
+
+		when(feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(feedbackId)).thenReturn(Optional.empty());
+
+		assertThrows(FeedbackDoesNotExistException.class,
+			() -> specificFindService.updateFeedbackIsReadByFeedbackId(feedbackId));
 	}
 }

--- a/survey/application/src/test/java/me/nalab/survey/application/service/findspecific/SpecificFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/findspecific/SpecificFindServiceTest.java
@@ -1,6 +1,7 @@
 package me.nalab.survey.application.service.findspecific;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -21,6 +22,7 @@ import me.nalab.survey.application.exception.SurveyDoesNotExistException;
 import me.nalab.survey.application.exception.SurveyDoesNotHasTargetException;
 import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackFindPort;
 import me.nalab.survey.application.port.out.persistence.findspecific.SurveyFindPort;
+import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackUpdatePort;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.survey.Survey;
 
@@ -34,10 +36,14 @@ class SpecificFindServiceTest {
 	@Mock
 	private SurveyFindPort surveyFindPort;
 
+	@Mock
+	private FeedbackUpdatePort feedbackUpdatePort;
+
+
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		specificFindService = new SpecificFindService(feedbackFindPort, surveyFindPort);
+		specificFindService = new SpecificFindService(feedbackFindPort, surveyFindPort, feedbackUpdatePort);
 	}
 
 	@Test
@@ -106,5 +112,14 @@ class SpecificFindServiceTest {
 
 		assertThrows(SurveyDoesNotHasTargetException.class,
 			() -> specificFindService.findSurveyBySurveyId(surveyId));
+	}
+
+	@Test
+	void UPDATE_FEEDBACK_IS_READ_BY_FEEDBACK_ID() {
+		Long feedbackId = 1L;
+
+		specificFindService.updateFeedbackIsReadByFeedbackId(feedbackId);
+
+		verify(feedbackUpdatePort).updateFeedbackIsReadByFeedbackId(feedbackId);
 	}
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackUpdateAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackUpdateAdaptor.java
@@ -1,0 +1,22 @@
+package me.nalab.survey.jpa.adaptor.findspecific;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.exception.FeedbackDoesNotExistException;
+import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackUpdatePort;
+import me.nalab.survey.jpa.adaptor.findspecific.repository.FeedbackFindJpaRepository;
+
+@Repository("findspecific.FeedbackUpdateAdaptor")
+@RequiredArgsConstructor
+public class FeedbackUpdateAdaptor implements FeedbackUpdatePort {
+
+	private final FeedbackFindJpaRepository feedbackFindJpaRepository;
+	@Override
+	public void updateFeedbackIsReadByFeedbackId(Long feedbackId) {
+		FeedbackEntity feedbackEntity = feedbackFindJpaRepository.findById(feedbackId)
+			.orElseThrow(() -> new FeedbackDoesNotExistException(feedbackId));
+		feedbackEntity.setRead(true);
+	}
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackUpdateAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackUpdateAdaptor.java
@@ -1,10 +1,11 @@
 package me.nalab.survey.jpa.adaptor.findspecific;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.core.data.feedback.FeedbackEntity;
-import me.nalab.survey.application.exception.FeedbackDoesNotExistException;
 import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackUpdatePort;
 import me.nalab.survey.jpa.adaptor.findspecific.repository.FeedbackFindJpaRepository;
 
@@ -14,9 +15,12 @@ public class FeedbackUpdateAdaptor implements FeedbackUpdatePort {
 
 	private final FeedbackFindJpaRepository feedbackFindJpaRepository;
 	@Override
-	public void updateFeedbackIsReadByFeedbackId(Long feedbackId) {
-		FeedbackEntity feedbackEntity = feedbackFindJpaRepository.findById(feedbackId)
-			.orElseThrow(() -> new FeedbackDoesNotExistException(feedbackId));
+	public Optional<Long> updateFeedbackIsReadByFeedbackId(Long feedbackId) {
+		Optional<FeedbackEntity> optionalFeedbackEntity = feedbackFindJpaRepository.findById(feedbackId);
+		if (optionalFeedbackEntity.isEmpty()) return Optional.empty();
+
+		FeedbackEntity feedbackEntity = optionalFeedbackEntity.get();
 		feedbackEntity.setRead(true);
+		return Optional.of(feedbackEntity.getId());
 	}
 }

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackUpdateAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackUpdateAdaptorTest.java
@@ -1,0 +1,59 @@
+package me.nalab.survey.jpa.adaptor.findspecific;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.exception.FeedbackDoesNotExistException;
+import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackUpdatePort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = FeedbackUpdateAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class FeedbackUpdateAdaptorTest {
+
+	@Autowired
+	private FeedbackUpdatePort feedbackUpdatePort;
+
+	@Autowired
+	private TestFeedbackFindJpaRepository testFeedbackFindJpaRepository;
+
+	@Test
+	void UPDATE_FEEDBACK_WITH_SUCCESS() {
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		Feedback feedback = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
+		FeedbackEntity feedbackEntity = FeedbackEntityMapper.toEntity(feedback);
+		FeedbackEntity savedFeedbackEntity = testFeedbackFindJpaRepository.save(feedbackEntity);
+
+		feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(savedFeedbackEntity.getId());
+
+		Optional<FeedbackEntity> resultFeedback = testFeedbackFindJpaRepository.findById(savedFeedbackEntity.getId());
+
+		assertTrue(resultFeedback.isPresent());
+		assertTrue(resultFeedback.get().isRead());
+	}
+
+	@Test
+	void UPDATE_FEEDBACK_WITH_FAIL() {
+		Long nonExistentFeedbackId = 999L;
+
+		assertThrows(FeedbackDoesNotExistException.class,
+			() -> feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(nonExistentFeedbackId));
+	}
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackUpdateAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findspecific/FeedbackUpdateAdaptorTest.java
@@ -13,7 +13,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 import me.nalab.core.data.feedback.FeedbackEntity;
-import me.nalab.survey.application.exception.FeedbackDoesNotExistException;
 import me.nalab.survey.application.port.out.persistence.findspecific.FeedbackUpdatePort;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.survey.Survey;
@@ -41,10 +40,10 @@ class FeedbackUpdateAdaptorTest {
 		FeedbackEntity feedbackEntity = FeedbackEntityMapper.toEntity(feedback);
 		FeedbackEntity savedFeedbackEntity = testFeedbackFindJpaRepository.save(feedbackEntity);
 
-		feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(savedFeedbackEntity.getId());
-
+		Optional<Long> feedbackId = feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(savedFeedbackEntity.getId());
 		Optional<FeedbackEntity> resultFeedback = testFeedbackFindJpaRepository.findById(savedFeedbackEntity.getId());
 
+		assertTrue(feedbackId.isPresent());
 		assertTrue(resultFeedback.isPresent());
 		assertTrue(resultFeedback.get().isRead());
 	}
@@ -53,7 +52,8 @@ class FeedbackUpdateAdaptorTest {
 	void UPDATE_FEEDBACK_WITH_FAIL() {
 		Long nonExistentFeedbackId = 999L;
 
-		assertThrows(FeedbackDoesNotExistException.class,
-			() -> feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(nonExistentFeedbackId));
+		Optional<Long> feedbackId = feedbackUpdatePort.updateFeedbackIsReadByFeedbackId(nonExistentFeedbackId);
+
+		assertTrue(feedbackId.isEmpty());
 	}
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/SpecificFeedbackController.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/SpecificFeedbackController.java
@@ -22,6 +22,7 @@ public class SpecificFeedbackController {
 	@GetMapping("/feedbacks/{feedback-id}")
 	public ResponseEntity<SpecificFeedbackResponse> getSpecificFeedback(@PathVariable("feedback-id") Long feedbackId) {
 		FeedbackDto feedbackDto = specificFindUseCase.findFeedbackByFeedbackId(feedbackId);
+		specificFindUseCase.updateFeedbackIsReadByFeedbackId(feedbackId);
 		SurveyDto surveyDto = specificFindUseCase.findSurveyBySurveyId(feedbackDto.getSurveyId());
 		SpecificFeedbackResponse specificFeedbackResponse = SpecificFeedbackResponseMapper.toSpecificFeedbackResponse(surveyDto, feedbackDto);
 		return ResponseEntity.ok(specificFeedbackResponse);


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?

읽음처리를 수행하는 부분은 다음의 두 부분입니다
[  `피드백에 대한 읽음 처리` ,  `피드백 각 문항에 대한 읽음 처리` ]
이 둘 중 (피드백 리스트에서) `피드백에 대한 읽음 처리`를 먼저 구현했습니다

해당 부분은 다음과 같습니다
<img width="227" alt="image" src="https://github.com/depromeet/na-lab-server/assets/71487608/0b43fc29-db2c-4c6e-863e-9e8186b70f85"> 

해당 기능은  `리뷰어의 개별 응답 조회`를 하였을 때에 피드백의 isRead 가 변경되도록 구현하였습니다
- [x] `개별 응답 조회` 유즈케이스에 `updateFeedbackIsReadByFeedbackId` 함수를 추가하였습니다
- [x] `FeedbackUpdatePort를` 추가하였습니다
- [x] 해당 포트의 구현체인 `FeedbackUpdateAdaptor를` 추가하였습니다
- [x]  `개별 응답 조회 `의 controller와 service 부분의 코드를 수정하였습니다
- [x] 테스트 코드를 수정 및 추가하였습니다

## 어떻게 해결했나요?


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
