### PR TITLE
[fix] : `SurveyExistCheckAdaptor` bean collision

### DIFF
--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/SurveyExistCheckAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/SurveyExistCheckAdaptor.java
@@ -1,16 +1,20 @@
 package me.nalab.survey.jpa.adaptor.findfeedbacksummary;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Repository;
 
-import lombok.RequiredArgsConstructor;
 import me.nalab.survey.application.port.out.persistence.feedbacksummary.SurveyExistCheckPort;
 import me.nalab.survey.jpa.adaptor.findfeedbacksummary.repository.SurveyExistCheckJpaRepository;
 
 @Repository("findfeedbacksummary.SurveyExistCheckAdaptor")
-@RequiredArgsConstructor
 public class SurveyExistCheckAdaptor implements SurveyExistCheckPort {
 
 	private final SurveyExistCheckJpaRepository surveyExistCheckJpaRepository;
+
+	SurveyExistCheckAdaptor(
+		@Qualifier("findfeedbacksummary.SurveyExistCheckJpaRepository") SurveyExistCheckJpaRepository surveyExistCheckJpaRepository) {
+		this.surveyExistCheckJpaRepository = surveyExistCheckJpaRepository;
+	}
 
 	@Override
 	public boolean isExistSurveyBySurveyId(Long surveyId) {

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/repository/SurveyExistCheckJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/repository/SurveyExistCheckJpaRepository.java
@@ -1,8 +1,10 @@
 package me.nalab.survey.jpa.adaptor.findfeedbacksummary.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import me.nalab.core.data.survey.SurveyEntity;
 
+@Repository("findfeedbacksummary.SurveyExistCheckJpaRepository")
 public interface SurveyExistCheckJpaRepository extends JpaRepository<SurveyEntity, Long> {
 }

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/SurveyExistCheckAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/SurveyExistCheckAdaptorTest.java
@@ -1,0 +1,78 @@
+package me.nalab.survey.jpa.adaptor.findfeedbacksummary;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.feedbacksummary.SurveyExistCheckPort;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = SurveyExistCheckAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class SurveyExistCheckAdaptorTest {
+
+	@Autowired
+	private SurveyExistCheckPort surveyExistCheckPort;
+
+	@Autowired
+	private TestSurveyJpaRepository testSurveyJpaRepository;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Test
+	@DisplayName("survey exist check 성공 - survey가 존재할때")
+	void SURVEY_EXIST_CHECK_SUCCESS() {
+		// given
+		TargetEntity targetEntity = getDefaultTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		testTargetJpaRepository.saveAndFlush(targetEntity);
+		testSurveyJpaRepository.saveAndFlush(surveyEntity);
+		testSurveyJpaRepository.flush();
+
+		// when
+		boolean result = surveyExistCheckPort.isExistSurveyBySurveyId(survey.getId());
+
+		// then
+		assertTrue(result);
+	}
+
+	@Test
+	@DisplayName("survey exist check 성공 - survey가 없을때")
+	void SURVEY_EXIST_CHECK_SUCCESS_EMPTY_SURVEY() {
+		// when
+		boolean result = surveyExistCheckPort.isExistSurveyBySurveyId(100L);
+
+		// then
+		assertFalse(result);
+	}
+
+	private TargetEntity getDefaultTargetEntity() {
+		return TargetEntity.builder()
+			.id(101L)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.nickname("test target")
+			.build();
+	}
+
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/TestSurveyJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/TestSurveyJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.findfeedbacksummary;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/TestTargetJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedbacksummary/TestTargetJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.findfeedbacksummary;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TestTargetJpaRepository extends JpaRepository<TargetEntity, Long> {
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`SurveyExistCheckAdaptor` 이름의 bean이 2개 있어서 충돌이 나는 버그를 수정했습니다.

## 어떻게 해결했나요?
- [x] `SurveyExistCheckAdaptor` 앞에, convention에 맞게 package 명을 추가했습니다.
- [x] 관련 테스트코드를 추가했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
