### PR TITLE
[feat] : `@Authorization` 어노테이션 기반 권한 검증 기능

### DIFF
--- a/core/authorization/authorization-aop/build.gradle
+++ b/core/authorization/authorization-aop/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    api project(':core:authorization:authorization-core')
+
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+}

--- a/core/authorization/authorization-aop/src/main/java/me/nalab/core/authorization/aop/AuthorizationAspect.java
+++ b/core/authorization/authorization-aop/src/main/java/me/nalab/core/authorization/aop/AuthorizationAspect.java
@@ -1,0 +1,123 @@
+package me.nalab.core.authorization.aop;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.authorization.aop.meta.Auth;
+import me.nalab.core.authorization.aop.meta.Authorization;
+import me.nalab.core.authorization.aop.util.ValidatorFactoryStorage;
+import me.nalab.core.authorization.api.Authorizer;
+import me.nalab.core.authorization.spi.ParameterExtractor;
+import me.nalab.core.authorization.spi.Validator;
+import me.nalab.core.authorization.spi.ValidatorFactory;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AuthorizationAspect {
+
+	private final Authorizer authorizer;
+	private final ValidatorFactoryStorage validatorFactoryStorage;
+	private final HttpServletRequest httpServletRequest;
+
+	@Around("@annotation(me.nalab.core.authorization.aop.meta.Authorization)")
+	public Object authorization(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+		ValidatorFactory<? extends ParameterExtractor, ? extends Validator> validatorFactory = extractValidatorFactory(
+			proceedingJoinPoint);
+
+		Class<?> expectedType = httpServletRequest.getAttribute("logined").getClass();
+		int targetIdx = getAuthAnnotatedParameterIdx(getMethod(proceedingJoinPoint));
+		Object[] args = proceedingJoinPoint.getArgs();
+		Class<?> targetType = args[targetIdx].getClass();
+
+		authorizer.authorization(expectedType.cast(httpServletRequest.getAttribute("logined")),
+			targetType.cast(args[targetIdx]), validatorFactory);
+
+		return proceedingJoinPoint.proceed(args);
+	}
+
+	@SuppressWarnings("unchecked")
+	private ValidatorFactory<ParameterExtractor, Validator> extractValidatorFactory(
+		JoinPoint joinPoint) {
+		Method targetMethod = getMethod(joinPoint);
+		Authorization authorization = getAuthorization(targetMethod);
+		return validatorFactoryStorage.getFactoryByType(
+			(Class<? extends ValidatorFactory<ParameterExtractor, Validator>>)authorization.factory());
+	}
+
+	private Method getMethod(JoinPoint joinPoint) {
+		String methodName = joinPoint.getSignature().getName();
+		Class<?> targetClass = joinPoint.getTarget().getClass();
+		try {
+			return getDeclaredMethod(methodName, targetClass);
+		} catch(NoSuchMethodException nse) {
+			return getInheritedMethod(methodName, targetClass);
+		}
+	}
+
+	private Method getDeclaredMethod(String methodName, Class<?> targetClass) throws NoSuchMethodException {
+		Method[] methods = targetClass.getDeclaredMethods();
+		return findMethodByName(methods, methodName);
+	}
+
+	private Method getInheritedMethod(String methodName, Class<?> targetClass) {
+		try {
+			Method[] methods = targetClass.getMethods();
+			return findMethodByName(methods, methodName);
+		} catch(NoSuchMethodException nse) {
+			throw new IllegalStateException(
+				"Cannot aspect method cause, cannot find method named by \"" + targetClass.getName() + "." + methodName
+					+ "()\"");
+		}
+	}
+
+	private Method findMethodByName(Method[] methods, String methodName) throws NoSuchMethodException {
+		for(Method method : methods) {
+			if(method.getName().equals(methodName)) {
+				return method;
+			}
+		}
+		throw new NoSuchMethodException();
+	}
+
+	private Authorization getAuthorization(Method method) {
+		Authorization authorization = method.getDeclaredAnnotation(Authorization.class);
+		if(authorization == null) {
+			authorization = method.getAnnotation(Authorization.class);
+		}
+		if(authorization == null) {
+			throw new IllegalStateException(
+				"Cannot aspect method cause, cannot find annotation by \"" + method.getName() + "\""
+			);
+		}
+		return authorization;
+	}
+
+	private int getAuthAnnotatedParameterIdx(Method method) {
+		Parameter[] parameters = method.getParameters();
+		for(int i = 0; i < parameters.length; i++) {
+			if(isAuthAnnotatedParameter(parameters[i])) {
+				return i;
+			}
+		}
+		throw new IllegalStateException("Cannot find @Auth annotated parameter on \"" + method.getName() + "\"");
+	}
+
+	private boolean isAuthAnnotatedParameter(Parameter parameter) {
+		Auth auth = parameter.getDeclaredAnnotation(Auth.class);
+		if(auth == null) {
+			auth = parameter.getAnnotation(Auth.class);
+		}
+		return auth != null;
+	}
+
+}

