### PR TITLE
[fix] : `질문폼의 모든 리뷰어 목록 조회 API`에서 예외처리 추가

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbackreviewers/SurveyExistCheckPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/feedbackreviewers/SurveyExistCheckPort.java
@@ -1,0 +1,15 @@
+package me.nalab.survey.application.port.out.persistence.feedbackreviewers;
+
+/**
+ * Survey가 존재하는지 확인하는 인터페이스 입니다.
+ */
+public interface SurveyExistCheckPort {
+
+	/**
+	 * surveyId 를 인자로 받아, survey가 저장되어 있다면 true, 아니라면 false를 반환하는 인터페이스 입니다.
+	 *
+	 * @param surveyId 조회할 survey의 id 입니다.
+	 * @return boolean survey가 있다면 true, 없다면 false를 반환해야 합니다.
+	 */
+	boolean isExistSurveyBySurveyId(Long surveyId);
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/feedbackreviewers/FeedbackReviewersFindService.java
@@ -8,8 +8,10 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.common.feedback.mapper.FeedbackDtoMapper;
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
 import me.nalab.survey.application.port.in.web.feedbackreviewers.FeedbackReviewersFindUseCase;
 import me.nalab.survey.application.port.out.persistence.feedbackreviewers.FeedbacksFindPort;
+import me.nalab.survey.application.port.out.persistence.feedbackreviewers.SurveyExistCheckPort;
 import me.nalab.survey.domain.feedback.Feedback;
 
 @Service
@@ -18,11 +20,20 @@ public class FeedbackReviewersFindService implements FeedbackReviewersFindUseCas
 
 	private final FeedbacksFindPort feedbacksFindPort;
 
+	private final SurveyExistCheckPort surveyExistCheckPort;
+
 	@Override
 	public List<FeedbackDto> findAllFeedback(Long surveyId) {
+		throwIfSurveyDoesNotExist(surveyId);
 		List<Feedback> feedbacks = feedbacksFindPort.findAllFeedback(surveyId);
 		return feedbacks.stream()
 			.map(FeedbackDtoMapper::toDto)
 			.collect(Collectors.toList());
+	}
+
+	private void throwIfSurveyDoesNotExist(Long surveyId) {
+		if(!surveyExistCheckPort.isExistSurveyBySurveyId(surveyId)) {
+			throw new SurveyDoesNotExistException(surveyId);
+		}
 	}
 }

--- a/survey/application/src/main/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/findfeedbacksummary/FeedbackSummaryFindService.java
@@ -20,17 +20,17 @@ public class FeedbackSummaryFindService implements FeedbackSummaryFindUseCase {
 
 	@Override
 	public long getTotalFeedbackCount(Long surveyId) {
-		checkIfSurveyExist(surveyId);
+		throwIfSurveyDoesNotExist(surveyId);
 		return totalFeedbackCountPort.getTotalFeedbackCountBySurveyId(surveyId);
 	}
 
 	@Override
 	public long getUpdatedFeedbackCount(Long surveyId) {
-		checkIfSurveyExist(surveyId);
+		throwIfSurveyDoesNotExist(surveyId);
 		return updatedFeedbackCountPort.getUpdatedFeedbackCountBySurveyId(surveyId);
 	}
 
-	private void checkIfSurveyExist(Long surveyId) {
+	private void throwIfSurveyDoesNotExist(Long surveyId) {
 		if(!surveyExistCheckPort.isExistSurveyBySurveyId(surveyId)) {
 			throw new SurveyDoesNotExistException(surveyId);
 		}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/SurveyExistCheckAdaptor.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/SurveyExistCheckAdaptor.java
@@ -1,0 +1,23 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.survey.application.port.out.persistence.feedbackreviewers.SurveyExistCheckPort;
+import me.nalab.survey.jpa.adaptor.feedbackreviewers.repository.SurveyExistCheckJpaRepository;
+
+@Repository("feedbackreviewers.SurveyExistCheckAdaptor")
+public class SurveyExistCheckAdaptor implements SurveyExistCheckPort {
+
+	private final SurveyExistCheckJpaRepository surveyExistCheckJpaRepository;
+
+	SurveyExistCheckAdaptor(
+		@Qualifier("feedbackreviewers.SurveyExistCheckJpaRepository") SurveyExistCheckJpaRepository surveyExistCheckJpaRepository) {
+		this.surveyExistCheckJpaRepository = surveyExistCheckJpaRepository;
+	}
+
+	@Override
+	public boolean isExistSurveyBySurveyId(Long surveyId) {
+		return surveyExistCheckJpaRepository.existsById(surveyId);
+	}
+}

--- a/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/repository/SurveyExistCheckJpaRepository.java
+++ b/survey/jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/repository/SurveyExistCheckJpaRepository.java
@@ -1,0 +1,10 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+@Repository("feedbackreviewers.SurveyExistCheckJpaRepository")
+public interface SurveyExistCheckJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/SurveyExistCheckAdaptorTest.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/SurveyExistCheckAdaptorTest.java
@@ -1,0 +1,58 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = SurveyExistCheckAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class SurveyExistCheckAdaptorTest {
+
+	@Autowired
+	private SurveyExistCheckAdaptor surveyExistCheckAdaptor;
+
+	@Autowired
+	private TestSurveyJpaRepository testSurveyJpaRepository;
+
+	@Autowired
+	private TestTargetJpaRepository testTargetJpaRepository;
+
+	@Test
+	void SURVEY_EXIST_CHECK_SUCCESS() {
+		// given
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(1L)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.nickname("target")
+			.build();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		testTargetJpaRepository.save(targetEntity);
+		testSurveyJpaRepository.save(surveyEntity);
+
+		// when
+		boolean result = surveyExistCheckAdaptor.isExistSurveyBySurveyId(survey.getId());
+
+		// then
+		assertTrue(result);
+	}
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/TestSurveyJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/TestSurveyJpaRepository.java
@@ -1,0 +1,9 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyJpaRepository extends JpaRepository<SurveyEntity, Long> {
+}

--- a/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/TestTargetJpaRepository.java
+++ b/survey/jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/feedbackreviewers/TestTargetJpaRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.feedbackreviewers;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TestTargetJpaRepository extends JpaRepository<TargetEntity, Long> {
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문 폼의 모든 리뷰어 목록 조회 API에서 예외처리가 빠져있는 부분을 수정했습니다

<img width="731" alt="image" src="https://github.com/depromeet/na-lab-server/assets/71487608/51d9ce2a-df67-4e7a-94d9-d5c635b1a086">

지금 전체 예외처리 검토중인데 해당 부분의 예외처리가 빠져있어서 추가했습니다

## 어떻게 해결했나요?

## 이슈 넘버
- #194 


<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
