### PR TITLE
[refactor] : survey가 여러개일시 마지막 값이 반환되도록 수정

### DIFF
--- a/survey/application/src/main/java/me/nalab/survey/application/service/getid/SurveyIdGetService.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/getid/SurveyIdGetService.java
@@ -1,5 +1,6 @@
 package me.nalab.survey.application.service.getid;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -23,10 +24,8 @@ public class SurveyIdGetService implements SurveyIdGetUseCase {
 		if(surveyIdList == null || surveyIdList.isEmpty()) {
 			throw new TargetDoesNotHasSurveyException(targetId);
 		}
-		if(surveyIdList.size() > 1) {
-			throw new IllegalStateException("Survey created more than 1");
-		}
-		return surveyIdList.get(0);
+		Collections.sort(surveyIdList);
+		return surveyIdList.get(surveyIdList.size() - 1);
 	}
 
 }

--- a/survey/application/src/test/java/me/nalab/survey/application/service/getid/SurveyIdGetServiceTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/getid/SurveyIdGetServiceTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +36,8 @@ class SurveyIdGetServiceTest {
 	@DisplayName("SurveyId List 조회 성공 테스트")
 	void GET_SURVEY_ID_LIST_SUCCESS() {
 		// given
-		List<Long> expectedSurveyIdList = List.of(1L);
+		List<Long> expectedSurveyIdList = new ArrayList<>();
+		expectedSurveyIdList.add(1L);
 
 		// when
 		when(surveyIdFindPort.findAllSurveyIdByTargetId(anyLong())).thenReturn(expectedSurveyIdList);


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
survey가 여러개 생성되었을때, `/v1/surveys-id` api가 마지막 survey의 id를 반환하도록 수정했습니다.

## 어떻게 해결했나요?
- [x] IllegalStateException 던지는 로직 삭제
- [x] ID값 기준 정렬 로직 추가
 
<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
