### PR TITLE
[feat] : 2차 MVP 공용 매퍼, DTO 업데이트

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/BookmarkResponse.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/BookmarkResponse.java
@@ -1,0 +1,22 @@
+package me.nalab.luffy.api.acceptance.test.feedback.create.response;
+
+import java.time.Instant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookmarkResponse {
+
+	private boolean isBookmarked;
+	private Instant bookmarkedAt;
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/FormQuestionResponseable.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/FormQuestionResponseable.java
@@ -31,5 +31,4 @@ public abstract class FormQuestionResponseable {
 	private String title;
 
 	private Integer order;
-
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/dto/BookmarkDto.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/dto/BookmarkDto.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.application.common.feedback.dto;
+
+import java.time.Instant;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class BookmarkDto {
+
+	private final boolean isBookmarked;
+	private final Instant bookmarkedAt;
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/dto/FormQuestionFeedbackDtoable.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/dto/FormQuestionFeedbackDtoable.java
@@ -14,5 +14,6 @@ public abstract class FormQuestionFeedbackDtoable {
 	private Long id;
 	private Long questionId;
 	private boolean isRead;
+	private BookmarkDto bookmarkDto;
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/mapper/FeedbackDtoMapper.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/mapper/FeedbackDtoMapper.java
@@ -3,11 +3,13 @@ package me.nalab.survey.application.common.feedback.mapper;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import me.nalab.survey.application.common.feedback.dto.BookmarkDto;
 import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FormQuestionFeedbackDtoable;
 import me.nalab.survey.application.common.feedback.dto.ReviewerDto;
 import me.nalab.survey.application.common.feedback.dto.ShortFormQuestionFeedbackDto;
+import me.nalab.survey.domain.feedback.Bookmark;
 import me.nalab.survey.domain.feedback.ChoiceFormQuestionFeedback;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
@@ -41,7 +43,7 @@ public final class FeedbackDtoMapper {
 
 	private static List<FormQuestionFeedbackable> getFormQuestionFeedbackList(FeedbackDto feedbackDto) {
 		return feedbackDto.getFormQuestionFeedbackDtoableList().stream().map(q -> {
-			if(q instanceof ShortFormQuestionFeedbackDto) {
+			if (q instanceof ShortFormQuestionFeedbackDto) {
 				return getShortFormQuestionFeedback((ShortFormQuestionFeedbackDto)q);
 			}
 			return getChoiceFormQuestionFeedback((ChoiceFormQuestionFeedbackDto)q);
@@ -52,6 +54,10 @@ public final class FeedbackDtoMapper {
 		ShortFormQuestionFeedbackDto shortFormQuestionFeedbackDto) {
 		return ShortFormQuestionFeedback.builder()
 			.questionId(shortFormQuestionFeedbackDto.getQuestionId())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(shortFormQuestionFeedbackDto.getBookmarkDto().isBookmarked())
+				.bookmarkedAt(shortFormQuestionFeedbackDto.getBookmarkDto().getBookmarkedAt())
+				.build())
 			.isRead(shortFormQuestionFeedbackDto.isRead())
 			.replyList(shortFormQuestionFeedbackDto.getReplyList())
 			.build();
@@ -61,6 +67,10 @@ public final class FeedbackDtoMapper {
 		ChoiceFormQuestionFeedbackDto choiceFormQuestionFeedbackDto) {
 		return ChoiceFormQuestionFeedback.builder()
 			.questionId(choiceFormQuestionFeedbackDto.getQuestionId())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(choiceFormQuestionFeedbackDto.getBookmarkDto().isBookmarked())
+				.bookmarkedAt(choiceFormQuestionFeedbackDto.getBookmarkDto().getBookmarkedAt())
+				.build())
 			.isRead(choiceFormQuestionFeedbackDto.isRead())
 			.selectedChoiceIdSet(choiceFormQuestionFeedbackDto.getSelectedChoiceIdSet())
 			.build();
@@ -89,7 +99,7 @@ public final class FeedbackDtoMapper {
 
 	private static List<FormQuestionFeedbackDtoable> getFormQuestionFeedbackDtoList(Feedback feedback) {
 		return feedback.getFormQuestionFeedbackableList().stream().map(q -> {
-			if(q instanceof ShortFormQuestionFeedback) {
+			if (q instanceof ShortFormQuestionFeedback) {
 				return getShortFormQuestionFeedbackDto((ShortFormQuestionFeedback)q);
 			}
 			return getChoiceFormQuestionFeedbackDto((ChoiceFormQuestionFeedback)q);
@@ -102,6 +112,10 @@ public final class FeedbackDtoMapper {
 			.id(shortFormQuestionFeedback.getId())
 			.questionId(shortFormQuestionFeedback.getQuestionId())
 			.isRead(shortFormQuestionFeedback.isRead())
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(shortFormQuestionFeedback.getBookmark().isBookmarked())
+				.bookmarkedAt(shortFormQuestionFeedback.getBookmark().getBookmarkedAt())
+				.build())
 			.replyList(shortFormQuestionFeedback.getReplyList())
 			.build();
 	}
@@ -112,6 +126,10 @@ public final class FeedbackDtoMapper {
 			.id(choiceFormQuestionFeedback.getId())
 			.questionId(choiceFormQuestionFeedback.getQuestionId())
 			.isRead(choiceFormQuestionFeedback.isRead())
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(choiceFormQuestionFeedback.getBookmark().isBookmarked())
+				.bookmarkedAt(choiceFormQuestionFeedback.getBookmark().getBookmarkedAt())
+				.build())
 			.selectedChoiceIdSet(choiceFormQuestionFeedback.getSelectedChoiceIdSet())
 			.build();
 	}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/survey/dto/TargetDto.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/survey/dto/TargetDto.java
@@ -13,5 +13,6 @@ public class TargetDto {
 
 	private final Long id;
 	private final String nickname;
+	private final String position;
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/survey/mapper/TargetDtoMapper.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/survey/mapper/TargetDtoMapper.java
@@ -20,6 +20,7 @@ public class TargetDtoMapper {
 		return TargetDto.builder()
 			.id(target.getId())
 			.nickname(target.getNickname())
+			.position(target.getPosition())
 			.build();
 	}
 }

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/RandomFeedbackDtoFixture.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/RandomFeedbackDtoFixture.java
@@ -1,7 +1,6 @@
 package me.nalab.survey.application;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -11,6 +10,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import lombok.Setter;
+import me.nalab.survey.application.common.feedback.dto.BookmarkDto;
 import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FormQuestionFeedbackDtoable;
@@ -71,7 +71,7 @@ public class RandomFeedbackDtoFixture {
 	private static List<FormQuestionFeedbackDtoable> getRandomQuestionFeedbackDtoListBySurvey(Survey survey) {
 		List<FormQuestionable> formQuestionableList = survey.getFormQuestionableList();
 		return formQuestionableList.stream().map(q -> {
-			if(q.getQuestionType() == QuestionType.CHOICE) {
+			if (q.getQuestionType() == QuestionType.CHOICE) {
 				return getRandomChoiceFormQuestionFeedbackDto((ChoiceFormQuestion)q);
 			}
 			return getRandomShortFormQuestionFeedbackDto((ShortFormQuestion)q);
@@ -81,11 +81,15 @@ public class RandomFeedbackDtoFixture {
 	private static ChoiceFormQuestionFeedbackDto getRandomChoiceFormQuestionFeedbackDto(
 		ChoiceFormQuestion choiceFormQuestion) {
 		Set<Long> selectedIdSet = new HashSet<>();
-		for(int i = 0; i < choiceFormQuestion.getMaxSelectableCount(); i++) {
+		for (int i = 0; i < choiceFormQuestion.getMaxSelectableCount(); i++) {
 			selectedIdSet.add(choiceFormQuestion.getChoiceList().get(i).getId());
 		}
 		return ChoiceFormQuestionFeedbackDto.builder()
 			.questionId(choiceFormQuestion.getId())
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(false)
+				.bookmarkedAt(Instant.now())
+				.build())
 			.isRead(RANDOM_BOOLEAN_SUPPLIER.getAsBoolean())
 			.selectedChoiceIdSet(selectedIdSet)
 			.build();
@@ -95,6 +99,10 @@ public class RandomFeedbackDtoFixture {
 		ShortFormQuestion shortFormQuestion) {
 		return ShortFormQuestionFeedbackDto.builder()
 			.questionId(shortFormQuestion.getId())
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(false)
+				.bookmarkedAt(Instant.now())
+				.build())
 			.isRead(RANDOM_BOOLEAN_SUPPLIER.getAsBoolean())
 			.replyList(List.of(RANDOM_STRING_SUPPLIER.get()))
 			.build();

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper.java
@@ -9,6 +9,7 @@ import me.nalab.core.data.feedback.FeedbackEntity;
 import me.nalab.core.data.feedback.FormFeedbackEntity;
 import me.nalab.core.data.feedback.ReviewerEntity;
 import me.nalab.core.data.feedback.ShortFormFeedbackEntity;
+import me.nalab.survey.domain.feedback.Bookmark;
 import me.nalab.survey.domain.feedback.ChoiceFormQuestionFeedback;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
@@ -44,7 +45,7 @@ public final class FeedbackEntityMapper {
 
 	private static List<FormQuestionFeedbackable> getFormQuestionFeedbackList(FeedbackEntity feedbackEntity) {
 		return feedbackEntity.getFormFeedbackEntityList().stream().map(q -> {
-			if(q instanceof ShortFormFeedbackEntity) {
+			if (q instanceof ShortFormFeedbackEntity) {
 				return getShortFormQuestionFeedback((ShortFormFeedbackEntity)q);
 			}
 			return getChoiceFormQuestionFeedback((ChoiceFormFeedbackEntity)q);
@@ -57,6 +58,10 @@ public final class FeedbackEntityMapper {
 			.id(shortFormFeedbackEntity.getId())
 			.questionId(shortFormFeedbackEntity.getQuestionId())
 			.isRead(shortFormFeedbackEntity.isRead())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(shortFormFeedbackEntity.isBookmarked())
+				.bookmarkedAt(shortFormFeedbackEntity.getBookmarkedAt())
+				.build())
 			.replyList(shortFormFeedbackEntity.getReplyList())
 			.build();
 	}
@@ -67,6 +72,10 @@ public final class FeedbackEntityMapper {
 			.id(choiceFormFeedbackEntity.getId())
 			.questionId(choiceFormFeedbackEntity.getQuestionId())
 			.isRead(choiceFormFeedbackEntity.isRead())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(choiceFormFeedbackEntity.isBookmarked())
+				.bookmarkedAt(choiceFormFeedbackEntity.getBookmarkedAt())
+				.build())
 			.selectedChoiceIdSet(choiceFormFeedbackEntity.getSelectSet())
 			.build();
 	}
@@ -97,7 +106,7 @@ public final class FeedbackEntityMapper {
 	private static List<FormFeedbackEntity> getFormFeedbackEntityList(Feedback feedback) {
 		return feedback.getFormQuestionFeedbackableList().stream()
 			.map(f -> {
-				if(f instanceof ShortFormQuestionFeedback) {
+				if (f instanceof ShortFormQuestionFeedback) {
 					return getShortFormFeedbackEntity((ShortFormQuestionFeedback)f);
 				}
 				return getChoiceFormFeedbackEntity((ChoiceFormQuestionFeedback)f);
@@ -110,6 +119,8 @@ public final class FeedbackEntityMapper {
 			.id(shortFormQuestionFeedback.getId())
 			.questionId(shortFormQuestionFeedback.getQuestionId())
 			.isRead(shortFormQuestionFeedback.isRead())
+			.isBookmarked(shortFormQuestionFeedback.getBookmark().isBookmarked())
+			.bookmarkedAt(shortFormQuestionFeedback.getBookmark().getBookmarkedAt())
 			.replyList(shortFormQuestionFeedback.getReplyList())
 			.build();
 	}
@@ -120,6 +131,8 @@ public final class FeedbackEntityMapper {
 			.id(choiceFormQuestionFeedback.getId())
 			.questionId(choiceFormQuestionFeedback.getQuestionId())
 			.isRead(choiceFormQuestionFeedback.isRead())
+			.isBookmarked(choiceFormQuestionFeedback.getBookmark().isBookmarked())
+			.bookmarkedAt(choiceFormQuestionFeedback.getBookmark().getBookmarkedAt())
 			.selectSet(choiceFormQuestionFeedback.getSelectedChoiceIdSet())
 			.build();
 	}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/TargetEntityMapper.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/TargetEntityMapper.java
@@ -13,6 +13,7 @@ public class TargetEntityMapper {
 		return TargetEntity.builder()
 			.id(target.getId())
 			.nickname(target.getNickname())
+			.position(target.getPosition())
 			.build();
 	}
 
@@ -20,6 +21,7 @@ public class TargetEntityMapper {
 		return Target.builder()
 			.id(targetEntity.getId())
 			.nickname(targetEntity.getNickname())
+			.position(targetEntity.getPosition())
 			.build();
 	}
 }

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/RandomFeedbackFixture.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/RandomFeedbackFixture.java
@@ -1,5 +1,6 @@
 package me.nalab.survey.jpa.adaptor;
 
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import lombok.Setter;
+import me.nalab.survey.domain.feedback.Bookmark;
 import me.nalab.survey.domain.feedback.ChoiceFormQuestionFeedback;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
@@ -86,7 +88,7 @@ public class RandomFeedbackFixture {
 	private static List<FormQuestionFeedbackable> getRandomQuestionFeedbackListBySurvey(Survey survey) {
 		List<FormQuestionable> formQuestionableList = survey.getFormQuestionableList();
 		return formQuestionableList.stream().map(q -> {
-			if(q.getQuestionType() == QuestionType.CHOICE) {
+			if (q.getQuestionType() == QuestionType.CHOICE) {
 				return getRandomChoiceFormQuestionFeedback((ChoiceFormQuestion)q);
 			}
 			return getRandomShortFormQuestionFeedback((ShortFormQuestion)q);
@@ -96,13 +98,17 @@ public class RandomFeedbackFixture {
 	private static ChoiceFormQuestionFeedback getRandomChoiceFormQuestionFeedback(
 		ChoiceFormQuestion choiceFormQuestion) {
 		Set<Long> selectedIdSet = new HashSet<>();
-		for(int i = 0; i < choiceFormQuestion.getMaxSelectableCount(); i++) {
+		for (int i = 0; i < choiceFormQuestion.getMaxSelectableCount(); i++) {
 			selectedIdSet.add(choiceFormQuestion.getChoiceList().get(i).getId());
 		}
 		return ChoiceFormQuestionFeedback.builder()
 			.id(choiceFormQuestion.getId())
 			.questionId(choiceFormQuestion.getId())
 			.isRead(randomBooleanGenerator.getAsBoolean())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(false)
+				.bookmarkedAt(Instant.now())
+				.build())
 			.selectedChoiceIdSet(selectedIdSet)
 			.build();
 	}
@@ -113,6 +119,10 @@ public class RandomFeedbackFixture {
 			.id(shortFormQuestion.getId())
 			.questionId(shortFormQuestion.getId())
 			.isRead(randomBooleanGenerator.getAsBoolean())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(false)
+				.bookmarkedAt(Instant.now())
+				.build())
 			.replyList(List.of(randomStringGenerator.get()))
 			.build();
 	}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/authorization/TargetIdFindAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/authorization/TargetIdFindAdaptorTest.java
@@ -1,6 +1,6 @@
 package me.nalab.survey.jpa.adaptor.authorization;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.time.Instant;
 import java.util.List;

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/FeedbackCreateController.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/FeedbackCreateController.java
@@ -1,5 +1,6 @@
 package me.nalab.survey.web.adaptor.createfeedback;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import me.nalab.core.secure.xss.meta.Xss;
 import me.nalab.core.secure.xss.meta.XssFiltering;
+import me.nalab.survey.application.common.feedback.dto.BookmarkDto;
 import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FormQuestionFeedbackDtoable;
@@ -63,7 +65,7 @@ public class FeedbackCreateController {
 		List<AbstractQuestionFeedbackRequest> abstractQuestionFeedbackRequestList) {
 		return abstractQuestionFeedbackRequestList.stream()
 			.map(r -> {
-				if(r instanceof ChoiceQuestionFeedbackRequest) {
+				if (r instanceof ChoiceQuestionFeedbackRequest) {
 					return toChoiceFormQuestionFeedbackDto((ChoiceQuestionFeedbackRequest)r);
 				}
 				return toShortFormQuestionFeedbackDto((ShortQuestionFeedbackRequest)r);
@@ -75,6 +77,11 @@ public class FeedbackCreateController {
 		ChoiceQuestionFeedbackRequest choiceQuestionFeedbackRequest) {
 		return ChoiceFormQuestionFeedbackDto.builder()
 			.questionId(Long.valueOf(choiceQuestionFeedbackRequest.getQuestionId()))
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(false)
+				// TODO
+				.bookmarkedAt(Instant.now())
+				.build())
 			.selectedChoiceIdSet(choiceQuestionFeedbackRequest.getChoiceSet().stream().map(Long::valueOf).collect(
 				Collectors.toSet()))
 			.build();
@@ -84,6 +91,11 @@ public class FeedbackCreateController {
 		ShortQuestionFeedbackRequest shortQuestionFeedbackRequest) {
 		return ShortFormQuestionFeedbackDto.builder()
 			.questionId(Long.valueOf(shortQuestionFeedbackRequest.getQuestionId()))
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(false)
+				// TODO
+				.bookmarkedAt(Instant.now())
+				.build())
 			.replyList(shortQuestionFeedbackRequest.getReplyList())
 			.build();
 	}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
2차 mvp 도메인과 엔티티 업데이트로 인한 DTO와 mapper 변경사항을 추가하였습니다.
그리고 application, jpa-adaptor, 인수테스트쪽에서 테스트 깨지는 것 모두 수정해놓았습니다

## 어떻게 해결했나요?

- [x] 2차 mvp DTO 업데이트
- [x] DTO mapper 수정
- [x] domain <-> entity mapper 수정
- [x] application, jpa-adaptor 테스트 에러 수정
- [x] 인수테스트 에러 수정

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
