### PR TITLE
[fix] : logined 된 유저 조회 수정

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/logined/LoginedTargetFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/logined/LoginedTargetFindAcceptanceTest.java
@@ -48,10 +48,10 @@ class LoginedTargetFindAcceptanceTest extends UserAcceptanceTestSupporter {
 		String token = jwtUtils.createAccessToken(Set.of(new Payload(Payload.Key.NICKNAME, nickname),
 			new Payload(Payload.Key.USER_ID, 12345 + ""), new Payload(Payload.Key.TARGET_ID, targetId + "")));
 		applicationEventPublisher.publishEvent(
-			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());
+			MockUserRegisterEvent.builder().expectedToken("bearer " + token).expectedId(targetId).build());
 
 		// when
-		ResultActions resultActions = getLoginedUser(token);
+		ResultActions resultActions = getLoginedUser("bearer " + token);
 
 		// then
 		assertIsLogined(resultActions, targetId, nickname);

--- a/user/user-application/src/main/java/me/nalab/user/application/exception/InvalidTokenException.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/exception/InvalidTokenException.java
@@ -1,0 +1,8 @@
+package me.nalab.user.application.exception;
+
+public final class InvalidTokenException extends RuntimeException{
+
+	public InvalidTokenException(String message) {
+		super(message);
+	}
+}

--- a/user/user-application/src/main/java/me/nalab/user/application/service/LoginedUserGetByTokenService.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/service/LoginedUserGetByTokenService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.user.application.common.dto.LoginedInfo;
+import me.nalab.user.application.exception.InvalidTokenException;
 import me.nalab.user.application.port.in.LoginedUserGetByTokenUseCase;
 import me.nalab.user.application.port.out.persistence.LoginedUserGetByTokenPort;
 
@@ -18,7 +19,15 @@ public class LoginedUserGetByTokenService implements LoginedUserGetByTokenUseCas
 	@Override
 	public LoginedInfo decryptToken(String encryptedToken) {
 		Objects.requireNonNull(encryptedToken, "encryptedToken은 null이 되면 안됩니다.");
-		return loginedUserGetByTokenPort.decryptToken(encryptedToken);
+		String[] split = encryptedToken.split(" ");
+		throwIfInvalidToken(split);
+		return loginedUserGetByTokenPort.decryptToken(split[1]);
+	}
+
+	private void throwIfInvalidToken(String[] split) {
+		if(split.length < 2) {
+			throw new InvalidTokenException(split[0]);
+		}
 	}
 
 }

--- a/user/user-application/src/test/java/me/nalab/user/application/service/LoginedUserGetByTokenServiceTest.java
+++ b/user/user-application/src/test/java/me/nalab/user/application/service/LoginedUserGetByTokenServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import me.nalab.user.application.common.dto.LoginedInfo;
+import me.nalab.user.application.exception.InvalidTokenException;
 import me.nalab.user.application.port.in.LoginedUserGetByTokenUseCase;
 import me.nalab.user.application.port.out.persistence.LoginedUserGetByTokenPort;
 
@@ -31,9 +32,9 @@ class LoginedUserGetByTokenServiceTest {
 	void GET_LOGINED_INFO_BY_TOKEN_SUCCESS() {
 		// given
 		LoginedInfo expected = new LoginedInfo("hello", 12345L, 54321L);
-		String token = "token";
+		String token = "hello token";
 
-		Mockito.when(loginedUserGetByTokenPort.decryptToken(token)).thenReturn(expected);
+		Mockito.when(loginedUserGetByTokenPort.decryptToken(token.split(" ")[1])).thenReturn(expected);
 
 		// when
 		LoginedInfo result = loginedUserGetByTokenUseCase.decryptToken(token);
@@ -44,12 +45,25 @@ class LoginedUserGetByTokenServiceTest {
 
 	@ParameterizedTest
 	@NullSource
-	void NULL_PARAMETER_TEST(String token){
+	void NULL_PARAMETER_TEST(String token) {
 		// when
 		Throwable result = Assertions.catchThrowable(() -> loginedUserGetByTokenUseCase.decryptToken(token));
 
 		// then
 		Assertions.assertThat(result).isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	@DisplayName("Invalid token signature 테스트")
+	void DECRYPT_INVALID_TOKEN() {
+		// given
+		String token = "invalid";
+
+		// when
+		Throwable result = Assertions.catchThrowable(() -> loginedUserGetByTokenUseCase.decryptToken(token));
+
+		// then
+		Assertions.assertThat(result).isInstanceOf(InvalidTokenException.class);
 	}
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
로그인된 유저 정보 조회에서 토큰의 정보 와 시그니처를 같이 복호화하는 버그를 해결했습니다.

## 어떻게 해결했나요?
- [x] JWT 복호화시, `bearer token` 을 token만 복호화 하도록 수정했습니다.
 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
