### PR TITLE
[refactor] : position naming hotfix

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -22,9 +22,9 @@ public final class FeedbackAcceptanceValidator {
 			jsonPath("$.collaboration_experience.yes").isNumber(),
 			jsonPath("$.collaboration_experience.no").isNumber(),
 			jsonPath("$.position.designer").isNumber(),
-			jsonPath("$.position.product-manager").isNumber(),
-			jsonPath("$.position.programmer").isNumber(),
-			jsonPath("$.position.other").isNumber()
+			jsonPath("$.position.pm").isNumber(),
+			jsonPath("$.position.developer").isNumber(),
+			jsonPath("$.position.others").isNumber()
 		);
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/FeedbackCreateAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/FeedbackCreateAcceptanceTest.java
@@ -98,8 +98,8 @@ class FeedbackCreateAcceptanceTest extends AbstractFeedbackTestSupporter {
 		List<FeedbackCreateRequest> feedbackCreateRequestList = List.of(
 			getFeedbackCreateRequest(surveyFindResponse, true, "developer"),
 			getFeedbackCreateRequest(surveyFindResponse, false, "designer"),
-			getFeedbackCreateRequest(surveyFindResponse, false, "other"),
-			getFeedbackCreateRequest(surveyFindResponse, true, "product-manager")
+			getFeedbackCreateRequest(surveyFindResponse, false, "others"),
+			getFeedbackCreateRequest(surveyFindResponse, true, "pm")
 		);
 
 		// when

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindAcceptanceTest.java
@@ -65,7 +65,7 @@ class FeedbackFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 
 		Long surveyId = createAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
 		SurveyFindResponse surveyFindResponse = getSurveyFindResponse(surveyId);
-		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "programmer");
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "developer");
 
 		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
@@ -92,7 +92,7 @@ class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 		Long surveyId = createSurveyAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
 		SurveyFindResponse surveyFindResponse = findSurveyAndGetSurveyResponse(surveyId);
 
-		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "programmer");
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "developer");
 		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
 
 		// when

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
@@ -71,7 +71,7 @@ public class SpecificFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 		Long surveyId = createSurveyAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
 		SurveyFindResponse surveyFindResponse = getSurveyFindResponse(surveyId);
 
