### PR TITLE
[feat] : 질문폼의 북마크된 피드백 교체 - `인수테스트` 작성

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
@@ -59,7 +59,6 @@ public abstract class AbstractFeedbackTestSupporter extends AbstractSurveyTestSu
 		);
 	}
 
-
 	protected ResultActions findFeedback(String token, Long surveyId) throws Exception {
 		return mockMvc.perform(MockMvcRequestBuilders
 			.get(String.format("/v2/surveys/%d/feedbacks", surveyId))
@@ -72,6 +71,16 @@ public abstract class AbstractFeedbackTestSupporter extends AbstractSurveyTestSu
 	protected ResultActions findSpecific(String token, Long feedbackId) throws Exception {
 		return mockMvc.perform(MockMvcRequestBuilders
 			.get("/v1/feedbacks/" + feedbackId)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header(HttpHeaders.AUTHORIZATION, token)
+		);
+	}
+
+	protected ResultActions replaceBookmark(String token, String form_question_feedback_id) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.patch("/v1/feedbacks/bookmarks")
+			.queryParam("form-question-feedback-id", form_question_feedback_id)
 			.accept(MediaType.APPLICATION_JSON)
 			.contentType(MediaType.APPLICATION_JSON)
 			.header(HttpHeaders.AUTHORIZATION, token)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -126,4 +126,8 @@ public final class FeedbackAcceptanceValidator {
 		);
 	}
 
+	public static void assertIsBookmarkReplaced(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(status().isOk());
+	}
+
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/bookmark/BookmarkReplaceAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/bookmark/BookmarkReplaceAcceptanceTest.java
@@ -1,0 +1,103 @@
+package me.nalab.luffy.api.acceptance.test.feedback.bookmark;
+
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.*;
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackCreateRequestFixture.*;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.feedback.AbstractFeedbackTestSupporter;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.FeedbackCreateRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.SurveyFindResponse;
+import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+public class BookmarkReplaceAcceptanceTest extends AbstractFeedbackTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	private static final ObjectMapper OBJECT_MAPPER;
+
+	static {
+		OBJECT_MAPPER = new ObjectMapper();
+		OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+	}
+
+	@Test
+	@DisplayName("북마크 교체 성공 인수테스트")
+	void REPLACE_BOOKMARK_SUCCESS_TEST() throws Exception {
+
+		// given
+		Long targetId = targetInitializer.saveTargetAndGetId("target", Instant.now());
+		String token = "token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedId(targetId)
+			.expectedToken(token)
+			.build());
+
+		Long surveyId = createAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+		SurveyFindResponse surveyFindResponse = getSurveyFindResponse(surveyId);
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "developer");
+		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
+		String formQuestionFeedbackId = findFeedbackAndGetFormQuestionFeedbackId(token, surveyId);
+
+		// when
+		ResultActions resultActions = replaceBookmark(token, formQuestionFeedbackId);
+
+		// then
+		assertIsBookmarkReplaced(resultActions);
+	}
+
+	private Long createAndGetSurveyId(String token, String content) throws Exception {
+		ResultActions resultActions = createSurvey(token, content);
+		Map<String, Long> surveyIdMap = OBJECT_MAPPER.readValue(
+			resultActions.andReturn().getResponse().getContentAsString(), new TypeReference<>() {
+			});
+		return surveyIdMap.get("survey_id");
+	}
+
+	private SurveyFindResponse getSurveyFindResponse(Long surveyId) throws Exception {
+		ResultActions resultActions = findSurvey(surveyId);
+		return OBJECT_MAPPER.readValue(resultActions.andReturn().getResponse().getContentAsString(),
+			SurveyFindResponse.class);
+	}
+
+	private String findFeedbackAndGetFormQuestionFeedbackId(String token, Long surveyId) throws Exception {
+		String stringResponse = findFeedback(token, surveyId).andReturn()
+			.getResponse()
+			.getContentAsString();
+		JSONObject jsonObject = new JSONObject(stringResponse);
+		return jsonObject.getJSONArray("question_feedback").getJSONObject(0).getJSONArray("feedbacks")
+			.getJSONObject(0).getString("form_question_feedback_id");
+	}
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/bookmark/BookmarkReplaceAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/bookmark/BookmarkReplaceAcceptanceTest.java
@@ -37,7 +37,7 @@ import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
 @ComponentScan("me.nalab")
 @EnableJpaRepositories(basePackages = {"me.nalab"})
 @EntityScan(basePackages = {"me.nalab"})
-public class BookmarkReplaceAcceptanceTest extends AbstractFeedbackTestSupporter {
+class BookmarkReplaceAcceptanceTest extends AbstractFeedbackTestSupporter {
 
 	@Autowired
 	private ApplicationEventPublisher applicationEventPublisher;


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?

**질문폼의 북마크된 피드백 교체** API에 대한 인수테스트를 작성했습니다

- [x]  bookmark 패키지를 추가하고, 해당 패키지에 **질문폼의 북마크된 피드백 교체** `인수테스트` 클래스를 생성했습니다
- [x] `AbstractFeedbackTestSupporter` 에 요청로직을 추가했습니다 -> `replaceBookmark`
- [x] `FeedbackAcceptanceValidator` 에 요청로직에 대한 validation 로직을 추가했습니다 -> `assertIsBookmarkReplaced`

## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
