### PR TITLE
[feat] : survey authorization validator 확장 정의

### DIFF
--- a/core/authorization/authorization-aop/src/main/java/module-info.java
+++ b/core/authorization/authorization-aop/src/main/java/module-info.java
@@ -1,5 +1,7 @@
 module luffy.core.authorization.authorization.aop.main {
 
+	exports me.nalab.core.authorization.aop.meta;
+
 	requires org.apache.tomcat.embed.core;
 	requires org.aspectj.weaver;
 	requires spring.context;

--- a/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/validator/LongValidExtractor.java
+++ b/core/authorization/authorization-aop/src/test/java/me/nalab/core/authorization/aop/validator/LongValidExtractor.java
@@ -1,6 +1,6 @@
 package me.nalab.core.authorization.aop.validator;
 
-import me.nalab.core.authorization.engine.ParameterReference;
+import me.nalab.core.authorization.api.ParameterReference;
 import me.nalab.core.authorization.spi.ParameterExtractor;
 
 public class LongValidExtractor implements ParameterExtractor {

--- a/core/authorization/authorization-core/src/main/java/me/nalab/core/authorization/api/ParameterReference.java
+++ b/core/authorization/authorization-core/src/main/java/me/nalab/core/authorization/api/ParameterReference.java
@@ -1,4 +1,4 @@
-package me.nalab.core.authorization.engine;
+package me.nalab.core.authorization.api;
 
 public class ParameterReference {
 

--- a/core/authorization/authorization-core/src/main/java/me/nalab/core/authorization/api/WrongReferenceTypeException.java
+++ b/core/authorization/authorization-core/src/main/java/me/nalab/core/authorization/api/WrongReferenceTypeException.java
@@ -1,4 +1,4 @@
-package me.nalab.core.authorization.engine;
+package me.nalab.core.authorization.api;
 
 public class WrongReferenceTypeException extends RuntimeException {
 

--- a/core/authorization/authorization-core/src/main/java/me/nalab/core/authorization/engine/DefaultAuthorizerEngine.java
+++ b/core/authorization/authorization-core/src/main/java/me/nalab/core/authorization/engine/DefaultAuthorizerEngine.java
@@ -1,6 +1,7 @@
 package me.nalab.core.authorization.engine;
 
 import me.nalab.core.authorization.api.Authorizer;
+import me.nalab.core.authorization.api.ParameterReference;
 import me.nalab.core.authorization.spi.ParameterExtractor;
 import me.nalab.core.authorization.spi.Validator;
 import me.nalab.core.authorization.spi.ValidatorFactory;

--- a/core/authorization/authorization-core/src/main/java/me/nalab/core/authorization/spi/ParameterExtractor.java
+++ b/core/authorization/authorization-core/src/main/java/me/nalab/core/authorization/spi/ParameterExtractor.java
@@ -1,6 +1,6 @@
 package me.nalab.core.authorization.spi;
 
-import me.nalab.core.authorization.engine.ParameterReference;
+import me.nalab.core.authorization.api.ParameterReference;
 
 /**
  * 요청받은 인자를 권한 인증에 필요한 ParameterReference 로 Wrapping 하는 SPI 입니다.

--- a/core/authorization/authorization-core/src/test/java/me/nalab/core/authorization/engine/ParameterReferenceTest.java
+++ b/core/authorization/authorization-core/src/test/java/me/nalab/core/authorization/engine/ParameterReferenceTest.java
@@ -6,6 +6,9 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import me.nalab.core.authorization.api.ParameterReference;
+import me.nalab.core.authorization.api.WrongReferenceTypeException;
+
 class ParameterReferenceTest {
 
 	@Test

--- a/core/authorization/authorization-core/src/test/java/me/nalab/core/authorization/spi/AuthorizationSystemTest.java
+++ b/core/authorization/authorization-core/src/test/java/me/nalab/core/authorization/spi/AuthorizationSystemTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.catchException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import me.nalab.core.authorization.engine.ParameterReference;
+import me.nalab.core.authorization.api.ParameterReference;
 import me.nalab.core.authorization.validator.LongValidorFactory;
 import me.nalab.core.authorization.validator.StringValidatorFactory;
 

--- a/core/authorization/authorization-core/src/test/java/me/nalab/core/authorization/validator/LongValidExtractor.java
+++ b/core/authorization/authorization-core/src/test/java/me/nalab/core/authorization/validator/LongValidExtractor.java
@@ -1,6 +1,6 @@
 package me.nalab.core.authorization.validator;
 
-import me.nalab.core.authorization.engine.ParameterReference;
+import me.nalab.core.authorization.api.ParameterReference;
 import me.nalab.core.authorization.spi.ParameterExtractor;
 
 public class LongValidExtractor implements ParameterExtractor {

--- a/core/authorization/authorization-core/src/test/java/me/nalab/core/authorization/validator/StringValidExtractor.java
+++ b/core/authorization/authorization-core/src/test/java/me/nalab/core/authorization/validator/StringValidExtractor.java
@@ -1,6 +1,6 @@
 package me.nalab.core.authorization.validator;
 
-import me.nalab.core.authorization.engine.ParameterReference;
+import me.nalab.core.authorization.api.ParameterReference;
 import me.nalab.core.authorization.spi.ParameterExtractor;
 
 public class StringValidExtractor implements ParameterExtractor {

--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -45,3 +45,4 @@ exclude me/nalab/auth/application/common/**/*
 exclude me/nalab/user/web/adaptor/logined/*
 exclude me/nalab/auth/interceptor/*
 exclude me/nalab/core/authorization/spring/Configurer
+exclude me/nalab/survey/application/port/in/authorization/SurveyAuthorization

--- a/survey/application/build.gradle
+++ b/survey/application/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
+    implementation project(':core:authorization:authorization-core')
     implementation project(':survey:domain')
-    testImplementation project(':survey:domain')
 
     implementation project(':core:id-generator:id-generator-starter')
 

--- a/survey/application/src/main/java/me/nalab/survey/application/port/in/authorization/SurveyAuthorization.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/in/authorization/SurveyAuthorization.java
@@ -1,0 +1,18 @@
+package me.nalab.survey.application.port.in.authorization;
+
+import me.nalab.core.authorization.spi.ParameterExtractor;
+import me.nalab.core.authorization.spi.Validator;
+import me.nalab.core.authorization.spi.ValidatorFactory;
+import me.nalab.survey.application.service.authorization.FeedbackIdValidatorFactory;
+import me.nalab.survey.application.service.authorization.SurveyIdValidatorFactory;
+
+public final class SurveyAuthorization {
+
+	public static final Class<? extends ValidatorFactory<? extends ParameterExtractor, ? extends Validator>> SURVEY_ID_VALIDATOR = SurveyIdValidatorFactory.class;
+	public static final Class<? extends ValidatorFactory<? extends ParameterExtractor, ? extends Validator>> FEEDBACK_ID_VALIDATOR = FeedbackIdValidatorFactory.class;
+
+	private SurveyAuthorization() {
+		throw new UnsupportedOperationException("Cannot invoke constructor \"SurveyAuthorization()\"");
+	}
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/authorization/TargetIdFindPort.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/port/out/persistence/authorization/TargetIdFindPort.java
@@ -1,0 +1,28 @@
+package me.nalab.survey.application.port.out.persistence.authorization;
+
+import java.util.Optional;
+
+/**
+ * Target의 id를 반환하는 인터페이스 입니다.
+ */
+public interface TargetIdFindPort {
+
+	/**
+	 * surveyId를 인자로 받아, 해당 surveyId를 소유하고있는 target의 Id를 반환합니다.
+	 * 만약, target의 Id를 찾을 수 없다면, Optional.empty() 를 반환합니다.
+	 *
+	 * @param surveyId survey의 id
+	 * @return 있다면, surveyId를 소유하고있는 target의 Id
+	 */
+	Optional<Long> findTargetIdBySurveyId(Long surveyId);
+
+	/**
+	 * feedbackId를 인자로 받아, 해당 surveyId를 소유하고있는 feedback의 Id를 반환합니다.
+	 * 만약, feedback의 Id를 찾을 수 없다면, Optional.empty() 를 반환합니다.
+	 *
+	 * @param feedbackId feedback의 id
+	 * @return 있다면, feedbackId를 소유하고있는 target의 Id
+	 */
+	Optional<Long> findTargetIdByFeedbackId(Long feedbackId);
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/authorization/FeedbackIdValidator.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/authorization/FeedbackIdValidator.java
@@ -1,6 +1,7 @@
 package me.nalab.survey.application.service.authorization;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.core.authorization.spi.Validator;
@@ -14,6 +15,7 @@ public class FeedbackIdValidator implements Validator {
 	private final TargetIdFindPort targetIdFindPort;
 
 	@Override
+	@Transactional(readOnly = true)
 	public <T, S> boolean valid(T expected, S result) {
 		validType(expected, result);
 		Long expectedTargetId = (Long)expected;

--- a/survey/application/src/main/java/me/nalab/survey/application/service/authorization/FeedbackIdValidator.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/authorization/FeedbackIdValidator.java
@@ -1,0 +1,36 @@
+package me.nalab.survey.application.service.authorization;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.authorization.spi.Validator;
+import me.nalab.survey.application.exception.FeedbackDoesNotExistException;
+import me.nalab.survey.application.port.out.persistence.authorization.TargetIdFindPort;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackIdValidator implements Validator {
+
+	private final TargetIdFindPort targetIdFindPort;
+
+	@Override
+	public <T, S> boolean valid(T expected, S result) {
+		validType(expected, result);
+		Long expectedTargetId = (Long)expected;
+		Long requestFeedbackId = (Long)result;
+		Long resultTargetId = targetIdFindPort.findTargetIdByFeedbackId(requestFeedbackId).orElseThrow(() -> {
+			throw new FeedbackDoesNotExistException(requestFeedbackId);
+		});
+		return expectedTargetId.equals(resultTargetId);
+	}
+
+	private <T, S> void validType(T expected, S result) {
+		if(expected instanceof Long && result instanceof Long) {
+			return;
+		}
+		throw new IllegalArgumentException(
+			"Expected \"expected\" type was Long \"" + expected.getClass() + "\"Expected \"result\" type was Long \""
+				+ result.getClass() + "\"");
+	}
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/authorization/FeedbackIdValidatorFactory.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/authorization/FeedbackIdValidatorFactory.java
@@ -1,0 +1,25 @@
+package me.nalab.survey.application.service.authorization;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.authorization.spi.ValidatorFactory;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackIdValidatorFactory implements ValidatorFactory<LongParameterExtractor, FeedbackIdValidator> {
+
+	private final LongParameterExtractor longParameterExtractor;
+	private final FeedbackIdValidator feedbackIdValidator;
+
+	@Override
+	public LongParameterExtractor parameterExtractor() {
+		return longParameterExtractor;
+	}
+
+	@Override
+	public FeedbackIdValidator validator() {
+		return feedbackIdValidator;
+	}
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/authorization/LongParameterExtractor.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/authorization/LongParameterExtractor.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.service.authorization;
+
+import org.springframework.stereotype.Service;
+
+import me.nalab.core.authorization.api.ParameterReference;
+import me.nalab.core.authorization.spi.ParameterExtractor;
+
+@Service
+public class LongParameterExtractor implements ParameterExtractor {
+
+	@Override
+	public <S> ParameterReference extract(S target) {
+		if(target instanceof Long) {
+			return ParameterReference.createInstance((Long)target);
+		}
+		throw new IllegalArgumentException(
+			"Cannot create reference cause expected target type is \"Long\" but was \"" + target.getClass() + "\"");
+	}
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/authorization/SurveyIdValidator.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/authorization/SurveyIdValidator.java
@@ -1,0 +1,36 @@
+package me.nalab.survey.application.service.authorization;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.authorization.spi.Validator;
+import me.nalab.survey.application.exception.SurveyDoesNotExistException;
+import me.nalab.survey.application.port.out.persistence.authorization.TargetIdFindPort;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyIdValidator implements Validator {
+
+	private final TargetIdFindPort targetIdFindPort;
+
+	@Override
+	public <T, S> boolean valid(T expected, S result) {
+		validType(expected, result);
+		Long expectedTargetId = (Long)expected;
+		Long requestSurveyId = (Long)result;
+		Long resultTargetId = targetIdFindPort.findTargetIdBySurveyId(requestSurveyId).orElseThrow(() -> {
+			throw new SurveyDoesNotExistException(requestSurveyId);
+		});
+		return expectedTargetId.equals(resultTargetId);
+	}
+
+	private <T, S> void validType(T expected, S result) {
+		if(expected instanceof Long && result instanceof Long) {
+			return;
+		}
+		throw new IllegalArgumentException(
+			"Expected \"expected\" type was Long \"" + expected.getClass() + "\"Expected \"result\" type was Long \""
+				+ result.getClass() + "\"");
+	}
+
+}

--- a/survey/application/src/main/java/me/nalab/survey/application/service/authorization/SurveyIdValidator.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/authorization/SurveyIdValidator.java
@@ -1,6 +1,7 @@
 package me.nalab.survey.application.service.authorization;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.core.authorization.spi.Validator;
@@ -14,6 +15,7 @@ public class SurveyIdValidator implements Validator {
 	private final TargetIdFindPort targetIdFindPort;
 
 	@Override
+	@Transactional(readOnly = true)
 	public <T, S> boolean valid(T expected, S result) {
 		validType(expected, result);
 		Long expectedTargetId = (Long)expected;

--- a/survey/application/src/main/java/me/nalab/survey/application/service/authorization/SurveyIdValidatorFactory.java
+++ b/survey/application/src/main/java/me/nalab/survey/application/service/authorization/SurveyIdValidatorFactory.java
@@ -1,0 +1,25 @@
+package me.nalab.survey.application.service.authorization;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.authorization.spi.ValidatorFactory;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyIdValidatorFactory implements ValidatorFactory<LongParameterExtractor, SurveyIdValidator> {
+
+	private final SurveyIdValidator surveyIdValidator;
+	private final LongParameterExtractor longParameterExtractor;
+
+	@Override
+	public LongParameterExtractor parameterExtractor() {
+		return longParameterExtractor;
+	}
+
+	@Override
+	public SurveyIdValidator validator() {
+		return surveyIdValidator;
+	}
+
+}

--- a/survey/application/src/main/java/module-info.java
+++ b/survey/application/src/main/java/module-info.java
@@ -24,10 +24,12 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.common.feedback.mapper;
 	exports me.nalab.survey.application.port.out.persistence.findspecific;
 	exports me.nalab.survey.application.port.in.web.findspecific;
-    exports me.nalab.survey.application.common.target.dto;
+	exports me.nalab.survey.application.common.target.dto;
+	exports me.nalab.survey.application.port.in.authorization;
 
-    requires luffy.survey.domain.main;
+	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;
+	requires luffy.core.authorization.authorization.core.main;
 
 	requires lombok;
 

--- a/survey/application/src/test/java/me/nalab/survey/application/service/authorization/FeedbackIdValidatorTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/authorization/FeedbackIdValidatorTest.java
@@ -1,0 +1,101 @@
+package me.nalab.survey.application.service.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.core.authorization.api.ParameterReference;
+import me.nalab.survey.application.port.out.persistence.authorization.TargetIdFindPort;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {FeedbackIdValidator.class, FeedbackIdValidatorFactory.class,
+	LongParameterExtractor.class})
+class FeedbackIdValidatorTest {
+
+	@Autowired
+	private FeedbackIdValidatorFactory feedbackIdValidatorFactory;
+
+	@MockBean
+	private TargetIdFindPort targetIdFindPort;
+
+	@Test
+	@DisplayName("targetId와 targetId가 갖고있는 feedbackId가 들어왔을때, 검증에 성공한다.")
+	void VALID_SUCCESS() {
+		// given
+		FeedbackIdValidator feedbackIdValidator = feedbackIdValidatorFactory.validator();
+		LongParameterExtractor longParameterExtractor = feedbackIdValidatorFactory.parameterExtractor();
+		Long targetId = 1L;
+		Long feedbackId = 2L;
+		ParameterReference parameterReference = longParameterExtractor.extract(feedbackId);
+
+		when(targetIdFindPort.findTargetIdByFeedbackId(feedbackId)).thenReturn(Optional.of(1L));
+
+		// when
+		boolean result = feedbackIdValidator.valid(targetId, parameterReference.value(Long.class));
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("targetId와 targetId가 갖고있지 않은 feedbackId가 들어왔을때, 검증에 실패한다.")
+	void VALID_FAIL() {
+		// given
+		FeedbackIdValidator feedbackIdValidator = feedbackIdValidatorFactory.validator();
+		LongParameterExtractor longParameterExtractor = feedbackIdValidatorFactory.parameterExtractor();
+		Long targetId = 1L;
+		Long feedbackId = 2L;
+		ParameterReference parameterReference = longParameterExtractor.extract(feedbackId);
+
+		when(targetIdFindPort.findTargetIdByFeedbackId(feedbackId)).thenReturn(Optional.of(3L));
+
+		// when
+		boolean result = feedbackIdValidator.valid(targetId, parameterReference.value(Long.class));
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("expected로 Long타입이 아닌 타입이 들어오면, 예외가 던져진다.")
+	void WRONG_EXPECTED_TYPE() {
+		// given
+		FeedbackIdValidator feedbackIdValidator = feedbackIdValidatorFactory.validator();
+		LongParameterExtractor longParameterExtractor = feedbackIdValidatorFactory.parameterExtractor();
+		String targetId = "1L";
+		Long feedbackId = 2L;
+		ParameterReference parameterReference = longParameterExtractor.extract(feedbackId);
+
+		// when
+		Throwable result = catchException(
+			() -> feedbackIdValidator.valid(targetId, parameterReference.value(Long.class)));
+
+		// then
+		assertThat(result.getClass()).isEqualTo(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("target으로 Long타입이 아닌 타입이 들어오면, 예외가 던져진다.")
+	void WRONG_TARGET_TYPE() {
+		// given
+		LongParameterExtractor longParameterExtractor = feedbackIdValidatorFactory.parameterExtractor();
+		String feedbackId = "2L";
+
+		// when
+		Throwable result = catchException(() -> longParameterExtractor.extract(feedbackId));
+
+		// then
+		assertThat(result.getClass()).isEqualTo(IllegalArgumentException.class);
+	}
+
+}

--- a/survey/application/src/test/java/me/nalab/survey/application/service/authorization/SurveyIdValidatorTest.java
+++ b/survey/application/src/test/java/me/nalab/survey/application/service/authorization/SurveyIdValidatorTest.java
@@ -1,0 +1,101 @@
+package me.nalab.survey.application.service.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.core.authorization.api.ParameterReference;
+import me.nalab.survey.application.port.out.persistence.authorization.TargetIdFindPort;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {LongParameterExtractor.class, SurveyIdValidator.class,
+	SurveyIdValidatorFactory.class})
+class SurveyIdValidatorTest {
+
+	@Autowired
+	private SurveyIdValidatorFactory surveyIdValidatorFactory;
+
+	@MockBean
+	private TargetIdFindPort targetIdFindPort;
+
+	@Test
+	@DisplayName("targetId와 targetId가 갖고있는 surveyId가 들어왔을때, 검증에 성공한다.")
+	void VALID_SUCCESS() {
+		// given
+		SurveyIdValidator surveyIdValidator = surveyIdValidatorFactory.validator();
+		LongParameterExtractor longParameterExtractor = surveyIdValidatorFactory.parameterExtractor();
+		Long targetId = 1L;
+		Long surveyId = 2L;
+		ParameterReference parameterReference = longParameterExtractor.extract(surveyId);
+
+		when(targetIdFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.of(1L));
+
+		// when
+		boolean result = surveyIdValidator.valid(targetId, parameterReference.value(Long.class));
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("targetId와 targetId가 갖고있지 않은 surveyId가 들어왔을때, 검증에 실패한다.")
+	void VALID_FAIL() {
+		// given
+		SurveyIdValidator surveyIdValidator = surveyIdValidatorFactory.validator();
+		LongParameterExtractor longParameterExtractor = surveyIdValidatorFactory.parameterExtractor();
+		Long targetId = 1L;
+		Long surveyId = 2L;
+		ParameterReference parameterReference = longParameterExtractor.extract(surveyId);
+
+		when(targetIdFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.of(3L));
+
+		// when
+		boolean result = surveyIdValidator.valid(targetId, parameterReference.value(Long.class));
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("expected로 Long타입이 아닌 타입이 들어오면, 예외가 던져진다.")
+	void WRONG_EXPECTED_TYPE() {
+		// given
+		SurveyIdValidator surveyIdValidator = surveyIdValidatorFactory.validator();
+		LongParameterExtractor longParameterExtractor = surveyIdValidatorFactory.parameterExtractor();
+		String targetId = "1L";
+		Long surveyId = 2L;
+		ParameterReference parameterReference = longParameterExtractor.extract(surveyId);
+
+		// when
+		Throwable result = catchException(
+			() -> surveyIdValidator.valid(targetId, parameterReference.value(Long.class)));
+
+		// then
+		assertThat(result.getClass()).isEqualTo(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("target으로 Long타입이 아닌 타입이 들어오면, 예외가 던져진다.")
+	void WRONG_TARGET_TYPE() {
+		// given
+		LongParameterExtractor longParameterExtractor = surveyIdValidatorFactory.parameterExtractor();
+		String surveyId = "2L";
+
+		// when
+		Throwable result = catchException(() -> longParameterExtractor.extract(surveyId));
+
+		// then
+		assertThat(result.getClass()).isEqualTo(IllegalArgumentException.class);
+	}
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
권한 인증 모듈의 surveyId와 feedbackId로 권한인증을 하는 기능을 확장했습니다.

## 어떻게 해결했나요?
- [x] `targetId <-> surveyId` authorization 확장 등록
- [x] `targetId <-> feedbackId` authorization 확장 등록
- [x] 권한 모듈 `ParameterRefrence.class` 위치 api 로 수정
- [x] 관련 테스트케이스 작성

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
