### PR TITLE
[fix] : RequestBody의 Long id를 String으로 변환

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackCreateRequestFixture.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackCreateRequestFixture.java
@@ -2,7 +2,6 @@ package me.nalab.luffy.api.acceptance.test.feedback;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import me.nalab.luffy.api.acceptance.test.feedback.create.request.AbstractQuestionFeedbackRequest;
 import me.nalab.luffy.api.acceptance.test.feedback.create.request.ChoiceQuestionFeedbackRequest;
@@ -50,7 +49,7 @@ public class FeedbackCreateRequestFixture {
 	private static ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
+			.questionId(shortFormQuestionResponse.getQuestionId())
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -60,11 +59,8 @@ public class FeedbackCreateRequestFixture {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
-			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
-				.map(Long::valueOf)
-				.collect(
-					Collectors.toList()))
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/FeedbackCreateAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/FeedbackCreateAcceptanceTest.java
@@ -1,6 +1,7 @@
 package me.nalab.luffy.api.acceptance.test.feedback.create;
 
 import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.assertIsFeedbackCreated;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDateTime;
@@ -169,7 +170,7 @@ class FeedbackCreateAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
+			.questionId(shortFormQuestionResponse.getQuestionId())
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -179,11 +180,8 @@ class FeedbackCreateAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
-			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
-				.map(Long::valueOf)
-				.collect(
-					Collectors.toList()))
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/request/AbstractQuestionFeedbackRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/request/AbstractQuestionFeedbackRequest.java
@@ -10,7 +10,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class AbstractQuestionFeedbackRequest {
 
 	@JsonProperty("question_id")
-	protected Long questionId;
+	protected String questionId;
 	protected String type;
 
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/request/ChoiceQuestionFeedbackRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/request/ChoiceQuestionFeedbackRequest.java
@@ -12,6 +12,6 @@ import lombok.experimental.SuperBuilder;
 public class ChoiceQuestionFeedbackRequest extends AbstractQuestionFeedbackRequest {
 
 	@JsonProperty("choies")
-	private List<Long> choiceList;
+	private List<String> choiceList;
 
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
@@ -150,7 +150,7 @@ class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
+			.questionId(shortFormQuestionResponse.getQuestionId())
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -160,11 +160,8 @@ class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
-			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
-				.map(Long::valueOf)
-				.collect(
-					Collectors.toList()))
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
@@ -139,7 +139,7 @@ public class SpecificFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private static ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
+			.questionId(shortFormQuestionResponse.getQuestionId())
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -149,11 +149,8 @@ public class SpecificFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
-			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
-				.map(Long::valueOf)
-				.collect(
-					Collectors.toList()))
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummary/FeedbackFindSummaryAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummary/FeedbackFindSummaryAcceptanceTest.java
@@ -146,7 +146,7 @@ class FeedbackFindSummaryAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
+			.questionId(shortFormQuestionResponse.getQuestionId())
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -156,11 +156,8 @@ class FeedbackFindSummaryAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
-			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
-				.map(Long::valueOf)
-				.collect(
-					Collectors.toList()))
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
 			.build();
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/reviewer/summary/ReviewerSummarizeAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/reviewer/summary/ReviewerSummarizeAcceptanceTest.java
@@ -150,7 +150,7 @@ class ReviewerSummarizeAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
 		ShortFormQuestionResponse shortFormQuestionResponse) {
 		return ShortQuestionFeedbackRequest.builder()
-			.questionId(Long.valueOf(shortFormQuestionResponse.getQuestionId()))
+			.questionId(shortFormQuestionResponse.getQuestionId())
 			.replyList(List.of("mocking", "words", "hello!"))
 			.type("short")
 			.build();
@@ -160,11 +160,8 @@ class ReviewerSummarizeAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
 		return ChoiceQuestionFeedbackRequest.builder()
 			.type("choice")
-			.questionId(Long.valueOf(choiceFormQuestionResponse.getQuestionId()))
-			.choiceList(Stream.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId())
-				.map(Long::valueOf)
-				.collect(
-					Collectors.toList()))
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
 			.build();
 	}
 

--- a/api/src/main/resources/db/migration/V3__user_email_unique.sql
+++ b/api/src/main/resources/db/migration/V3__user_email_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD UNIQUE (email);

--- a/core/data/src/main/java/me/nalab/core/data/user/UserEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/user/UserEntity.java
@@ -24,6 +24,6 @@ public class UserEntity extends TimeBaseEntity {
 	@Column(nullable = false)
 	private String nickname;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String email;
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/FeedbackCreateController.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/FeedbackCreateController.java
@@ -70,15 +70,16 @@ public class FeedbackCreateController {
 	private ChoiceFormQuestionFeedbackDto toChoiceFormQuestionFeedbackDto(
 		ChoiceQuestionFeedbackRequest choiceQuestionFeedbackRequest) {
 		return ChoiceFormQuestionFeedbackDto.builder()
-			.questionId(choiceQuestionFeedbackRequest.getQuestionId())
-			.selectedChoiceIdSet(choiceQuestionFeedbackRequest.getChoiceSet())
+			.questionId(Long.valueOf(choiceQuestionFeedbackRequest.getQuestionId()))
+			.selectedChoiceIdSet(choiceQuestionFeedbackRequest.getChoiceSet().stream().map(Long::valueOf).collect(
+				Collectors.toSet()))
 			.build();
 	}
 
 	private ShortFormQuestionFeedbackDto toShortFormQuestionFeedbackDto(
 		ShortQuestionFeedbackRequest shortQuestionFeedbackRequest) {
 		return ShortFormQuestionFeedbackDto.builder()
-			.questionId(shortQuestionFeedbackRequest.getQuestionId())
+			.questionId(Long.valueOf(shortQuestionFeedbackRequest.getQuestionId()))
 			.replyList(shortQuestionFeedbackRequest.getReplyList())
 			.build();
 	}

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/AbstractQuestionFeedbackRequest.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/AbstractQuestionFeedbackRequest.java
@@ -19,6 +19,6 @@ import lombok.ToString;
 public abstract class AbstractQuestionFeedbackRequest {
 
 	@JsonProperty("question_id")
-	protected Long questionId;
+	protected String questionId;
 
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/ChoiceQuestionFeedbackRequest.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/ChoiceQuestionFeedbackRequest.java
@@ -14,6 +14,6 @@ import lombok.ToString;
 public class ChoiceQuestionFeedbackRequest extends AbstractQuestionFeedbackRequest {
 
 	@JsonProperty("choies")
-	private Set<Long> choiceSet;
+	private Set<String> choiceSet;
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
RequestBody의 Long id를 String id로 변경했습니다.
> JS 2020부터 2^64를 지원한다고 하네요..

## 어떻게 해결했나요?
- [x] feedback create request의 RequestBody Long type을 String type으로 변경했습니다.

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
