### PR TITLE
[hotfix] sign in 인수 test 타겟 초기화 추가

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/auth/signin/SignInWithOAuthAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/auth/signin/SignInWithOAuthAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import me.nalab.auth.web.adaptor.api.SignInWithOAuthController;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
 import me.nalab.luffy.api.acceptance.test.UserInitializer;
 import me.nalab.user.domain.user.Provider;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,9 @@ class SignInWithOAuthAcceptanceTest extends AbstractAuthTestSupporter {
 
 	@Autowired
 	private UserInitializer userInitializer;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
 
 	private static final ObjectMapper OBJECT_MAPPER;
 
@@ -73,7 +77,9 @@ class SignInWithOAuthAcceptanceTest extends AbstractAuthTestSupporter {
 		var oauthProvider = provider.name();
 		var apiRequest = new SignInWithOAuthController.Request(nickname, email);
 
-		userInitializer.saveUserWithOAuth(provider, nickname, email, LocalDateTime.now());
+		LocalDateTime now = LocalDateTime.now();
+		userInitializer.saveUserWithOAuth(provider, nickname, email, now);
+		targetInitializer.saveTargetAndGetId(nickname, now);
 
 		// when
 		ResultActions resultActions = postSignInWithOAuth(oauthProvider, OBJECT_MAPPER.writeValueAsString(apiRequest));

--- a/auth/auth-application/src/test/java/me/nalab/auth/application/service/SignInWithOAuthServiceTest.java
+++ b/auth/auth-application/src/test/java/me/nalab/auth/application/service/SignInWithOAuthServiceTest.java
@@ -4,7 +4,9 @@ import me.nalab.auth.application.common.dto.AuthToken;
 import me.nalab.auth.application.common.dto.SignInWithOAuthRequest;
 import me.nalab.auth.application.port.in.web.AuthTokenCreateUseCase;
 import me.nalab.auth.application.port.in.web.SignUpWithOAuthUseCase;
+import me.nalab.survey.application.common.survey.dto.TargetDto;
 import me.nalab.survey.application.port.in.web.CreateTargetUseCase;
+import me.nalab.survey.application.port.in.web.target.find.TargetFindByUsernameUseCase;
 import me.nalab.user.application.port.in.UserFindByProviderAndTokenUseCase;
 import me.nalab.user.domain.user.Provider;
 import org.assertj.core.api.Assertions;
@@ -28,6 +30,7 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = {SignInWithOAuthService.class})
 class SignInWithOAuthServiceTest {
 
+    public static final String USERNAME = "username";
     @Autowired
     private SignInWithOAuthService signInWithOAuthService;
 
@@ -36,6 +39,9 @@ class SignInWithOAuthServiceTest {
 
     @MockBean
     private CreateTargetUseCase createTargetUseCase;
+
+    @MockBean
+    private TargetFindByUsernameUseCase targetFindByUsernameUseCase;
 
     @MockBean
     private SignUpWithOAuthUseCase signUpWithOAuthUseCase;
@@ -81,6 +87,11 @@ class SignInWithOAuthServiceTest {
     void RETURN_AUTH_TOKEN_WHEN_VALID_INPUT() {
         // given
         var expectedToken = new AuthToken("token");
+        var targetDto = TargetDto.builder()
+                .id(1L)
+                .nickname(USERNAME)
+                .build();
+        when(targetFindByUsernameUseCase.findTargetByUsername(any())).thenReturn(Optional.of(targetDto));
         when(userFindByProviderAndTokenUseCase.findByProviderAndToken(any())).thenReturn(Optional.of(1L));
         when(authTokenCreateUseCase.create(any())).thenReturn(expectedToken);
         var request = createRequest().build();
@@ -97,6 +108,11 @@ class SignInWithOAuthServiceTest {
     void RETURN_AUTH_TOKEN_WHEN_VALID_INPUT_AND_NOT_SIGN_UP() {
         // given
         var expectedToken = new AuthToken("token");
+        var targetDto = TargetDto.builder()
+                .id(1L)
+                .nickname(USERNAME)
+                .build();
+        when(targetFindByUsernameUseCase.findTargetByUsername(any())).thenReturn(Optional.of(targetDto));
         when(userFindByProviderAndTokenUseCase.findByProviderAndToken(any())).thenReturn(Optional.empty());
         when(signUpWithOAuthUseCase.signUpWithOAuth(any())).thenReturn(1L);
         when(authTokenCreateUseCase.create(any())).thenReturn(expectedToken);
@@ -114,7 +130,7 @@ class SignInWithOAuthServiceTest {
     private SignInWithOAuthRequest.SignInWithOAuthRequestBuilder createRequest() {
         return SignInWithOAuthRequest.builder()
                 .providerName(Provider.KAKAO.name())
-                .username("username")
+                .username(USERNAME)
                 .email("test@test.com")
                 .phoneNumber(null);
     }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?

- 로그인 시 회원 가입되어있다면 이미 생성된 target을 조회하는 로직 변경에 대한 테스트 초기화 반영

## 어떻게 해결했나요?

- 인수테스트에 기 구현된 TargetInitializer를 통해 유저와 함께 target 초기화 추가
- 단위 테스트에 모킹 추가