-		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "programmer");
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "developer");
 		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
 
 		Long feedbackId = findFeedbackAndGetRandomFeedbackId(token, surveyId);

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/RequestSample.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/RequestSample.java
@@ -40,7 +40,7 @@ public final class RequestSample {
 							.choiceRequestList(
 								List.of(
 									ChoiceRequest.builder()
-										.content("programmer")
+										.content("developer")
 										.order(1)
 										.build(),
 									ChoiceRequest.builder()
@@ -48,11 +48,11 @@ public final class RequestSample {
 										.order(2)
 										.build(),
 									ChoiceRequest.builder()
-										.content("product-manager")
+										.content("pm")
 										.order(3)
 										.build(),
 									ChoiceRequest.builder()
-										.content("other")
+										.content("others")
 										.order(4)
 										.build()
 								)
@@ -137,7 +137,7 @@ public final class RequestSample {
 							.choiceRequestList(
 								List.of(
 									ChoiceRequest.builder()
-										.content("programmer")
+										.content("developer")
 										.order(1)
 										.build(),
 									ChoiceRequest.builder()
@@ -145,11 +145,11 @@ public final class RequestSample {
 										.order(2)
 										.build(),
 									ChoiceRequest.builder()
-										.content("product-manager")
+										.content("pm")
 										.order(3)
 										.build(),
 									ChoiceRequest.builder()
-										.content("other")
+										.content("others")
 										.order(4)
 										.build()
 								)

--- a/api/api-mock/src/main/java/me/nalab/api/mock/MockController.java
+++ b/api/api-mock/src/main/java/me/nalab/api/mock/MockController.java
@@ -237,9 +237,9 @@ public class MockController {
 			+ "    },\n"
 			+ "    \"position\": {\n"
 			+ "        \"developer\": 2,\n"
-			+ "        \"product-manager\": 3,\n"
-			+ "        \"programmer\": 2,\n"
-			+ "        \"other\": 1\n"
+			+ "        \"pm\": 3,\n"
+			+ "        \"designer\": 2,\n"
+			+ "        \"others\": 1\n"
 			+ "    }\n"
 			+ "}";
 	}

--- a/survey/application/src/test/java/me/nalab/survey/application/service/summaryreviewer/ReviewerSummaryGetServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/summaryreviewer/ReviewerSummaryGetServiceTest.java
@@ -54,7 +54,7 @@ class ReviewerSummaryGetServiceTest {
 			Arguments.of( // expected
 				ReviewerSummaryDto.builder()
 					.position(ReviewerSummaryDto.Position.builder()
-						.positionReplyMap(Map.of("developer", 2, "designer", 1, "product-manager", 1))
+						.positionReplyMap(Map.of("developer", 2, "designer", 1, "pm", 1))
 						.build())
 					.collaborationExperience(ReviewerSummaryDto.CollaborationExperience.builder()
 						.yes(3)
@@ -63,7 +63,7 @@ class ReviewerSummaryGetServiceTest {
 					).build(),
 				List.of( // response
 					getReviewer("developer", true),
-					getReviewer("product-manager", false),
+					getReviewer("pm", false),
 					getReviewer("designer", true),
 					getReviewer("developer", true)
 				)

--- a/survey/domain/src/test/java/me/nalab/survey/domain/feedback/FeedbackDomainTest.java
+++ b/survey/domain/src/test/java/me/nalab/survey/domain/feedback/FeedbackDomainTest.java
@@ -48,7 +48,7 @@ class FeedbackDomainTest {
 		Survey survey = RandomSurveyFixture.createRandomSurvey();
 		List<Feedback> feedbackList = List.of(
 			getFeedback(survey, "hello", true, "designer"),
-			getFeedback(survey, "world", false, "product-manager"),
+			getFeedback(survey, "world", false, "pm"),
 			getFeedback(survey, "hello", false, "developer")
 		);
 

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/ReviewerRequest.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/ReviewerRequest.java
@@ -16,7 +16,7 @@ public class ReviewerRequest {
 	@JsonProperty("collaboration_experience")
 	private boolean collaborationExperience;
 
-	@Pattern(regexp = "^(designer|product-manager|programmer|other)$")
+	@Pattern(regexp = "^(designer|pm|developer|others)$")
 	private String position;
 
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/summaryreviewer/ReviewerSummaryResponseMapper.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/summaryreviewer/ReviewerSummaryResponseMapper.java
@@ -24,9 +24,9 @@ final class ReviewerSummaryResponseMapper {
 
 		return PositionSummaryReponse.builder()
 			.designer(reviewerSummaryDto.getPosition().getPositionReplyMap().getOrDefault("designer", 0))
-			.productManager(reviewerSummaryDto.getPosition().getPositionReplyMap().getOrDefault("product-manager", 0))
-			.programmer(reviewerSummaryDto.getPosition().getPositionReplyMap().getOrDefault("programmer", 0))
-			.other(reviewerSummaryDto.getPosition().getPositionReplyMap().getOrDefault("other", 0))
+			.productManager(reviewerSummaryDto.getPosition().getPositionReplyMap().getOrDefault("pm", 0))
+			.developer(reviewerSummaryDto.getPosition().getPositionReplyMap().getOrDefault("developer", 0))
+			.others(reviewerSummaryDto.getPosition().getPositionReplyMap().getOrDefault("others", 0))
 			.build();
 	}
 

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/summaryreviewer/response/PositionSummaryReponse.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/summaryreviewer/response/PositionSummaryReponse.java
@@ -14,9 +14,9 @@ import lombok.ToString;
 public class PositionSummaryReponse {
 
 	private final int designer;
-	@JsonProperty("product-manager")
+	@JsonProperty("pm")
 	private final int productManager;
-	private final int programmer;
-	private final int other;
+	private final int developer;
+	private final int others;
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
position naming을 전체적으로 변경했습니다.

## 어떻게 해결했나요?
- [x] `other` -> `others`
- [x] `programmer` -> `developer`
- [x] `product-manager` -> `pm`
- [x] 관련 테스크케이스와 매퍼를 변경했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
