### PR TITLE
[fix] : delete credentials

### DIFF
--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
@@ -17,6 +17,9 @@ public class JwtDecryptInterceptor implements HandlerInterceptor {
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		if(isPreflight(request)) {
+			return true;
+		}
 		if(!isExcludedURI(request)) {
 			String token = request.getHeader("Authorization");
 			throwIfCannotValidToken(token);
@@ -24,6 +27,10 @@ public class JwtDecryptInterceptor implements HandlerInterceptor {
 			request.setAttribute("logined", targetId);
 		}
 		return true;
+	}
+
+	private boolean isPreflight(HttpServletRequest request) {
+		return request.getMethod().equals("OPTIONS");
 	}
 
 	private boolean isExcludedURI(HttpServletRequest httpServletRequest) {

--- a/core/secure/src/main/java/me/nalab/core/secure/CorsConfig.java
+++ b/core/secure/src/main/java/me/nalab/core/secure/CorsConfig.java
@@ -14,14 +14,12 @@ class CorsConfig implements WebMvcConfigurer {
 		registry.addMapping("/v1/**")
 			.allowedOrigins("*")
 			.allowedHeaders("*")
-			.allowCredentials(true)
 			.allowedMethods(ALLOWED_METHOD_NAMES)
 			.maxAge(3600);
 
 		registry.addMapping("/mock/**")
 			.allowedOrigins("*")
 			.allowedHeaders("*")
-			.allowCredentials(true)
 			.allowedMethods(ALLOWED_METHOD_NAMES)
 			.maxAge(3600);
 	}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
cors 설정에 credentials를 넣은걸 제외 했습니다.
> Origins가 `*` 면 credentials를 true로 할 수 없음.


[트러블 슈팅]
JwtInterceptor가 OPTIONS메소드에 대해서도 적용되고 있었고, 인증이 필요한preflight에서 Authorization헤더가 비어있어 null pointer 예외가 발생한거 같습니다.
그래서, 응답으로 `500 Internal server error` + Cors 라는 조합이 뜬거 같아요

## 어떻게 해결했나요?
- [x] credentials 제거
- [x] JwtInterceptor가 OPTIONS HTTP Method에 대해서, 수행되지 않도록 했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
