### PR TITLE
[fix] : 질문폼의 타입에 해당하는 피드백 조회 mock api 수정

### DIFF
--- a/api/api-mock/src/main/java/me/nalab/api/mock/MockController.java
+++ b/api/api-mock/src/main/java/me/nalab/api/mock/MockController.java
@@ -298,7 +298,7 @@ public class MockController {
 	@ResponseStatus(HttpStatus.OK)
 	Object getFeedbackBySurveyIdAndFormType(@RequestParam("survey-id") Long surveyId,
 		@RequestParam(value = "form-type", required = false) String formType) {
-		if(formType == null || formType.isBlank()) {
+		if (formType == null || formType.isBlank()) {
 			return "{\n"
 				+ "    \"question_feedback\": [\n"
 				+ "        {\n"
@@ -311,17 +311,17 @@ public class MockController {
 				+ "                {\n"
 				+ "                    \"choice_id\": \"1\",\n"
 				+ "                    \"order\": 1,\n"
-				+ "                    \"content\": \"UI\"\n"
+				+ "                    \"content\": \"꼼꼼한\"\n"
 				+ "                },\n"
 				+ "                {\n"
 				+ "                    \"choice_id\": \"2\",\n"
 				+ "                    \"order\": 2,\n"
-				+ "                    \"content\": \"UX\"\n"
+				+ "                    \"content\": \"도전적인\"\n"
 				+ "                },\n"
 				+ "                {\n"
 				+ "                    \"choice_id\": 3,\n"
 				+ "                    \"order\": 3,\n"
-				+ "                    \"content\": \"BX\"\n"
+				+ "                    \"content\": \"사교적인\"\n"
 				+ "                }\n"
 				+ "            ],\n"
 				+ "            \"feedbacks\": [\n"
@@ -380,7 +380,7 @@ public class MockController {
 				+ "    ]\n"
 				+ "}";
 		}
- 		return "{\n"
+		return "{\n"
 			+ "    \"question_feedback\": [\n"
 			+ "        {\n"
 			+ "            \"question_id\": 1,\n"
@@ -393,19 +393,19 @@ public class MockController {
 			+ "                    \"choice_id\": 1,\n"
 			+ "                    \"order\": 1,\n"
 			+ "                    \"selected_count\": 5,\n"
-			+ "                    \"content\": \"UI\"\n"
+			+ "                    \"content\": \"꼼꼼한\"\n"
 			+ "                },\n"
 			+ "                {\n"
 			+ "                    \"choice_id\": 2,\n"
 			+ "                    \"order\": 2,\n"
 			+ "                    \"selected_count\": 10,\n"
-			+ "                    \"content\": \"UX\"\n"
+			+ "                    \"content\": \"도전적인\"\n"
 			+ "                },\n"
 			+ "                {\n"
 			+ "                    \"choice_id\": 3,\n"
 			+ "                    \"order\": 3,\n"
 			+ "                    \"selected_count\": 0,\n"
-			+ "                    \"content\": \"BX\"\n"
+			+ "                    \"content\": \"사교적인\"\n"
 			+ "                }\n"
 			+ "            ]\n"
 			+ "        }\n"
@@ -474,6 +474,5 @@ public class MockController {
 	void bookmark(@RequestParam("form-question-feedback-id") Long formQuestionFeedbackId) {
 		// 200 OK 반환용 mock api 메소드로 비어있음
 	}
-
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`질문폼의 타입에 해당하는 피드백 조회` 의 mock api에서 formType에 해당하는 키워드를 그에 맞게 수정하였습니다

## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
