### PR TITLE
[fix] 로그인 시 target 생성 삭제 및 조회 기능 구현

### DIFF
--- a/auth/auth-application/src/main/java/me/nalab/auth/application/service/SignInWithOAuthService.java
+++ b/auth/auth-application/src/main/java/me/nalab/auth/application/service/SignInWithOAuthService.java
@@ -8,8 +8,7 @@ import me.nalab.auth.application.common.dto.SignUpWithOAuthRequest;
 import me.nalab.auth.application.port.in.web.AuthTokenCreateUseCase;
 import me.nalab.auth.application.port.in.web.SignInWithOAuthUseCase;
 import me.nalab.auth.application.port.in.web.SignUpWithOAuthUseCase;
-import me.nalab.survey.application.common.target.dto.CreateTargetRequest;
-import me.nalab.survey.application.port.in.web.CreateTargetUseCase;
+import me.nalab.survey.application.port.in.web.target.find.TargetFindByUsernameUseCase;
 import me.nalab.user.application.common.dto.FindByProviderAndTokenRequest;
 import me.nalab.user.application.port.in.UserFindByProviderAndTokenUseCase;
 import org.springframework.stereotype.Service;
@@ -22,7 +21,7 @@ import java.util.Optional;
 public class SignInWithOAuthService implements SignInWithOAuthUseCase {
 
     private final UserFindByProviderAndTokenUseCase userFindByProviderAndTokenUseCase;
-    private final CreateTargetUseCase createTargetUseCase;
+    private final TargetFindByUsernameUseCase targetFindByUsernameUseCase;
     private final SignUpWithOAuthUseCase signUpWithOAuthUseCase;
     private final AuthTokenCreateUseCase authTokenCreateUseCase;
 
@@ -35,9 +34,7 @@ public class SignInWithOAuthService implements SignInWithOAuthUseCase {
 
         var foundUser = findUserIdAndSignUpIfNeeded(request, providerName, email);
         var userId = foundUser.orElseThrow(IllegalAccessError::new);
-
-        var createTargetRequest = new CreateTargetRequest(request.getUsername());
-        var targetId = createTargetUseCase.create(createTargetRequest);
+        var targetId = targetFindByUsernameUseCase.findTargetByUsername(request.getUsername()).orElseThrow();
 
         var authTokenCreateRequest = new CreateAuthTokenRequest(userId.toString(), request.getUsername(), String.valueOf(targetId));
 

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/web/target/find/TargetFindByUsernameUseCase.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/web/target/find/TargetFindByUsernameUseCase.java
@@ -1,0 +1,21 @@
+package me.nalab.survey.application.port.in.web.target.find;
+
+import me.nalab.survey.application.common.survey.dto.TargetDto;
+
+import java.util.Optional;
+
+/**
+ *  유저의 이름을 통해서 target을 조회합니다.
+ */
+public interface TargetFindByUsernameUseCase {
+
+    /**
+     * 유저 이름을 통해 target을 조회합니다.
+     * 여러 개가 있을 경우 가장 마지막으로 생성된 타겟을 조회합니다.
+     *
+     * @param username 사용자의 이름
+     * @return target 데이터를 가진 dto
+     */
+    Optional<TargetDto> findTargetByUsername(String username);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/target/find/TargetFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/target/find/TargetFindPort.java
@@ -1,8 +1,9 @@
 package me.nalab.survey.application.port.out.persistence.target.find;
 
-import java.util.Optional;
-
 import me.nalab.survey.domain.target.Target;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface TargetFindPort {
 
@@ -21,4 +22,11 @@ public interface TargetFindPort {
 	 * @return Optional 만약, 어떠한 surveyId도 없을 경우, Optional.empty() 를 반환해야 합니다.
 	 */
 	Optional<Long> findTargetIdBySurveyId(Long surveyId);
+
+	/**
+	 * 유저 이름으로 모든 target을 조회합니다
+	 * @param username 유저 이름
+	 * @return 유저 이름으로 생성된 모든 target
+	 */
+	List<Target> findAllByUsername(String username);
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/TargetFindByUsernameService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/TargetFindByUsernameService.java
@@ -1,0 +1,33 @@
+package me.nalab.survey.application.service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.common.survey.dto.TargetDto;
+import me.nalab.survey.application.common.survey.mapper.TargetDtoMapper;
+import me.nalab.survey.application.port.in.web.target.find.TargetFindByUsernameUseCase;
+import me.nalab.survey.application.port.out.persistence.target.find.TargetFindPort;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TargetFindByUsernameService implements TargetFindByUsernameUseCase {
+
+    private final TargetFindPort targetFindPort;
+
+    @Override
+    public Optional<TargetDto> findTargetByUsername(String username) {
+        Assert.hasText(username, "타겟 조회 시 username은 필수 입니다.");
+
+        var allTargets = targetFindPort.findAllByUsername(username);
+        if (allTargets.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var lastIndex = allTargets.size() - 1;
+        var latestTarget = allTargets.get(lastIndex);
+        var latestTargetDto = TargetDtoMapper.toTargetDto(latestTarget);
+        return Optional.of(latestTargetDto);
+    }
+}

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module luffy.survey.application.main {
 
 	requires lombok;
 
+	requires spring.core;
 	requires spring.boot;
 	requires spring.boot.autoconfigure;
 	requires spring.context;

--- a/survey/application/src/test/java/me/nalab/survey/application/service/find/TargetFindByUsernameServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/find/TargetFindByUsernameServiceTest.java
@@ -1,0 +1,108 @@
+package me.nalab.survey.application.service.find;
+
+import me.nalab.survey.application.port.out.persistence.target.find.TargetFindPort;
+import me.nalab.survey.application.service.TargetFindByUsernameService;
+import me.nalab.survey.domain.target.Target;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TargetFindByUsernameService.class)
+class TargetFindByUsernameServiceTest {
+
+    @Autowired
+    private TargetFindByUsernameService targetFindByUsernameService;
+
+    @MockBean
+    private TargetFindPort targetFindPort;
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("username이 빈 값이거나 없다면 예외를 던진다")
+    void THROW_EXCEPTION_WHEN_NULL_OR_EMPTY_USERNAME(String username) {
+        // given
+        // when
+        var throwable = Assertions.catchThrowable(() -> targetFindByUsernameService.findTargetByUsername(username));
+
+        // then
+        Assertions.assertThat(throwable)
+                .isNotNull()
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("username에 해당하는 유저가 없다면, empty 값을 반환한다")
+    void RETURN_EMPTY_WHEN_NOT_EXIST_TARGET_BY_USERNAME() {
+        // given
+        var username = "username";
+        when(targetFindPort.findAllByUsername(any())).thenReturn(Collections.emptyList());
+
+        // when
+        var result = targetFindByUsernameService.findTargetByUsername(username);
+
+        // then
+        Assertions.assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("username에 해당하는 타겟이 하나라면, 해당 타겟 dto 값을 반환한다")
+    void RETURN_TARGET_DTO_WHEN_EXIST_ONLY_ONE_TARGET_BY_USERNAME() {
+        // given
+        var username = "username";
+        var target = Target.builder()
+                .id(1L)
+                .nickname(username)
+                .build();
+        when(targetFindPort.findAllByUsername(any())).thenReturn(List.of(target));
+
+        // when
+        var result = targetFindByUsernameService.findTargetByUsername(username);
+
+        // then
+        Assertions.assertThat(result).isPresent();
+        var dto = result.get();
+        Assertions.assertThat(dto.getId()).isEqualTo(target.getId());
+        Assertions.assertThat(dto.getNickname()).isEqualTo(target.getNickname());
+    }
+
+    @Test
+    @DisplayName("username에 해당하는 타겟이 여러 개라면, 가장 마지막 dto 값을 반환한다")
+    void RETURN_LATEST_TARGET_DTO_WHEN_EXIST_MANY_TARGET_BY_USERNAME() {
+        // given
+        var username = "username";
+        var maxId = 10;
+        var targetList = LongStream.rangeClosed(0, maxId)
+                .mapToObj(id ->
+                        Target.builder()
+                                .id(id)
+                                .nickname(username)
+                                .build()
+                ).collect(Collectors.toList());
+        when(targetFindPort.findAllByUsername(any())).thenReturn(targetList);
+
+        // when
+        var result = targetFindByUsernameService.findTargetByUsername(username);
+
+        // then
+        Assertions.assertThat(result).isPresent();
+        var dto = result.get();
+        Assertions.assertThat(dto.getId()).isEqualTo(maxId);
+        Assertions.assertThat(dto.getNickname()).isEqualTo(username);
+    }
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/find/TargetFindAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/find/TargetFindAdaptor.java
@@ -1,9 +1,5 @@
 package me.nalab.survey.jpa.adaptor.find;
 
-import java.util.Optional;
-
-import org.springframework.stereotype.Repository;
-
 import lombok.RequiredArgsConstructor;
 import me.nalab.core.data.survey.SurveyEntity;
 import me.nalab.core.data.target.TargetEntity;
@@ -12,6 +8,12 @@ import me.nalab.survey.domain.target.Target;
 import me.nalab.survey.jpa.adaptor.common.mapper.TargetEntityMapper;
 import me.nalab.survey.jpa.adaptor.find.repository.SurveyFindRepository;
 import me.nalab.survey.jpa.adaptor.find.repository.TargetFindRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -37,5 +39,15 @@ public class TargetFindAdaptor implements TargetFindPort {
 			return Optional.empty();
 		}
 		return Optional.of(surveyEntity.get().getTargetId());
+	}
+
+	@Override
+	public List<Target> findAllByUsername(String username) {
+		var allTargetEntity = targetFindRepository.findAllByNicknameOrderByCreatedAt(username);
+		if (allTargetEntity.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		return allTargetEntity.stream().map(TargetEntityMapper::toTarget).collect(Collectors.toList());
 	}
 }

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/find/repository/TargetFindRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/find/repository/TargetFindRepository.java
@@ -1,8 +1,10 @@
 package me.nalab.survey.jpa.adaptor.find.repository;
 
+import me.nalab.core.data.target.TargetEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import me.nalab.core.data.target.TargetEntity;
+import java.util.List;
 
 public interface TargetFindRepository extends JpaRepository<TargetEntity, Long> {
+    List<TargetEntity> findAllByNicknameOrderByCreatedAt(String nickname);
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?

- 로그인 시 타겟을 생성하지 않고 기존의 타겟을 가져오도록 변경
- username 기반 target 조회 기능 구현 및 테스트 작성

## 어떻게 해결했나요?

- 회원 가입 시에 target에 생성되는 데도 불구하고 로그인 시에 해당 target 조회가 아닌 생성을 하고 있었음.
- 로그인 시에 생성 로직을 삭제, 조회 로직으로 변경