--- a/core/authorization/authorization-aop/src/main/java/me/nalab/core/authorization/aop/meta/Auth.java
+++ b/core/authorization/authorization-aop/src/main/java/me/nalab/core/authorization/aop/meta/Auth.java
@@ -1,0 +1,17 @@
+package me.nalab.core.authorization.aop.meta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 이 어노테이션이 마크된 파라미터는 권한 인증의 대상이 됩니다. <br> <br>
+ *
+ * *주의* <br>
+ * 하나의 메소드의 파라미터에 @Auth 어노테이션이 여러개 마킹되어 있을경우, 첫번째 파라미터만 권한 인증의 대상이 됩니다.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/core/authorization/authorization-aop/src/main/java/me/nalab/core/authorization/aop/meta/Authorization.java
+++ b/core/authorization/authorization-aop/src/main/java/me/nalab/core/authorization/aop/meta/Authorization.java
@@ -1,0 +1,26 @@
+package me.nalab.core.authorization.aop.meta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import me.nalab.core.authorization.spi.ValidatorFactory;
+
+/**
+ * 이 어노테이션이 마크된 메소드는 호출전에, 권한 인증이 진행됩니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authorization {
+
+	/**
+	 * 인증에 사용할 ValidatorFactory 구현체를 등록합니다.
+	 *
+	 * @see ValidatorFactory
+	 *
+	 * @return ValidatorFactory 구현체의 class
+	 */
+	Class<?> factory();
+
+}

--- a/core/authorization/authorization-aop/src/main/java/me/nalab/core/authorization/aop/util/ValidatorFactoryStorage.java
+++ b/core/authorization/authorization-aop/src/main/java/me/nalab/core/authorization/aop/util/ValidatorFactoryStorage.java
@@ -1,0 +1,22 @@
+package me.nalab.core.authorization.aop.util;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import lombok.AllArgsConstructor;
+import me.nalab.core.authorization.spi.ParameterExtractor;
+import me.nalab.core.authorization.spi.Validator;
+import me.nalab.core.authorization.spi.ValidatorFactory;
+
+@Component
+@AllArgsConstructor
+public class ValidatorFactoryStorage {
+
+	private final ApplicationContext applicationContext;
+
+	public ValidatorFactory<ParameterExtractor, Validator> getFactoryByType(
+		Class<? extends ValidatorFactory<ParameterExtractor, Validator>> type) {
+		return applicationContext.getBean(type);
+	}
+
+}

--- a/core/authorization/authorization-aop/src/main/java/module-info.java
+++ b/core/authorization/authorization-aop/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module luffy.core.authorization.authorization.aop.main {
+
+	requires org.apache.tomcat.embed.core;
+	requires org.aspectj.weaver;
+	requires spring.context;
+	requires lombok;
+	requires luffy.core.authorization.authorization.core.main;
+
+}

