### PR TITLE
[feat] : target, bookmark 엔티티 업데이트 

### DIFF
--- a/api/src/main/resources/db/migration/V4__add_bookmark.sql
+++ b/api/src/main/resources/db/migration/V4__add_bookmark.sql
@@ -1,0 +1,1 @@
+ALTER TABLE form_feedback ADD is_bookmarked boolean not null default false;

--- a/api/src/main/resources/db/migration/V4__add_bookmark.sql
+++ b/api/src/main/resources/db/migration/V4__add_bookmark.sql
@@ -1,1 +1,2 @@
 ALTER TABLE form_feedback ADD is_bookmarked boolean not null default false;
+ALTER TABLE form_feedback ADD bookmarked_at timestamp(6);

--- a/core/data/src/main/java/me/nalab/core/data/feedback/FormFeedbackEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/feedback/FormFeedbackEntity.java
@@ -7,7 +7,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 
 import lombok.AllArgsConstructor;

--- a/core/data/src/main/java/me/nalab/core/data/feedback/FormFeedbackEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/feedback/FormFeedbackEntity.java
@@ -1,10 +1,13 @@
 package me.nalab.core.data.feedback;
 
+import java.time.Instant;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 
 import lombok.AllArgsConstructor;
@@ -39,4 +42,7 @@ public abstract class FormFeedbackEntity {
 
 	@Column(name = "is_bookmarked", nullable = false)
 	protected boolean isBookmarked;
+
+	@Column(name = "bookmarked_at", columnDefinition = "TIMESTAMP(6)")
+	protected Instant bookmarkedAt;
 }

--- a/core/data/src/main/java/me/nalab/core/data/feedback/FormFeedbackEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/feedback/FormFeedbackEntity.java
@@ -37,4 +37,6 @@ public abstract class FormFeedbackEntity {
 	@JoinColumn(name = "feedback_id", nullable = false)
 	protected FeedbackEntity feedbackEntity;
 
+	@Column(name = "is_bookmarked", nullable = false)
+	protected boolean isBookmarked;
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
2차 mvp에 추가되는 엔티티의 업데이트내용을 반영하고, flyway에 v4를 추가하였습니다

## 어떻게 해결했나요?

- [x] `FormFeedbackEntity`에 `isBookmarked` 필드를 추가했습니다
- [x] flyway v4에 해당 내용을 업데이트하고, 기존에 있는 데이터들은 `false`로 세팅되게끔 하였습니다

- 그리고 mapper 변경사항은 그리고 도메인, 엔티티 각 부분 merge후에 수정하면 될 것 같습니다.

## 이슈 넘버
- close #290 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
