### PR TITLE
[refactor] : unique constraint to `users.email`

### DIFF
--- a/api/src/main/resources/db/migration/V3__user_email_unique.sql
+++ b/api/src/main/resources/db/migration/V3__user_email_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD UNIQUE (email);

--- a/core/data/src/main/java/me/nalab/core/data/user/UserEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/user/UserEntity.java
@@ -24,6 +24,6 @@ public class UserEntity extends TimeBaseEntity {
 	@Column(nullable = false)
 	private String nickname;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String email;
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
엔티티 `users.email` 에 `unique` 제약이 안걸려있어서, 동시성 이슈로 중복 유저가 생성되는 문제를 해결했습니다.

## 어떻게 해결했나요?
- [x] flyway V3에 `users.email` 에 `unique` constraint 추가
- [x] user jpa entity users.email 필드에 `unique` constraint 추가

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
