### PR TITLE
[refactor] : 질문폼의 모든 피드백 조회 v2로 업데이트, is_read 버그 수정

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -1,8 +1,6 @@
 package me.nalab.luffy.api.acceptance.test.feedback;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -44,6 +42,7 @@ public final class FeedbackAcceptanceValidator {
 			jsonPath("$.question_feedback.[0].feedbacks").isArray(),
 			jsonPath("$.question_feedback.[0].feedbacks").isNotEmpty(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].feedback_id").isString(),
+			jsonPath("$.question_feedback.[0].feedbacks.[0].form_question_feedback_id").isString(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].created_at").isString(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].is_read").isBoolean(),
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -45,6 +45,9 @@ public final class FeedbackAcceptanceValidator {
 			jsonPath("$.question_feedback.[0].feedbacks.[0].form_question_feedback_id").isString(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].created_at").isString(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].is_read").isBoolean(),
+			jsonPath("$.question_feedback.[0].feedbacks.[0].bookmark").isNotEmpty(),
+			jsonPath("$.question_feedback.[0].feedbacks.[0].bookmark.is_bookmarked").isBoolean(),
+			jsonPath("$.question_feedback.[0].feedbacks.[0].bookmark.bookmarked_at").isString(),
 
 			jsonPath("$.question_feedback.[0].feedbacks.[0].reviewer.reviewer_id").isString(),
 			jsonPath("$.question_feedback.[0].feedbacks.[0].reviewer.nickname").isString(),

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindAcceptanceTest.java
@@ -1,8 +1,7 @@
 package me.nalab.luffy.api.acceptance.test.feedback.find;
 
-import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.assertIsFeedbackFound;
-import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.assertIsFeedbackNotFound;
-import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackCreateRequestFixture.getFeedbackCreateRequest;
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.*;
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackCreateRequestFixture.*;
 
 import java.time.Instant;
 import java.util.Map;

--- a/support/e2e/v1_3_feedback_find.hurl
+++ b/support/e2e/v1_3_feedback_find.hurl
@@ -173,8 +173,11 @@ jsonpath "$.question_feedback.[0].form_type" matches "tendency|strength|custom"
 jsonpath "$.question_feedback.[0].title" exists
 jsonpath "$.question_feedback.[0].feedbacks" count == 1
 jsonpath "$.question_feedback.[0].feedbacks.[0].feedback_id" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].form_question_feedback_id" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].created_at" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].is_read" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].bookmark.is_bookmarked" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].bookmark.bookmarked_at" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].reviewer.reviewer_id" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].reviewer.nickname" matches "^[A-Z].*"
 jsonpath "$.question_feedback.[0].feedbacks.[0].reviewer.collaboration_experience" exists

--- a/support/e2e/v2_3_feedback_find.hurl
+++ b/support/e2e/v2_3_feedback_find.hurl
@@ -173,6 +173,8 @@ jsonpath "$.question_feedback.[0].feedbacks.[0].feedback_id" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].form_question_feedback_id" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].created_at" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].is_read" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].bookmark.is_bookmarked" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].bookmark.bookmarked_at" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].reviewer.reviewer_id" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].reviewer.nickname" matches "^[A-Z].*"
 jsonpath "$.question_feedback.[0].feedbacks.[0].reviewer.collaboration_experience" exists

