### PR TITLE
[fix] : json response `long` to `string`

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -35,7 +35,7 @@ public final class FeedbackAcceptanceValidator {
 
 			jsonPath("$.question_feedback").isArray(),
 			jsonPath("$.question_feedback").isNotEmpty(),
-			jsonPath("$.question_feedback.[0].question_id").isNumber(),
+			jsonPath("$.question_feedback.[0].question_id").isString(),
 			jsonPath("$.question_feedback.[0].order").isNumber(),
 			jsonPath("$.question_feedback.[0].type").isString(),
 			jsonPath("$.question_feedback.[0].form_type").isString(),
@@ -43,11 +43,11 @@ public final class FeedbackAcceptanceValidator {
 
 			jsonPath("$.question_feedback.[0].feedbacks").isArray(),
 			jsonPath("$.question_feedback.[0].feedbacks").isNotEmpty(),
-			jsonPath("$.question_feedback.[0].feedbacks.[0].feedback_id").isNumber(),
+			jsonPath("$.question_feedback.[0].feedbacks.[0].feedback_id").isString(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].created_at").isString(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].is_read").isBoolean(),
 
-			jsonPath("$.question_feedback.[0].feedbacks.[0].reviewer.reviewer_id").isNumber(),
+			jsonPath("$.question_feedback.[0].feedbacks.[0].reviewer.reviewer_id").isString(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].reviewer.nickname").isString(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].reviewer.collaboration_experience").isBoolean(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].reviewer.position").isString()
@@ -62,7 +62,7 @@ public final class FeedbackAcceptanceValidator {
 			jsonPath("$.question_feedback").isArray(),
 			jsonPath("$.question_feedback").isNotEmpty(),
 
-			jsonPath("$.question_feedback.[0].question_id").isNumber(),
+			jsonPath("$.question_feedback.[0].question_id").isString(),
 			jsonPath("$.question_feedback.[0].order").isNumber(),
 			jsonPath("$.question_feedback.[0].type").isString(),
 			jsonPath("$.question_feedback.[0].form_type").isString(),
@@ -96,7 +96,7 @@ public final class FeedbackAcceptanceValidator {
 			status().isOk(),
 			content().contentType(MediaType.APPLICATION_JSON),
 			jsonPath("$.feedbacks").isArray(),
-			jsonPath("$.feedbacks[0].feedback_id").isNumber(),
+			jsonPath("$.feedbacks[0].feedback_id").isString(),
 			jsonPath("$.feedbacks[0].created_at").isString(),
 			jsonPath("$.feedbacks[0].reviewer.nickname").isString(),
 			jsonPath("$.feedbacks[0].reviewer.collaboration_experience").isBoolean(),
@@ -109,13 +109,13 @@ public final class FeedbackAcceptanceValidator {
 		resultActions.andExpectAll(
 			status().isOk(),
 			content().contentType(MediaType.APPLICATION_JSON),
-			jsonPath("$.feedback_id").isNumber(),
+			jsonPath("$.feedback_id").isString(),
 			jsonPath("$.created_at").isString(),
 			jsonPath("$.reviewer.nickname").isString(),
 			jsonPath("$.reviewer.collaboration_experience").isBoolean(),
 			jsonPath("$.reviewer.position").isString(),
 			jsonPath("$.question").isArray(),
-			jsonPath("$.question[0].question_id").isNumber(),
+			jsonPath("$.question[0].question_id").isString(),
 			jsonPath("$.question[0].type").isString(),
 			jsonPath("$.question[0].form_type").isString(),
 			jsonPath("$.question[0].title").isString(),

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackCreateRequestFixture.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackCreateRequestFixture.java
@@ -2,6 +2,7 @@ package me.nalab.luffy.api.acceptance.test.feedback;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import me.nalab.luffy.api.acceptance.test.feedback.create.request.AbstractQuestionFeedbackRequest;
 import me.nalab.luffy.api.acceptance.test.feedback.create.request.ChoiceQuestionFeedbackRequest;
@@ -49,7 +50,7 @@ public class FeedbackCreateRequestFixture {
 	private static ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(shortFormQuestionResponse.getQuestionId())
+			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -59,8 +60,11 @@ public class FeedbackCreateRequestFixture {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(choiceFormQuestionResponse.getQuestionId())
-			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
+			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
+				.map(Long::valueOf)
+				.collect(
+					Collectors.toList()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/FeedbackCreateAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/FeedbackCreateAcceptanceTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -168,7 +169,7 @@ class FeedbackCreateAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(shortFormQuestionResponse.getQuestionId())
+			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -178,8 +179,11 @@ class FeedbackCreateAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(choiceFormQuestionResponse.getQuestionId())
-			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
+			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
+				.map(Long::valueOf)
+				.collect(
+					Collectors.toList()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/ChoiceResponse.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/ChoiceResponse.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 public class ChoiceResponse {
 
 	@JsonProperty("choice_id")
-	private Long choiceId;
+	private String choiceId;
 
 	private String content;
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/FormQuestionResponseable.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/FormQuestionResponseable.java
@@ -23,7 +23,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class FormQuestionResponseable {
 
 	@JsonProperty("question_id")
-	private Long questionId;
+	private String questionId;
 
 	@JsonProperty("form_type")
 	private String formType;

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/SurveyFindResponse.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/SurveyFindResponse.java
@@ -20,7 +20,7 @@ import lombok.ToString;
 public class SurveyFindResponse {
 
 	@JsonProperty("survey_id")
-	private Long surveyId;
+	private String surveyId;
 
 	private TargetResponse target;
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/TargetResponse.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/TargetResponse.java
@@ -15,7 +15,7 @@ import lombok.ToString;
 @AllArgsConstructor
 public class TargetResponse {
 
-	private Long id;
+	private String id;
 
 	private String nickname;
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
@@ -6,6 +6,7 @@ import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceVali
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
@@ -108,7 +109,7 @@ class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 			.getContentAsString();
 
 		JSONObject jsonObject = new JSONObject(stringResponse);
-		return jsonObject.getLong("survey_id");
+		return Long.valueOf(jsonObject.getString("survey_id"));
 	}
 
 	private SurveyFindResponse findSurveyAndGetSurveyResponse(Long surveyId) throws Exception {
@@ -149,7 +150,7 @@ class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(shortFormQuestionResponse.getQuestionId())
+			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -159,8 +160,11 @@ class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(choiceFormQuestionResponse.getQuestionId())
-			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
+			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
+				.map(Long::valueOf)
+				.collect(
+					Collectors.toList()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
@@ -5,6 +5,7 @@ import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceVali
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
@@ -87,8 +88,8 @@ public class SpecificFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 			.getResponse()
 			.getContentAsString();
 		JSONObject jsonObject = new JSONObject(stringResponse);
-		return jsonObject.getJSONArray("question_feedback").getJSONObject(0).getJSONArray("feedbacks")
-			.getJSONObject(0).getLong("feedback_id");
+		return Long.valueOf(jsonObject.getJSONArray("question_feedback").getJSONObject(0).getJSONArray("feedbacks")
+			.getJSONObject(0).getString("feedback_id"));
 	}
 
 	private Long createSurveyAndGetSurveyId(String token, String content) throws Exception {
@@ -98,7 +99,7 @@ public class SpecificFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 			.getContentAsString();
 
 		JSONObject jsonObject = new JSONObject(stringResponse);
-		return jsonObject.getLong("survey_id");
+		return Long.valueOf(jsonObject.getString("survey_id"));
 	}
 
 	private SurveyFindResponse getSurveyFindResponse(Long surveyId) throws Exception {
@@ -138,7 +139,7 @@ public class SpecificFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private static ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(shortFormQuestionResponse.getQuestionId())
+			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -148,8 +149,11 @@ public class SpecificFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(choiceFormQuestionResponse.getQuestionId())
-			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
+			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
+				.map(Long::valueOf)
+				.collect(
+					Collectors.toList()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummary/FeedbackFindSummaryAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummary/FeedbackFindSummaryAcceptanceTest.java
@@ -5,6 +5,7 @@ import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceVali
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
@@ -105,7 +106,7 @@ class FeedbackFindSummaryAcceptanceTest extends AbstractFeedbackTestSupporter {
 			.getContentAsString();
 
 		JSONObject jsonObject = new JSONObject(stringResponse);
-		return jsonObject.getLong("survey_id");
+		return Long.valueOf(jsonObject.getString("survey_id"));
 	}
 
 	private SurveyFindResponse getSurveyFindResponse(Long surveyId) throws Exception {
@@ -145,7 +146,7 @@ class FeedbackFindSummaryAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(shortFormQuestionResponse.getQuestionId())
+			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -155,8 +156,11 @@ class FeedbackFindSummaryAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(choiceFormQuestionResponse.getQuestionId())
-			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
+			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
+				.map(Long::valueOf)
+				.collect(
+					Collectors.toList()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/reviewer/summary/ReviewerSummarizeAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/reviewer/summary/ReviewerSummarizeAcceptanceTest.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -149,7 +150,7 @@ class ReviewerSummarizeAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(shortFormQuestionResponse.getQuestionId())
+			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -159,8 +160,11 @@ class ReviewerSummarizeAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(choiceFormQuestionResponse.getQuestionId())
-			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
+			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
+				.map(Long::valueOf)
+				.collect(
+					Collectors.toList()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
@@ -13,7 +13,7 @@ public class SurveyAcceptanceValidator {
 		resultActions.andExpectAll(
 			status().isCreated(),
 			content().contentType(MediaType.APPLICATION_JSON),
-			jsonPath("$.survey_id").isNumber()
+			jsonPath("$.survey_id").isString()
 		);
 	}
 
@@ -21,7 +21,7 @@ public class SurveyAcceptanceValidator {
 		resultActions.andExpectAll(
 			status().isOk(),
 			content().contentType(MediaType.APPLICATION_JSON),
-			jsonPath("$.survey_id").isNumber()
+			jsonPath("$.survey_id").isString()
 		);
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/find/SurveyFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/find/SurveyFindAcceptanceTest.java
@@ -48,9 +48,9 @@ class SurveyFindAcceptanceTest extends AbstractSurveyTestSupporter {
 			.getContentAsString();
 
 		JSONObject jsonObject = new JSONObject(stringResponse);
-		Long surveyId = jsonObject.getLong("survey_id");
+		String surveyId = jsonObject.getString("survey_id");
 
-		ResultActions resultActions = findSurvey(surveyId);
+		ResultActions resultActions = findSurvey(Long.valueOf(surveyId));
 
 		assertIsSurveyAndQuestionFound(resultActions);
 	}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/SurveyCreateController.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/SurveyCreateController.java
@@ -24,9 +24,10 @@ class SurveyCreateController {
 
 	@PostMapping("/surveys")
 	@ResponseStatus(HttpStatus.CREATED)
-	SurveyIdResponse createSurvey(@RequestAttribute("logined") Long loginId, @RequestBody SurveyCreateRequest surveyCreateRequest) {
+	SurveyIdResponse createSurvey(@RequestAttribute("logined") Long loginId,
+		@RequestBody SurveyCreateRequest surveyCreateRequest) {
 		createSurveyUseCase.createSurvey(loginId, SurveyCreateRequestMapper.toSurveyDto(surveyCreateRequest));
-		Long latestSurveyId = latestSurveyIdFindUseCase.getLatestSurveyIdByTargetId(loginId);
+		String latestSurveyId = String.valueOf(latestSurveyIdFindUseCase.getLatestSurveyIdByTargetId(loginId));
 		return new SurveyIdResponse(latestSurveyId);
 	}
 

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/response/SurveyIdResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/response/SurveyIdResponse.java
@@ -12,6 +12,6 @@ import lombok.ToString;
 public class SurveyIdResponse {
 
 	@JsonProperty("survey_id")
-	private final Long surveyId;
+	private final String surveyId;
 
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersController.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersController.java
@@ -23,7 +23,8 @@ public class FeedbackReviewersController {
 	@GetMapping("/reviewers")
 	public ResponseEntity<FeedbackReviewersResponse> getFeedbackReviewers(@RequestParam("survey-id") Long surveyId) {
 		List<FeedbackDto> feedbacks = feedbackReviewersFindService.findAllFeedback(surveyId);
-		FeedbackReviewersResponse feedbackReviewersResponse = FeedbackReviewersResponseMapper.toFeedbackReviewersResponse(feedbacks);
+		FeedbackReviewersResponse feedbackReviewersResponse = FeedbackReviewersResponseMapper.toFeedbackReviewersResponse(
+			feedbacks);
 		return ResponseEntity.ok(feedbackReviewersResponse);
 	}
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapper.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapper.java
@@ -16,7 +16,7 @@ class FeedbackReviewersResponseMapper {
 	static FeedbackReviewersResponse toFeedbackReviewersResponse(List<FeedbackDto> feedbacks) {
 		List<FeedbackReviewer> feedbackReviewers = feedbacks.stream()
 			.map(it -> FeedbackReviewer.builder()
-				.feedbackId(it.getId())
+				.feedbackId(String.valueOf(it.getId()))
 				.createdAt(it.getCreatedAt())
 				.reviewer(ReviewerResponse.builder()
 					.nickName(it.getReviewerDto().getNickName())

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/FeedbackReviewer.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/feedbackreviewers/response/FeedbackReviewer.java
@@ -17,7 +17,7 @@ import lombok.ToString;
 public class FeedbackReviewer {
 
 	@JsonProperty("feedback_id")
-	private Long feedbackId;
+	private String feedbackId;
 
 	@JsonProperty("created_at")
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/ResponseMapper.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/ResponseMapper.java
@@ -43,7 +43,7 @@ final class ResponseMapper {
 	private static AbstractSurveyResponse toChoiceSurveyResponse(ChoiceFormQuestionDto choiceFormQuestionDto,
 		List<FeedbackDto> feedbackDto) {
 		return ChoiceSurveyResponse.builder()
-			.questionId(choiceFormQuestionDto.getId())
+			.questionId(String.valueOf(choiceFormQuestionDto.getId()))
 			.order(choiceFormQuestionDto.getOrder())
 			.type(choiceFormQuestionDto.getQuestionDtoType().name().toLowerCase())
 			.formType(choiceFormQuestionDto.getChoiceFormQuestionDtoType().name().toLowerCase())
@@ -56,7 +56,7 @@ final class ResponseMapper {
 	private static List<ChoiceSurveyResponse.QuestionResponse> toChoiceQuestionResponse(List<ChoiceDto> choiceDtoList) {
 		return choiceDtoList.stream().map(
 			c -> ChoiceSurveyResponse.QuestionResponse.builder()
-				.choiceId(c.getId())
+				.choiceId(String.valueOf(c.getId()))
 				.order(c.getOrder())
 				.content(c.getContent())
 				.build()).collect(Collectors.toList()
@@ -75,10 +75,14 @@ final class ResponseMapper {
 		feedbackDto.getFormQuestionFeedbackDtoableList().stream()
 			.filter(q -> q.getQuestionId().equals(questionId))
 			.forEach(cq -> {
-				Set<Long> selectedChoiceIdSet = ((ChoiceFormQuestionFeedbackDto)cq).getSelectedChoiceIdSet();
+				Set<String> selectedChoiceIdSet = ((ChoiceFormQuestionFeedbackDto)cq).getSelectedChoiceIdSet()
+					.stream()
+					.map(String::valueOf)
+					.collect(
+						Collectors.toSet());
 				choiceFeedbackResponseList.add(
 					ChoiceFeedbackResponse.builder()
-						.id(feedbackDto.getId())
+						.id(String.valueOf(feedbackDto.getId()))
 						.choiceIdSet(selectedChoiceIdSet)
 						.createdAt(feedbackDto.getCreatedAt())
 						.read(feedbackDto.isRead())
@@ -90,7 +94,7 @@ final class ResponseMapper {
 
 	private static ReviewerResponse toReviewerResponse(ReviewerDto reviewerDto) {
 		return ReviewerResponse.builder()
-			.id(reviewerDto.getId())
+			.id(String.valueOf(reviewerDto.getId()))
 			.nickName(reviewerDto.getNickName())
 			.collaborationExperience(reviewerDto.isCollaborationExperience())
 			.position(reviewerDto.getPosition())
@@ -100,7 +104,7 @@ final class ResponseMapper {
 	private static AbstractSurveyResponse toShortSurveyResponse(ShortFormQuestionDto shortFormQuestionDto,
 		List<FeedbackDto> feedbackDtoList) {
 		return ShortSurveyResponse.builder()
-			.questionId(shortFormQuestionDto.getId())
+			.questionId(String.valueOf(shortFormQuestionDto.getId()))
 			.order(shortFormQuestionDto.getOrder())
 			.type(shortFormQuestionDto.getQuestionDtoType().name().toLowerCase())
 			.formType(shortFormQuestionDto.getShortFormQuestionDtoType().name().toLowerCase())

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/AbstractFeedbackResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/AbstractFeedbackResponse.java
@@ -14,7 +14,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class AbstractFeedbackResponse {
 
 	@JsonProperty("feedback_id")
-	private final Long id;
+	private final String id;
 	@JsonProperty("created_at")
 	private final LocalDateTime createdAt;
 	@JsonProperty("is_read")

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ChoiceFeedbackResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ChoiceFeedbackResponse.java
@@ -14,6 +14,6 @@ import lombok.experimental.SuperBuilder;
 public class ChoiceFeedbackResponse extends AbstractFeedbackResponse {
 
 	@JsonProperty("choice_id")
-	private final Set<Long> choiceIdSet;
+	private final Set<String> choiceIdSet;
 
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ReviewerResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/ReviewerResponse.java
@@ -12,7 +12,7 @@ import lombok.ToString;
 public class ReviewerResponse {
 
 	@JsonProperty("reviewer_id")
-	private final Long id;
+	private final String id;
 	@JsonProperty("nickname")
 	private final String nickName;
 	@JsonProperty("collaboration_experience")

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/AbstractSurveyResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/AbstractSurveyResponse.java
@@ -12,7 +12,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class AbstractSurveyResponse {
 
 	@JsonProperty("question_id")
-	private final Long questionId;
+	private final String questionId;
 	private final Integer order;
 	private final String type;
 	@JsonProperty("form_type")

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/ChoiceSurveyResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/survey/ChoiceSurveyResponse.java
@@ -26,7 +26,7 @@ public class ChoiceSurveyResponse extends AbstractSurveyResponse {
 	@ToString
 	public static final class QuestionResponse {
 		@JsonProperty("choice_id")
-		private final Long choiceId;
+		private final String choiceId;
 		private final Integer order;
 		private final String content;
 	}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findid/SurveyIdGetController.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findid/SurveyIdGetController.java
@@ -22,7 +22,7 @@ public class SurveyIdGetController {
 	@ResponseStatus(HttpStatus.OK)
 	SurveyIdResponse getSurveyId(@RequestAttribute("logined") Long loginId) {
 		Long surveyId = surveyIdGetUseCase.getSurveyIdByTargetId(loginId);
-		return new SurveyIdResponse(surveyId);
+		return new SurveyIdResponse(String.valueOf(surveyId));
 	}
 
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findid/response/SurveyIdResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findid/response/SurveyIdResponse.java
@@ -10,6 +10,6 @@ import lombok.Getter;
 public class SurveyIdResponse {
 
 	@JsonProperty("survey_id")
-	private final Long surveyId;
+	private final String surveyId;
 
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/SpecificFeedbackResponseMapper.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/SpecificFeedbackResponseMapper.java
@@ -26,7 +26,7 @@ class SpecificFeedbackResponseMapper {
 
 	static SpecificFeedbackResponse toSpecificFeedbackResponse(SurveyDto surveyDto, FeedbackDto feedbackDto) {
 		return SpecificFeedbackResponse.builder()
-			.feedbackId(feedbackDto.getId())
+			.feedbackId(String.valueOf(feedbackDto.getId()))
 			.createdAt(feedbackDto.getCreatedAt())
 			.reviewer(ReviewerResponse.builder()
 				.nickName(feedbackDto.getReviewerDto().getNickName())
@@ -67,7 +67,7 @@ class SpecificFeedbackResponseMapper {
 	private static ShortFormFeedbackResponse toShortFormFeedbackResponse(ShortFormQuestionDto questionDto,
 		ShortFormQuestionFeedbackDto feedbackDto) {
 		return ShortFormFeedbackResponse.builder()
-			.questionId(questionDto.getId())
+			.questionId(String.valueOf(questionDto.getId()))
 			.type("short")
 			.formType(questionDto.getShortFormQuestionDtoType().name().toLowerCase())
 			.title(questionDto.getTitle())
@@ -82,14 +82,14 @@ class SpecificFeedbackResponseMapper {
 		List<ChoiceResponse> choices = questionDto.getChoiceDtoList().stream()
 			.filter(it -> feedbackDto.getSelectedChoiceIdSet().contains(it.getId()))
 			.map(it -> ChoiceResponse.builder()
-				.choiceId(it.getId())
+				.choiceId(String.valueOf(it.getId()))
 				.content(it.getContent())
 				.order(it.getOrder())
 				.build())
 			.collect(Collectors.toList());
 
 		return ChoiceFormFeedbackResponse.builder()
-			.questionId(questionDto.getId())
+			.questionId(String.valueOf(questionDto.getId()))
 			.type("choice")
 			.formType(questionDto.getChoiceFormQuestionDtoType().name().toLowerCase())
 			.title(questionDto.getTitle())

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/response/ChoiceResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/response/ChoiceResponse.java
@@ -14,7 +14,7 @@ import lombok.ToString;
 public class ChoiceResponse {
 
 	@JsonProperty("choice_id")
-	private final long choiceId;
+	private final String choiceId;
 
 	private final String content;
 

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/response/FormFeedbackResponseable.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/response/FormFeedbackResponseable.java
@@ -10,7 +10,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class FormFeedbackResponseable {
 
 	@JsonProperty("question_id")
-	private final long questionId;
+	private final String questionId;
 
 	private final String type;
 	@JsonProperty("form_type")

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/response/SpecificFeedbackResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findspecific/response/SpecificFeedbackResponse.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 public class SpecificFeedbackResponse {
 
 	@JsonProperty("feedback_id")
-	private final Long feedbackId;
+	private final String feedbackId;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
 	@JsonProperty("created_at")

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/mapper/SurveyFindResponseMapper.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/mapper/SurveyFindResponseMapper.java
@@ -22,8 +22,8 @@ public class SurveyFindResponseMapper {
 
 	public static SurveyFindResponse toSurveyFindResponse(TargetDto targetDto, SurveyDto surveyDto) {
 		return SurveyFindResponse.builder()
-			.surveyId(surveyDto.getId())
-			.target(TargetResponse.builder().id(targetDto.getId()).nickname(targetDto.getNickname()).build())
+			.surveyId(String.valueOf(surveyDto.getId()))
+			.target(TargetResponse.builder().id(String.valueOf(targetDto.getId())).nickname(targetDto.getNickname()).build())
 			.questionCount(surveyDto.getFormQuestionDtoableList().size())
 			.question(surveyDto.getFormQuestionDtoableList()
 				.stream()
@@ -41,7 +41,7 @@ public class SurveyFindResponseMapper {
 
 	public static ChoiceFormQuestionResponse toChoiceFormQuestionResponse(ChoiceFormQuestionDto choiceFormQuestionDto) {
 		return ChoiceFormQuestionResponse.builder()
-			.questionId(choiceFormQuestionDto.getId())
+			.questionId(String.valueOf(choiceFormQuestionDto.getId()))
 			.type(choiceFormQuestionDto.getQuestionDtoType().toString().toLowerCase())
 			.formType(choiceFormQuestionDto.getChoiceFormQuestionDtoType().name().toLowerCase())
 			.title(choiceFormQuestionDto.getTitle())
@@ -50,7 +50,7 @@ public class SurveyFindResponseMapper {
 			.choices(choiceFormQuestionDto.getChoiceDtoList()
 				.stream()
 				.map(it -> ChoiceResponse.builder()
-					.choiceId(it.getId())
+					.choiceId(String.valueOf(it.getId()))
 					.content(it.getContent())
 					.order(it.getOrder())
 					.build())
@@ -60,7 +60,7 @@ public class SurveyFindResponseMapper {
 
 	public static ShortFormQuestionResponse toShortFormQuestionResponse(ShortFormQuestionDto shortFormQuestionDto) {
 		return ShortFormQuestionResponse.builder()
-			.questionId(shortFormQuestionDto.getId())
+			.questionId(String.valueOf(shortFormQuestionDto.getId()))
 			.type(shortFormQuestionDto.getQuestionDtoType().toString().toLowerCase())
 			.formType(shortFormQuestionDto.getShortFormQuestionDtoType().name().toLowerCase())
 			.title(shortFormQuestionDto.getTitle())

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/response/ChoiceResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/response/ChoiceResponse.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ChoiceResponse {
 
 	@JsonProperty("choice_id")
-	private Long choiceId;
+	private String choiceId;
 
 	private String content;
 

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/response/FormQuestionResponseable.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/response/FormQuestionResponseable.java
@@ -14,7 +14,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class FormQuestionResponseable {
 
 	@JsonProperty("question_id")
-	private Long questionId;
+	private String questionId;
 
 	private String type;
 

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/response/SurveyFindResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/response/SurveyFindResponse.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 public class SurveyFindResponse {
 
 	@JsonProperty("survey_id")
-	private Long surveyId;
+	private String surveyId;
 
 	private TargetResponse target;
 

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/response/TargetResponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/survey/find/response/TargetResponse.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class TargetResponse {
 
-	private Long id;
+	private String id;
 
 	private String nickname;
 

--- a/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapperTest.java
+++ b/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/feedbackreviewers/FeedbackReviewersResponseMapperTest.java
@@ -29,7 +29,7 @@ class FeedbackReviewersResponseMapperTest {
 
 		assertAll(
 			() -> assertThat(response.getFeedbacks()).hasSize(1),
-			() -> assertThat(feedbackReviewer.getFeedbackId()).isEqualTo(1L),
+			() -> assertThat(feedbackReviewer.getFeedbackId()).isEqualTo("1"),
 			() -> assertThat(feedbackReviewer.getIsRead()).isTrue(),
 			() -> assertThat(feedbackReviewer.getReviewer().getNickName()).isEqualTo("sujin"),
 			() -> assertThat(feedbackReviewer.getReviewer().getCollaborationExperience()).isTrue(),

--- a/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/findspecific/SpecificFeedbackResponseMapperTest.java
+++ b/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/findspecific/SpecificFeedbackResponseMapperTest.java
@@ -103,13 +103,13 @@ class SpecificFeedbackResponseMapperTest {
 
 	private static SpecificFeedbackResponse getSpecificFeedbackResponse() {
 		return SpecificFeedbackResponse.builder()
-			.feedbackId(7L)
+			.feedbackId("7")
 			.createdAt(LocalDateTime.of(2023, 5, 26, 6, 46, 0))
 			.reviewer(ReviewerResponse.builder()
 				.nickName("sujin").collaborationExperience(true).position("developer").build())
 			.question(List.of(
 				ChoiceFormFeedbackResponse.builder()
-					.questionId(3L)
+					.questionId("3")
 					.type("choice")
 					.formType("tendency")
 					.title("Choice Question")
@@ -117,19 +117,19 @@ class SpecificFeedbackResponseMapperTest {
 					.isRead(true)
 					.choices(List.of(
 						ChoiceResponse.builder()
-							.choiceId(1L)
+							.choiceId("1")
 							.content("Choice 1")
 							.order(1)
 							.build(),
 						ChoiceResponse.builder()
-							.choiceId(2L)
+							.choiceId("2")
 							.content("Choice 2")
 							.order(2)
 							.build()
 					))
 					.build(),
 				ShortFormFeedbackResponse.builder()
-					.questionId(4L)
+					.questionId("4")
 					.type("short")
 					.formType("strength")
 					.title("Short Question")

--- a/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/survey/find/mapper/SurveyFindResponseMapperTest.java
+++ b/survey/web-adaptor/src/test/java/me/nalab/survey/web/adaptor/survey/find/mapper/SurveyFindResponseMapperTest.java
@@ -53,11 +53,11 @@ class SurveyFindResponseMapperTest {
 			.build();
 
 		SurveyFindResponse response = SurveyFindResponseMapper.toSurveyFindResponse(targetDto, surveyDto);
-		assertEquals(surveyDto.getId(), response.getSurveyId());
+		assertEquals(String.valueOf(surveyDto.getId()), response.getSurveyId());
 
 		TargetResponse targetResponse = response.getTarget();
 		assertAll(
-			() -> assertEquals(targetDto.getId(), targetResponse.getId()),
+			() -> assertEquals(String.valueOf(targetDto.getId()), targetResponse.getId()),
 			() -> assertEquals(targetDto.getNickname(), targetResponse.getNickname())
 		);
 
@@ -67,7 +67,7 @@ class SurveyFindResponseMapperTest {
 		ChoiceFormQuestionDto choiceQuestionDto = (ChoiceFormQuestionDto)surveyDto.getFormQuestionDtoableList().get(0);
 		ChoiceFormQuestionResponse choiceQuestionResponse = (ChoiceFormQuestionResponse)questionList.get(0);
 		assertAll(
-			() -> assertEquals(choiceQuestionDto.getId(), choiceQuestionResponse.getQuestionId()),
+			() -> assertEquals(String.valueOf(choiceQuestionDto.getId()), choiceQuestionResponse.getQuestionId()),
 			() -> assertEquals(QuestionDtoType.CHOICE.toString().toLowerCase(), choiceQuestionResponse.getType()),
 			() -> assertEquals(choiceQuestionDto.getTitle(), choiceQuestionResponse.getTitle()),
 			() -> assertEquals(choiceQuestionDto.getOrder(), choiceQuestionResponse.getOrder()),
@@ -86,7 +86,7 @@ class SurveyFindResponseMapperTest {
 			ChoiceResponse choiceResponse = choiceList.get(i);
 
 			assertAll(
-				() -> assertEquals(choiceDto.getId(), choiceResponse.getChoiceId()),
+				() -> assertEquals(String.valueOf(choiceDto.getId()), choiceResponse.getChoiceId()),
 				() -> assertEquals(choiceDto.getContent(), choiceResponse.getContent()),
 				() -> assertEquals(choiceDto.getOrder(), choiceResponse.getOrder())
 			);
@@ -95,7 +95,7 @@ class SurveyFindResponseMapperTest {
 		ShortFormQuestionDto shortQuestionDto = (ShortFormQuestionDto)surveyDto.getFormQuestionDtoableList().get(1);
 		ShortFormQuestionResponse shortQuestionResponse = (ShortFormQuestionResponse)questionList.get(1);
 		assertAll(
-			() -> assertEquals(shortQuestionDto.getId(), shortQuestionResponse.getQuestionId()),
+			() -> assertEquals(String.valueOf(shortQuestionDto.getId()), shortQuestionResponse.getQuestionId()),
 			() -> assertEquals(QuestionDtoType.SHORT.toString().toLowerCase(), shortQuestionResponse.getType()),
 			() -> assertEquals(shortQuestionDto.getTitle(), shortQuestionResponse.getTitle()),
 			() -> assertEquals(shortQuestionDto.getOrder(), shortQuestionResponse.getOrder())

--- a/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/LoginedUserGetController.java
+++ b/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/LoginedUserGetController.java
@@ -22,7 +22,7 @@ public class LoginedUserGetController {
 	public LoginedInfoResponse getLoginedUserByToken(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
 		LoginedInfo loginedInfo = loginedUserGetByTokenUseCase.decryptToken(token);
 
-		return new LoginedInfoResponse(loginedInfo.getTargetId(), loginedInfo.getNickName());
+		return new LoginedInfoResponse(String.valueOf(loginedInfo.getTargetId()), loginedInfo.getNickName());
 	}
 
 }

--- a/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/response/LoginedInfoResponse.java
+++ b/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/response/LoginedInfoResponse.java
@@ -8,7 +8,7 @@ import lombok.Data;
 public class LoginedInfoResponse {
 
 	@JsonProperty("target_id")
-	private final long targetId;
+	private final String targetId;
 	@JsonProperty("nickname")
 	private final String nickName;
 


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
controller response의 id long type을 string으로 변경했습니다.

변경한 이유
``` html
브라우저 API에서 반환되는 값은 대부분 JSON(JSON.stringify) 형태로 전달됩니다.
JSON은 문자열로만 구성되어 있기 때문에 53비트 정밀도를 넘어서는 크기의 정수는 정확하게 전달되지 않으면서 값이 변경되어 반환될 수 있습니다. 
이때, 값의 변형이 발생할 경우 맨 앞의 0들이 생략되는 현상이 발생하여 00으로 변경될 수 있습니다.

이러한 경우, 서버에서 전달되는 값을 자르거나 문자열로 형변환하여 해결할 수 있습니다.
또한, JavaScript에서 BigInt라는 객체를 사용하면 지원 가능한 범위를 넘어 선 수치에 대해 정확한 값을 표현할 수 있기 때문에
이를 사용하여 문제를 해결할 수도 있습니다.
```

그런데, 클라이언트측에서 browser에서 요청이 자스로 도달하기전에 2^53으로 변경하는 이슈가 있다고 하네요.. 그래서 서버측에서 string으로 변경했습니다.

## 어떻게 해결했나요?
- [x] 컨트롤러의 response dto를 String으로 변경했습니다.
- [x] 관련 인수테스트와 통합테스트, 단위테스트를 수정했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
