### PR TITLE
[fix] : 질문 폼의 피드백 요약정보 조회 API에서 예외처리 추가

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbacksummary/SurveyExistCheckPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbacksummary/SurveyExistCheckPort.java
@@ -1,0 +1,15 @@
+package me.nalab.survey.application.port.out.persistence.feedbacksummary;
+
+/**
+ * Survey가 존재하는지 확인하는 인터페이스 입니다.
+ */
+public interface SurveyExistCheckPort {
+
+	/**
+	 * surveyId 를 인자로 받아, survey가 저장되어 있다면 true, 아니라면 false를 반환하는 인터페이스 입니다.
+	 *
+	 * @param surveyId 조회할 survey의 id 입니다.
+	 * @return boolean survey가 있다면 true, 없다면 false를 반환해야 합니다.
+	 */
+	boolean isExistSurveyBySurveyId(Long surveyId);
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindService.java
@@ -3,7 +3,9 @@ package me.nalab.survey.application.service.findfeedbacksummary;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
 import me.nalab.survey.application.port.in.web.feedbacksummary.FeedbackSummaryFindUseCase;
+import me.nalab.survey.application.port.out.persistence.feedbacksummary.SurveyExistCheckPort;
 import me.nalab.survey.application.port.out.persistence.feedbacksummary.TotalFeedbackCountPort;
 import me.nalab.survey.application.port.out.persistence.feedbacksummary.UpdatedFeedbackCountPort;
 
@@ -14,13 +16,23 @@ public class FeedbackSummaryFindService implements FeedbackSummaryFindUseCase {
 	private final TotalFeedbackCountPort totalFeedbackCountPort;
 	private final UpdatedFeedbackCountPort updatedFeedbackCountPort;
 
+	private final SurveyExistCheckPort surveyExistCheckPort;
+
 	@Override
 	public long getTotalFeedbackCount(Long surveyId) {
+		checkIfSurveyExist(surveyId);
 		return totalFeedbackCountPort.getTotalFeedbackCountBySurveyId(surveyId);
 	}
 
 	@Override
 	public long getUpdatedFeedbackCount(Long surveyId) {
+		checkIfSurveyExist(surveyId);
 		return updatedFeedbackCountPort.getUpdatedFeedbackCountBySurveyId(surveyId);
+	}
+
+	private void checkIfSurveyExist(Long surveyId) {
+		if(!surveyExistCheckPort.isExistSurveyBySurveyId(surveyId)) {
+			throw new SurveyDoesNotExistException(surveyId);
+		}
 	}
 }

--- a/survey/application/src/test/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
+import me.nalab.survey.application.port.out.persistence.feedbacksummary.SurveyExistCheckPort;
 import me.nalab.survey.application.port.out.persistence.feedbacksummary.TotalFeedbackCountPort;
 import me.nalab.survey.application.port.out.persistence.feedbacksummary.UpdatedFeedbackCountPort;
 
@@ -20,12 +22,15 @@ class FeedbackSummaryFindServiceTest {
 	@Mock
 	private UpdatedFeedbackCountPort updatedFeedbackCountPort;
 
+	@Mock
+	private SurveyExistCheckPort surveyExistCheckPort;
+
 	private FeedbackSummaryFindService feedbackSummaryFindService;
 
 	@BeforeEach
 	void setup() {
 		MockitoAnnotations.openMocks(this);
-		feedbackSummaryFindService = new FeedbackSummaryFindService(totalFeedbackCountPort, updatedFeedbackCountPort);
+		feedbackSummaryFindService = new FeedbackSummaryFindService(totalFeedbackCountPort, updatedFeedbackCountPort, surveyExistCheckPort);
 	}
 
 	@Test
@@ -33,6 +38,7 @@ class FeedbackSummaryFindServiceTest {
 
 		Long surveyId = 1L;
 		long expectedCount = 10L;
+		when(surveyExistCheckPort.isExistSurveyBySurveyId(surveyId)).thenReturn(true);
 		when(totalFeedbackCountPort.getTotalFeedbackCountBySurveyId(surveyId)).thenReturn(expectedCount);
 
 		long actualCount = feedbackSummaryFindService.getTotalFeedbackCount(surveyId);
@@ -45,13 +51,10 @@ class FeedbackSummaryFindServiceTest {
 	void FEEDBACK_SUMMARY_FIND_SERVICE_FAIL_TEST() {
 
 		Long surveyId = 1L;
-		long expectedCount = 5L;
-		when(updatedFeedbackCountPort.getUpdatedFeedbackCountBySurveyId(surveyId)).thenReturn(expectedCount);
 
-		long actualCount = feedbackSummaryFindService.getUpdatedFeedbackCount(surveyId);
+		when(surveyExistCheckPort.isExistSurveyBySurveyId(surveyId)).thenReturn(false);
 
-		assertEquals(expectedCount, actualCount);
-		verify(updatedFeedbackCountPort).getUpdatedFeedbackCountBySurveyId(surveyId);
+		assertThrows(SurveyDoesNotExistException.class, () -> feedbackSummaryFindService.getTotalFeedbackCount(surveyId));
 	}
 
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/SurveyExistCheckAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/SurveyExistCheckAdaptor.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.jpa.adaptor.findfeedbacksummary;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.port.out.persistence.feedbacksummary.SurveyExistCheckPort;
+import me.nalab.survey.jpa.adaptor.findfeedbacksummary.repository.SurveyExistCheckJpaRepository;
+
+@Repository("findfeedbacksummary.SurveyExistCheckAdaptor")
+@RequiredArgsConstructor
+public class SurveyExistCheckAdaptor implements SurveyExistCheckPort {
+
+	private final SurveyExistCheckJpaRepository surveyExistCheckJpaRepository;
+
+	@Override
+	public boolean isExistSurveyBySurveyId(Long surveyId) {
+		return surveyExistCheckJpaRepository.existsById(surveyId);
+	}
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/repository/SurveyExistCheckJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/repository/SurveyExistCheckJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.findfeedbacksummary.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface SurveyExistCheckJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문 폼의 피드백 요약정보 조회 API에서 예외처리가 빠져있는 부분을 수정했습니다
<img width="597" alt="image" src="https://github.com/depromeet/na-lab-server/assets/71487608/13d4325c-ff66-45eb-a666-9a7ca08b2edb">
지금 예외처리 검토중인데 해당 부분의 예외처리가 빠져있어서 추가했습니다

## 어떻게 해결했나요?

## 이슈 넘버
- #194 


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
