### PR TITLE
[fix] : bearer 공백으로 제거

### DIFF
--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
@@ -23,7 +23,7 @@ public class JwtDecryptInterceptor implements HandlerInterceptor {
 		if(!isExcludedURI(request)) {
 			String token = request.getHeader("Authorization");
 			throwIfCannotValidToken(token);
-			Long targetId = targetIdGetPort.getTargetId(token);
+			Long targetId = targetIdGetPort.getTargetId(token.split(" ")[1]);
 			request.setAttribute("logined", targetId);
 		}
 		return true;


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
jwt에 공백을 함께 복호화 하는 버그 수정

## 어떻게 해결했나요?
- [x] Interceptor 에서, `bearer + " " + token` 의 공백을 기준으로 split 했습니다.
 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
