### PR TITLE
[fix] : 질문폼생성, 응답 부분에 @Valid 검증 추가

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/RequestSample.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/RequestSample.java
@@ -17,6 +17,7 @@ public final class RequestSample {
 	private static final ObjectMapper OBJECT_MAPPER;
 	public static final String DEFAULT_JSON;
 	public static final String CUSTOM_JSON;
+	public static final String FAILED_JSON;
 
 	static {
 		OBJECT_MAPPER = new ObjectMapper();
@@ -24,18 +25,19 @@ public final class RequestSample {
 
 		DEFAULT_JSON = loadDefaultJson();
 		CUSTOM_JSON = loadCustomJson();
+		FAILED_JSON = failedJson();
 	}
 
 	private static String loadDefaultJson() {
 		try {
 			return OBJECT_MAPPER.writeValueAsString(SurveyCreateRequest.builder()
-				.questionCount(1000)
+				.questionCount(4)
 				.formQuestionRequestableList(
 					List.of(ChoiceFormQuestionRequest.builder()
 							.questionType("choice")
 							.choiceFormQuestionType("custom")
 							.title("당신의 포지션을 알려주세요.")
-							.maxSelectableCount(1)
+							.maxSelectableCount(2)
 							.order(3)
 							.choiceRequestList(
 								List.of(
@@ -109,7 +111,7 @@ public final class RequestSample {
 							.build(),
 						ShortFormQuestionRequest.builder()
 							.questionType("short")
-							.shortFormQuestionType("weakness")
+							.shortFormQuestionType("custom")
 							.title("당신이 생각하는 예진님의 직무적 약점은 무엇인가요?")
 							.order(6)
 							.build()
@@ -126,13 +128,13 @@ public final class RequestSample {
 	private static String loadCustomJson() {
 		try {
 			return OBJECT_MAPPER.writeValueAsString(SurveyCreateRequest.builder()
-				.questionCount(1000)
+				.questionCount(8)
 				.formQuestionRequestableList(
 					List.of(ChoiceFormQuestionRequest.builder()
 							.questionType("choice")
 							.choiceFormQuestionType("custom")
 							.title("당신의 포지션을 알려주세요.")
-							.maxSelectableCount(1)
+							.maxSelectableCount(2)
 							.order(3)
 							.choiceRequestList(
 								List.of(
@@ -206,7 +208,7 @@ public final class RequestSample {
 							.build(),
 						ShortFormQuestionRequest.builder()
 							.questionType("short")
-							.shortFormQuestionType("weakness")
+							.shortFormQuestionType("custom")
 							.title("당신이 생각하는 예진님의 직무적 약점은 무엇인가요?")
 							.order(6)
 							.build(),
@@ -270,6 +272,103 @@ public final class RequestSample {
 			);
 		} catch(JsonProcessingException jpe) {
 			throw new IllegalStateException("Cannot start acceptance test fail to load \"CUSTOM_JSON\"");
+		}
+	}
+
+	private static String failedJson() {
+		try {
+			return OBJECT_MAPPER.writeValueAsString(SurveyCreateRequest.builder()
+				.questionCount(1000)
+				.formQuestionRequestableList(
+					List.of(ChoiceFormQuestionRequest.builder()
+							.questionType("choice")
+							.choiceFormQuestionType("custom")
+							.title("당신의 포지션을 알려주세요.")
+							.maxSelectableCount(2)
+							.order(3)
+							.choiceRequestList(
+								List.of(
+									ChoiceRequest.builder()
+										.content("developer")
+										.order(1)
+										.build(),
+									ChoiceRequest.builder()
+										.content("designer")
+										.order(2)
+										.build(),
+									ChoiceRequest.builder()
+										.content("pm")
+										.order(3)
+										.build(),
+									ChoiceRequest.builder()
+										.content("others")
+										.order(4)
+										.build()
+								)
+							)
+							.build(),
+						ChoiceFormQuestionRequest.builder()
+							.questionType("choice")
+							.choiceFormQuestionType("tendency")
+							.title("예진님의 성향은 어떤 것이 돋보이나요?")
+							.maxSelectableCount(5)
+							.order(4)
+							.choiceRequestList(
+								List.of(
+									ChoiceRequest.builder()
+										.content("적응력 좋은")
+										.order(1)
+										.build(),
+									ChoiceRequest.builder()
+										.content("완벽주의적인")
+										.order(2)
+										.build(),
+									ChoiceRequest.builder()
+										.content("사교적인")
+										.order(3)
+										.build(),
+									ChoiceRequest.builder()
+										.content("눈치빠른")
+										.order(4)
+										.build(),
+									ChoiceRequest.builder()
+										.content("긍정적인")
+										.order(5)
+										.build(),
+									ChoiceRequest.builder()
+										.content("현실적인")
+										.order(6)
+										.build(),
+									ChoiceRequest.builder()
+										.content("통찰력 있는")
+										.order(7)
+										.build(),
+									ChoiceRequest.builder()
+										.content("추진력 있는")
+										.order(8)
+										.build()
+								)
+							)
+							.build(),
+						ShortFormQuestionRequest.builder()
+							.questionType("short")
+							.shortFormQuestionType("strength")
+							.title("당신이 생각하는 예진님의 직무적 강점은 무엇인가요?")
+							.order(5)
+							.build(),
+						ShortFormQuestionRequest.builder()
+							.questionType("short")
+							.shortFormQuestionType("custom")
+							.title("당신이 생각하는 예진님의 직무적 약점은 무엇인가요?")
+							.order(6)
+							.build()
+					)
+				)
+				.build()
+			);
+		} catch(JsonProcessingException jpe) {
+			throw new IllegalStateException(
+				"Cannot start acceptance test fail to load \"DEFAULT_JSON\" " + jpe.getMessage());
 		}
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
@@ -17,6 +17,10 @@ public class SurveyAcceptanceValidator {
 		);
 	}
 
+	public static void assertIsSurveyCreateIsFailed(ResultActions resultActions) throws Exception {
+		resultActions.andExpect(status().isBadRequest());
+	}
+
 	public static void assertIsSurveyFound(ResultActions resultActions) throws Exception {
 		resultActions.andExpectAll(
 			status().isOk(),

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/SurveyCreateAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/SurveyCreateAcceptanceTest.java
@@ -1,5 +1,6 @@
 package me.nalab.luffy.api.acceptance.test.survey.create;
 
+import static me.nalab.luffy.api.acceptance.test.survey.SurveyAcceptanceValidator.assertIsSurveyCreateIsFailed;
 import static me.nalab.luffy.api.acceptance.test.survey.SurveyAcceptanceValidator.assertIsSurveyCreated;
 
 import java.time.LocalDateTime;
@@ -60,7 +61,7 @@ class SurveyCreateAcceptanceTest extends AbstractSurveyTestSupporter {
 	}
 
 	@Test
-	@DisplayName("새로우 Survey 생성 성공 테스트 - 커스텀 질문 포함")
+	@DisplayName("새로운 Survey 생성 성공 테스트 - 커스텀 질문 포함")
 	void CREATE_NEW_SURVEY_SUCCESS_SUCCESS_CUSTOM() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("luffy", LocalDateTime.now().minusYears(24));
@@ -75,6 +76,25 @@ class SurveyCreateAcceptanceTest extends AbstractSurveyTestSupporter {
 
 		// then
 		assertIsSurveyCreated(resultActions);
+	}
+
+	@Test
+	@DisplayName("새로운 Survey 생성 시 Valid에 걸리면 예외가 발생한다")
+	void CREATE_NEW_SURVEY_WITH_FAIL() throws Exception {
+		// given
+		Long targetId = targetInitializer.saveTargetAndGetId("luffy", LocalDateTime.now().minusYears(24));
+		String token = "luffy's-double-token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedToken(token)
+			.expectedId(targetId)
+			.build());
+
+		// when
+		ResultActions resultActions = createSurvey(token, RequestSample.FAILED_JSON);
+
+		// then
+		assertIsSurveyCreateIsFailed(resultActions);
+
 	}
 
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/FeedbackCreateController.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/FeedbackCreateController.java
@@ -3,6 +3,8 @@ package me.nalab.survey.web.adaptor.createfeedback;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,7 +37,7 @@ public class FeedbackCreateController {
 	@PostMapping("/feedbacks")
 	@ResponseStatus(HttpStatus.CREATED)
 	public void createFeedback(@RequestParam("survey-id") Long surveyId,
-		@Validated @RequestBody FeedbackCreateRequest feedbackCreateRequest) {
+		@Valid @RequestBody FeedbackCreateRequest feedbackCreateRequest) {
 		feedbackCreateUseCase.createFeedback(surveyId, toFeedbackDto(feedbackCreateRequest));
 	}
 

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/ReviewerRequest.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/ReviewerRequest.java
@@ -16,7 +16,7 @@ public class ReviewerRequest {
 	@JsonProperty("collaboration_experience")
 	private boolean collaborationExperience;
 
-	@Pattern(regexp = "^(designer|pm|developer|others)$")
+	@Pattern(regexp = "^(designer|pm|developer|others)$", message = "position은 designer, pm, developer, others 중 하나이어야 합니다.")
 	private String position;
 
 }

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/ShortQuestionFeedbackRequest.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/request/ShortQuestionFeedbackRequest.java
@@ -15,7 +15,7 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 public class ShortQuestionFeedbackRequest extends AbstractQuestionFeedbackRequest {
 
-	@Size(min = 1, max = 5)
+	@Size(min = 1, max = 50, message = "응답은 최소 1번, 최대 50번까지만 할 수 있습니다.")
 	@JsonProperty("reply")
 	private List<String> replyList;
 

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/SurveyCreateController.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/SurveyCreateController.java
@@ -1,5 +1,7 @@
 package me.nalab.survey.web.adaptor.createsurvey;
 
+import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -25,7 +27,7 @@ class SurveyCreateController {
 	@PostMapping("/surveys")
 	@ResponseStatus(HttpStatus.CREATED)
 	SurveyIdResponse createSurvey(@RequestAttribute("logined") Long loginId,
-		@RequestBody SurveyCreateRequest surveyCreateRequest) {
+		@Valid @RequestBody SurveyCreateRequest surveyCreateRequest) {
 		createSurveyUseCase.createSurvey(loginId, SurveyCreateRequestMapper.toSurveyDto(surveyCreateRequest));
 		String latestSurveyId = String.valueOf(latestSurveyIdFindUseCase.getLatestSurveyIdByTargetId(loginId));
 		return new SurveyIdResponse(latestSurveyId);

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/request/ChoiceFormQuestionRequest.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/request/ChoiceFormQuestionRequest.java
@@ -2,7 +2,9 @@ package me.nalab.survey.web.adaptor.createsurvey.request;
 
 import java.util.List;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,11 +19,13 @@ import me.nalab.survey.application.common.survey.dto.QuestionDtoType;
 @EqualsAndHashCode(callSuper = true)
 public class ChoiceFormQuestionRequest extends FormQuestionRequestable {
 
-	@Min(value = 1, message = "객관식 질문지의 최대 선택가능한 수는 1보다 작아지면 안됩니다.")
+	@Min(value = 1, message = "객관식 질문지의 최대 선택 개수는 최소 1개입니다.")
+	@Max(value = 19, message = "객관식 질문지의 최대 선택 개수는 최대 19개입니다.")
 	@JsonProperty("max_selectable_count")
 	private Integer maxSelectableCount;
 
 	@JsonProperty("form_type")
+	@Pattern(regexp = "^(tendency|custom)$", message = "객관식 질문 type은 tendency 또는 custom 중 하나이어야 합니다.")
 	private String choiceFormQuestionType;
 
 	@Size(min = 2, max = 20, message = "객관식 질문의 수는 2 에서 20 사이가 되어야 합니다.")

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/request/FormQuestionRequestable.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/request/FormQuestionRequestable.java
@@ -28,7 +28,7 @@ public abstract class FormQuestionRequestable {
 	protected String title;
 
 	@Min(value = 1, message = "질문지의 order 는 1보다 작아지면 안됩니다.")
-	@Max(value = 25, message = "질문지의 order 는 25보다 커지면 안됩니다.  ")
+	@Max(value = 24, message = "질문지의 order 는 24보다 커지면 안됩니다.")
 	protected Integer order;
 
 	public abstract QuestionDtoType getQuestionFormType();

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/request/ShortFormQuestionRequest.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/request/ShortFormQuestionRequest.java
@@ -1,5 +1,7 @@
 package me.nalab.survey.web.adaptor.createsurvey.request;
 
+import javax.validation.constraints.Pattern;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.EqualsAndHashCode;
@@ -13,6 +15,7 @@ import me.nalab.survey.application.common.survey.dto.QuestionDtoType;
 public class ShortFormQuestionRequest extends FormQuestionRequestable {
 
 	@JsonProperty("form_type")
+	@Pattern(regexp = "^(strength|custom)$", message = "객관식 질문 type은 strength 또는 custom 중 하나이어야 합니다.")
 	private String shortFormQuestionType;
 
 	@Override

--- a/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/request/SurveyCreateRequest.java
+++ b/survey/web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createsurvey/request/SurveyCreateRequest.java
@@ -2,6 +2,8 @@ package me.nalab.survey.web.adaptor.createsurvey.request;
 
 import java.util.List;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,9 +18,11 @@ import lombok.ToString;
 public class SurveyCreateRequest {
 
 	@JsonProperty("question_count")
+	@Min(value = 4, message = "설문지의 질문 갯수는 최소 4개입니다.")
+	@Max(value = 24, message = "설문지의 질문 갯수는 최대 24개입니다.")
 	private Integer questionCount;
 
-	@Size(min = 5, max = 25, message = "설문지의 설문 갯수는 5에서 25사이가 되어야 합니다.")
+	@Size(min = 4, max = 24, message = "설문지의 설문 갯수는 4에서 24사이가 되어야 합니다.")
 	@JsonProperty("question")
 	private List<FormQuestionRequestable> formQuestionRequestableList;
 


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문 폼 생성, 질문 폼 응답 API controller 쪽에 @Valid 를 추가하여 requestBody 를 검증하도록 하였습니다
그리고 최근 업데이트 된 요구사항까지 추가하여 어노테이션을 부착하였습니다

## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->
- #223 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

## 고민점
이거 테스트부분을 어떻게 추가해야할지 고민입니다...!!
일단 예시 하나만 추가했는데, 현재는 저희가 인수테스트 부분을 성공에 대한 코드만 작성을 해서
실패 부분에 대한 검증 테스트는 어디서 해야할지 얘기해보고 싶었습니다
아님 같은 web-adaptor 모듈의 테스트에 넣어야 할지?

## 참고자료