--- a/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/AspectTarget.java
+++ b/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/AspectTarget.java
@@ -1,0 +1,27 @@
+package me.nalab.core.authorization.aop;
+
+import org.springframework.stereotype.Component;
+
+import me.nalab.core.authorization.aop.meta.Auth;
+import me.nalab.core.authorization.aop.meta.Authorization;
+import me.nalab.core.authorization.aop.validator.LongValidorFactory;
+
+@Component
+class AspectTarget {
+
+	@Authorization(factory = LongValidorFactory.class)
+	Long isArrived(@Auth Long id) {
+		return id;
+	}
+
+	@Authorization(factory = LongValidorFactory.class)
+	Long isArrived(@Auth Long id1, @Auth Long id2) {
+		return id1;
+	}
+
+	@Authorization(factory = LongValidorFactory.class)
+	Long isArrivedWithOutAuth(Long id) {
+		return id;
+	}
+
+}

--- a/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/AuthorizationAspectTest.java
+++ b/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/AuthorizationAspectTest.java
@@ -1,0 +1,109 @@
+package me.nalab.core.authorization.aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.core.authorization.aop.util.ValidatorFactoryStorage;
+import me.nalab.core.authorization.aop.validator.LongValidorFactory;
+import me.nalab.core.authorization.engine.CannotAuthorizationException;
+import me.nalab.core.authorization.spring.Configurer;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {Configurer.class,
+	AuthorizationAspect.class,
+	ValidatorFactoryStorage.class,
+	AspectTarget.class,
+	LongValidorFactory.class
+})
+class AuthorizationAspectTest {
+
+	@Autowired
+	private AuthorizationAspect authorizationAspect;
+
+	@MockBean
+	private MockHttpServletRequest mockHttpServletRequest;
+
+	@Test
+	@DisplayName("하나의 @Auth가 있을때, 인증에 성공한다.")
+	void AUTHORIZATION_WITH_SINGLE_AUTH() {
+		// given
+		Long parameter = 1L;
+		AspectTarget aspectTarget = getAspectTarget();
+
+		when(mockHttpServletRequest.getAttribute("logined")).thenReturn(parameter);
+
+		// when
+		Long result = aspectTarget.isArrived(parameter);
+
+		// then
+		assertThat(result).isEqualTo(parameter);
+	}
+
+	@Test
+	@DisplayName("두개의 @Auth가 있을때, 첫번째 Auth 기준으로 인증하면 성공한다.")
+	void AUTHORIZATION_WITH_TWO_AUTH_FIRST_PARAMETER() {
+		// given
+		Long parameter1 = 1L;
+		Long parameter2 = 2L;
+		AspectTarget aspectTarget = getAspectTarget();
+
+		when(mockHttpServletRequest.getAttribute("logined")).thenReturn(parameter1);
+
+		// when
+		Long result = aspectTarget.isArrived(parameter1, parameter2);
+
+		// then
+		assertThat(result).isEqualTo(parameter1);
+	}
+
+	@Test
+	@DisplayName("두개의 @Auth가 있을때, 두번째 Auth 기준으로 인증하면 실패한다.")
+	void AUTHORIZATION_WITH_TWO_SECOND_PARAMETER() {
+		// given
+		Long parameter1 = 1L;
+		Long parameter2 = 2L;
+		AspectTarget aspectTarget = getAspectTarget();
+
+		when(mockHttpServletRequest.getAttribute("logined")).thenReturn(parameter1);
+
+		// when
+		Exception result = catchException(() -> aspectTarget.isArrived(parameter2, parameter1));
+
+		// then
+		assertThat(result.getClass()).isEqualTo(CannotAuthorizationException.class);
+	}
+
+	@Test
+	@DisplayName("@Auth 어노테이션이 없을때, 실패한다.")
+	void AUTHORIZATION_WITH_NO_AUTH_ANNOTATION() {
+		// given
+		Long parameter = 1L;
+		AspectTarget aspectTarget = getAspectTarget();
+
+		when(mockHttpServletRequest.getAttribute("logined")).thenReturn(parameter);
+
+		// when
+		Exception result = catchException(() -> aspectTarget.isArrivedWithOutAuth(parameter));
+
+		// then
+		assertThat(result.getClass()).isEqualTo(IllegalStateException.class);
+	}
+
+	private AspectTarget getAspectTarget() {
+		AspectJProxyFactory aspectJProxyFactory = new AspectJProxyFactory(new AspectTarget());
+		aspectJProxyFactory.addAspect(authorizationAspect);
+		return aspectJProxyFactory.getProxy();
+	}
+
+}