--- a/support/e2e/v2_3_feedback_find.hurl
+++ b/support/e2e/v2_3_feedback_find.hurl
@@ -170,6 +170,7 @@ jsonpath "$.question_feedback.[0].form_type" matches "tendency|strength|custom"
 jsonpath "$.question_feedback.[0].title" exists
 jsonpath "$.question_feedback.[0].feedbacks" count == 1
 jsonpath "$.question_feedback.[0].feedbacks.[0].feedback_id" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].form_question_feedback_id" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].created_at" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].is_read" exists
 jsonpath "$.question_feedback.[0].feedbacks.[0].reviewer.reviewer_id" exists

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/ResponseMapper.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/ResponseMapper.java
@@ -34,7 +34,7 @@ final class ResponseMapper {
 		return QuestionFeedbackResponse.builder()
 			.abstractSurveyResponse(surveyDto.getFormQuestionDtoableList().stream().map(
 				f -> {
-					if(f.getQuestionDtoType() == QuestionDtoType.CHOICE) {
+					if (f.getQuestionDtoType() == QuestionDtoType.CHOICE) {
 						return toChoiceSurveyResponse((ChoiceFormQuestionDto)f, feedbackDtoList);
 					}
 					return toShortSurveyResponse((ShortFormQuestionDto)f, feedbackDtoList);
@@ -85,10 +85,11 @@ final class ResponseMapper {
 				choiceFeedbackResponseList.add(
 					ChoiceFeedbackResponse.builder()
 						.id(String.valueOf(feedbackDto.getId()))
+						.formQuestionFeedbackId(String.valueOf(cq.getId()))
 						.choiceIdSet(selectedChoiceIdSet)
 						.createdAt(ZonedDateTime.ofInstant(feedbackDto.getCreatedAt(), ZoneId.of("Asia/Seoul"))
 							.toLocalDateTime())
-						.read(feedbackDto.isRead())
+						.read(cq.isRead())
 						.reviewerResponse(toReviewerResponse(feedbackDto.getReviewerDto()))
 						.build()
 				);
@@ -129,10 +130,11 @@ final class ResponseMapper {
 			.forEach(sq -> shortFeedbackResponseList.add(
 				ShortFeedbackResponse.builder()
 					.id(String.valueOf(feedbackDto.getId()))
+					.formQuestionFeedbackId(String.valueOf(sq.getId()))
 					.replyList(((ShortFormQuestionFeedbackDto)sq).getReplyList())
 					.createdAt(
 						ZonedDateTime.ofInstant(feedbackDto.getCreatedAt(), ZoneId.of("Asia/Seoul")).toLocalDateTime())
-					.read(feedbackDto.isRead())
+					.read(sq.isRead())
 					.reviewerResponse(toReviewerResponse(feedbackDto.getReviewerDto()))
 					.build()
 			));

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/ResponseMapper.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/ResponseMapper.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import me.nalab.survey.application.common.feedback.dto.BookmarkDto;
 import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.ReviewerDto;
@@ -17,6 +18,7 @@ import me.nalab.survey.application.common.survey.dto.QuestionDtoType;
 import me.nalab.survey.application.common.survey.dto.ShortFormQuestionDto;
 import me.nalab.survey.application.common.survey.dto.SurveyDto;
 import me.nalab.survey.web.adaptor.findfeedback.response.QuestionFeedbackResponse;
+import me.nalab.survey.web.adaptor.findfeedback.response.feedback.BookmarkResponse;
 import me.nalab.survey.web.adaptor.findfeedback.response.feedback.ChoiceFeedbackResponse;
 import me.nalab.survey.web.adaptor.findfeedback.response.feedback.ReviewerResponse;
 import me.nalab.survey.web.adaptor.findfeedback.response.feedback.ShortFeedbackResponse;
@@ -90,6 +92,7 @@ final class ResponseMapper {
 						.createdAt(ZonedDateTime.ofInstant(feedbackDto.getCreatedAt(), ZoneId.of("Asia/Seoul"))
 							.toLocalDateTime())
 						.read(cq.isRead())
+						.bookmarkResponse(toBookmarkResponse(cq.getBookmarkDto()))
 						.reviewerResponse(toReviewerResponse(feedbackDto.getReviewerDto()))
 						.build()
 				);
@@ -135,9 +138,18 @@ final class ResponseMapper {
 					.createdAt(
 						ZonedDateTime.ofInstant(feedbackDto.getCreatedAt(), ZoneId.of("Asia/Seoul")).toLocalDateTime())
 					.read(sq.isRead())
+					.bookmarkResponse(toBookmarkResponse(sq.getBookmarkDto()))
 					.reviewerResponse(toReviewerResponse(feedbackDto.getReviewerDto()))
 					.build()
 			));
+	}
+
+	private static BookmarkResponse toBookmarkResponse(BookmarkDto bookmarkDto) {
+		return BookmarkResponse.builder()
+			.isBookmarked(bookmarkDto.isBookmarked())
+			.bookmarkedAt(
+				ZonedDateTime.ofInstant(bookmarkDto.getBookmarkedAt(), ZoneId.of("Asia/Seoul")).toLocalDateTime())
+			.build();
 	}
 
 }

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/AbstractFeedbackResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/AbstractFeedbackResponse.java
@@ -23,5 +23,7 @@ public abstract class AbstractFeedbackResponse {
 	private final boolean read;
 	@JsonProperty("reviewer")
 	private final ReviewerResponse reviewerResponse;
+	@JsonProperty("bookmark")
+	private final BookmarkResponse bookmarkResponse;
 
 }

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/AbstractFeedbackResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/AbstractFeedbackResponse.java
@@ -15,6 +15,8 @@ public abstract class AbstractFeedbackResponse {
 
 	@JsonProperty("feedback_id")
 	private final String id;
+	@JsonProperty("form_question_feedback_id")
+	private final String formQuestionFeedbackId;
 	@JsonProperty("created_at")
 	private final LocalDateTime createdAt;
 	@JsonProperty("is_read")

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/BookmarkResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/BookmarkResponse.java
@@ -1,0 +1,22 @@
+package me.nalab.survey.web.adaptor.findfeedback.response.feedback;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class BookmarkResponse {
+
+	@JsonProperty("is_bookmarked")
+	private final boolean isBookmarked;
+
+	@JsonProperty("bookmarked_at")
+	private final LocalDateTime bookmarkedAt;
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/BookmarkResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/BookmarkResponse.java
@@ -5,13 +5,14 @@ import java.time.LocalDateTime;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @Builder
 @ToString
-@EqaulsAndHashCode
+@EqualsAndHashCode
 public class BookmarkResponse {
 
 	@JsonProperty("is_bookmarked")

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/BookmarkResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/response/feedback/BookmarkResponse.java
@@ -11,6 +11,7 @@ import lombok.ToString;
 @Getter
 @Builder
 @ToString
+@EqaulsAndHashCode
 public class BookmarkResponse {
 
 	@JsonProperty("is_bookmarked")


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
기존 api 인 `질문폼의 모든 피드백 조회`에서 하나의 feedback에서 각각의 문항에 대한 `form_question_feedback_id` 를 추가했습니다.
이젠 해당 id 값으로 `bookmark` 를 달 수 있습니다.
그리고 `bookmark` 필드도 함께 추가했습니다.

그리고 이거 수정하면서 `is_read`도 feedback이 아닌 `form_question_feedback에 대한 is_read`로 변경해놓았습니다 (버그수정)

## 어떻게 해결했나요?

<img width="451" alt="image" src="https://github.com/depromeet/na-lab-server/assets/71487608/bafa4c93-38bb-42eb-ba7f-f109732c3ae0">

* 빨간 색은 api 업데이트 되면서 추가한 내용이고,
* 파란 색은 버그 수정한 부분입니다

- [x] response 에 `form_question_feedback_id`, `bookmark` 추가
- [x] mapper 수정
- [x] 인수테스트, e2e 테스트 수정 + 통과 확인
- [x] is_read 필드 버그 수정

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
