### PR TITLE
[feat] : Server Side Oauth Service 배포파일 생성

### DIFF
--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -47,6 +47,8 @@ jobs:
             DB_URL=${{ secrets.DB_URL }} 
             DB_USERNAME=${{ secrets.DB_USERNAME }} 
             DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            JWT_SECRET=${{ secrets.JWT_SECRET }}
+            KAKAO_CLIENT_ID=${{ secrets.KAKAO_CIENT_ID }}
           tags: | 
             samillmu/luffy:latest
             ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,22 @@ ARG JAR_FILE=./api/build/libs/*-SNAPSHOT.jar
 ARG DB_URL
 ARG DB_USERNAME
 ARG DB_PASSWORD
+ARG JWT_SECRET
+ARG KAKAO_CLIENT_ID
 
 COPY ${JAR_FILE} luffy.jar
 
 ENV db_url=${DB_URL} \
     db_username=${DB_USERNAME} \
-    db_password=${DB_PASSWORD}
+    db_password=${DB_PASSWORD} \
+    jwt_secret=${JWT_SECRET} \
+    kakao_client_id=${KAKAO_CLIENT_ID}
+
 
 ENTRYPOINT java -jar luffy.jar \
             --spring.datasource.url=${db_url} \
             --spring.datasource.username=${db_username} \
-            --spring.datasource.password=${db_password}
+            --spring.datasource.password=${db_password} \
+            --jwt.secret=${jwt_secret} \
+            --oauth.kakao.client-id=${kakao_client_id}
+


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
server side oauth service의 배포파일을 생성했습니다.

## 어떻게 해결했나요?
- [x] Dockerfile 수정
- [x] Github secret에 값 바인딩
- [x] docker-publisher action에 바인딩된 값 같이 빌드
 
<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