--- a/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/validator/LongValidExtractor.java
+++ b/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/validator/LongValidExtractor.java
@@ -1,0 +1,21 @@
+package me.nalab.core.authorization.aop.validator;
+
+import me.nalab.core.authorization.engine.ParameterReference;
+import me.nalab.core.authorization.spi.ParameterExtractor;
+
+public class LongValidExtractor implements ParameterExtractor {
+
+	@Override
+	public <S> ParameterReference extract(S target) {
+		validType(target);
+		return ParameterReference.createInstance(target);
+	}
+
+	private <S> void validType(S target) {
+		if(target instanceof Long) {
+			return;
+		}
+		throw new IllegalStateException();
+	}
+
+}

--- a/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/validator/LongValidator.java
+++ b/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/validator/LongValidator.java
@@ -1,0 +1,20 @@
+package me.nalab.core.authorization.aop.validator;
+
+import me.nalab.core.authorization.spi.Validator;
+
+public class LongValidator implements Validator {
+
+	@Override
+	public <T, S> boolean valid(T expected, S result) {
+		validType(expected, result);
+		return expected.equals(result);
+	}
+
+	private <T, S> void validType(T expected, S result) {
+		if(expected instanceof Long && result instanceof Long) {
+			return;
+		}
+		throw new IllegalStateException();
+	}
+
+}

--- a/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/validator/LongValidorFactory.java
+++ b/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/validator/LongValidorFactory.java
@@ -1,0 +1,17 @@
+package me.nalab.core.authorization.aop.validator;
+
+import me.nalab.core.authorization.spi.ValidatorFactory;
+
+public class LongValidorFactory implements ValidatorFactory<LongValidExtractor, LongValidator> {
+
+	@Override
+	public LongValidExtractor parameterExtractor() {
+		return new LongValidExtractor();
+	}
+
+	@Override
+	public LongValidator validator() {
+		return new LongValidator();
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,7 @@ include 'core:id-generator:tsid'
 include 'core:id-generator:mock-id-generator'
 include 'core:id-generator:id-generator-starter'
 include 'core:authorization:authorization-core'
+include 'core:authorization:authorization-aop'
 
 include 'user'
 include 'user:user-domain'
@@ -47,4 +48,3 @@ include 'user:user-jpa-adapter'
 include 'user:user-application'
 include 'user:user-web-adaptor'
 include 'auth:auth-interceptor'
-


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`@Authorization` 과 `@Auth` 어노테이션을 이용해 권한 검증을 진행하는 AOP를 추가했습니다.

사용예시
``` java
@Component
class AspectTarget {

	// 예) Survey에 실 적용하면 SurveyValidatorFactory.class 적용
	@Authorization(factory = LongValidorFactory.class) 
	Long isArrived(@Auth Long id) {
		return id;
	}

	@Authorization(factory = LongValidorFactory.class)
	Long isArrived(@Auth Long id1, @Auth Long id2) {
		return id1;
	}

	@Authorization(factory = LongValidorFactory.class)
	Long isArrivedWithOutAuth(Long id) {
		return id;
	}

}
```

## 어떻게 해결했나요?
- [x] 권한 검증을 진행하는 Aspect 를 추가했습니다.
- [x] 팩토리에 권한 검증을 진행할 로직을 유연하게 설정하도록 추가  
- [x] `@Authorization` -> pointcut 으로 설정
- [x] `@Auth` -> 권한 weaving 시 사용할 파라미터 마킹용 어노테이션으로 설정
- [x] 관련 테스트케이스 추가

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
