### PR TITLE
[fix] : cors 호출시 header 제한 제거 핫픽스

### DIFF
--- a/core/secure/src/main/java/me/nalab/core/secure/CorsConfig.java
+++ b/core/secure/src/main/java/me/nalab/core/secure/CorsConfig.java
@@ -1,7 +1,6 @@
 package me.nalab.core.secure;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -15,7 +14,6 @@ class CorsConfig implements WebMvcConfigurer {
 		registry.addMapping("/**")
 			.allowedOrigins("*")
 			.allowedMethods(ALLOWED_METHOD_NAMES)
-			.exposedHeaders(HttpHeaders.LOCATION)
 			.maxAge(3600);
 	}
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
cors 호출시 Header 제한에 Location이 걸려있는 버그 수정

## 어떻게 해결했나요?
- [x] exposeHeader() 메소드를 제거했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
