### PR TITLE
[stage] : flyway v4, v5 pre-apply

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/BookmarkResponse.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/BookmarkResponse.java
@@ -1,0 +1,22 @@
+package me.nalab.luffy.api.acceptance.test.feedback.create.response;
+
+import java.time.Instant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookmarkResponse {
+
+	private boolean isBookmarked;
+	private Instant bookmarkedAt;
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/FormQuestionResponseable.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/response/FormQuestionResponseable.java
@@ -31,5 +31,4 @@ public abstract class FormQuestionResponseable {
 	private String title;
 
 	private Integer order;
-
 }

--- a/api/src/main/resources/db/migration/V4__add_bookmark.sql
+++ b/api/src/main/resources/db/migration/V4__add_bookmark.sql
@@ -1,0 +1,2 @@
+ALTER TABLE form_feedback ADD is_bookmarked boolean not null default false;
+ALTER TABLE form_feedback ADD bookmarked_at timestamp(6);

--- a/api/src/main/resources/db/migration/V5__add_target_position.sql
+++ b/api/src/main/resources/db/migration/V5__add_target_position.sql
@@ -1,0 +1,1 @@
+ALTER TABLE target ADD position varchar(16);

--- a/core/data/src/main/java/me/nalab/core/data/feedback/FormFeedbackEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/feedback/FormFeedbackEntity.java
@@ -1,5 +1,7 @@
 package me.nalab.core.data.feedback;
 
+import java.time.Instant;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -37,4 +39,9 @@ public abstract class FormFeedbackEntity {
 	@JoinColumn(name = "feedback_id", nullable = false)
 	protected FeedbackEntity feedbackEntity;
 
+	@Column(name = "is_bookmarked", nullable = false)
+	protected boolean isBookmarked;
+
+	@Column(name = "bookmarked_at", columnDefinition = "TIMESTAMP(6)")
+	protected Instant bookmarkedAt;
 }

--- a/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
@@ -28,4 +28,7 @@ public class TargetEntity extends TimeBaseEntity {
 	@Column(name = "target_name", nullable = false)
 	private String nickname;
 
+	@Column(name = "position")
+	private String position;
+
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/dto/BookmarkDto.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/dto/BookmarkDto.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.application.common.feedback.dto;
+
+import java.time.Instant;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class BookmarkDto {
+
+	private final boolean isBookmarked;
+	private final Instant bookmarkedAt;
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/dto/FormQuestionFeedbackDtoable.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/dto/FormQuestionFeedbackDtoable.java
@@ -14,5 +14,6 @@ public abstract class FormQuestionFeedbackDtoable {
 	private Long id;
 	private Long questionId;
 	private boolean isRead;
+	private BookmarkDto bookmarkDto;
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/mapper/FeedbackDtoMapper.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/feedback/mapper/FeedbackDtoMapper.java
@@ -3,11 +3,13 @@ package me.nalab.survey.application.common.feedback.mapper;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import me.nalab.survey.application.common.feedback.dto.BookmarkDto;
 import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FormQuestionFeedbackDtoable;
 import me.nalab.survey.application.common.feedback.dto.ReviewerDto;
 import me.nalab.survey.application.common.feedback.dto.ShortFormQuestionFeedbackDto;
+import me.nalab.survey.domain.feedback.Bookmark;
 import me.nalab.survey.domain.feedback.ChoiceFormQuestionFeedback;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
@@ -41,7 +43,7 @@ public final class FeedbackDtoMapper {
 
 	private static List<FormQuestionFeedbackable> getFormQuestionFeedbackList(FeedbackDto feedbackDto) {
 		return feedbackDto.getFormQuestionFeedbackDtoableList().stream().map(q -> {
-			if(q instanceof ShortFormQuestionFeedbackDto) {
+			if (q instanceof ShortFormQuestionFeedbackDto) {
 				return getShortFormQuestionFeedback((ShortFormQuestionFeedbackDto)q);
 			}
 			return getChoiceFormQuestionFeedback((ChoiceFormQuestionFeedbackDto)q);
@@ -52,6 +54,10 @@ public final class FeedbackDtoMapper {
 		ShortFormQuestionFeedbackDto shortFormQuestionFeedbackDto) {
 		return ShortFormQuestionFeedback.builder()
 			.questionId(shortFormQuestionFeedbackDto.getQuestionId())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(shortFormQuestionFeedbackDto.getBookmarkDto().isBookmarked())
+				.bookmarkedAt(shortFormQuestionFeedbackDto.getBookmarkDto().getBookmarkedAt())
+				.build())
 			.isRead(shortFormQuestionFeedbackDto.isRead())
 			.replyList(shortFormQuestionFeedbackDto.getReplyList())
 			.build();
@@ -61,6 +67,10 @@ public final class FeedbackDtoMapper {
 		ChoiceFormQuestionFeedbackDto choiceFormQuestionFeedbackDto) {
 		return ChoiceFormQuestionFeedback.builder()
 			.questionId(choiceFormQuestionFeedbackDto.getQuestionId())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(choiceFormQuestionFeedbackDto.getBookmarkDto().isBookmarked())
+				.bookmarkedAt(choiceFormQuestionFeedbackDto.getBookmarkDto().getBookmarkedAt())
+				.build())
 			.isRead(choiceFormQuestionFeedbackDto.isRead())
 			.selectedChoiceIdSet(choiceFormQuestionFeedbackDto.getSelectedChoiceIdSet())
 			.build();
@@ -89,7 +99,7 @@ public final class FeedbackDtoMapper {
 
 	private static List<FormQuestionFeedbackDtoable> getFormQuestionFeedbackDtoList(Feedback feedback) {
 		return feedback.getFormQuestionFeedbackableList().stream().map(q -> {
-			if(q instanceof ShortFormQuestionFeedback) {
+			if (q instanceof ShortFormQuestionFeedback) {
 				return getShortFormQuestionFeedbackDto((ShortFormQuestionFeedback)q);
 			}
 			return getChoiceFormQuestionFeedbackDto((ChoiceFormQuestionFeedback)q);
@@ -102,6 +112,10 @@ public final class FeedbackDtoMapper {
 			.id(shortFormQuestionFeedback.getId())
 			.questionId(shortFormQuestionFeedback.getQuestionId())
 			.isRead(shortFormQuestionFeedback.isRead())
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(shortFormQuestionFeedback.getBookmark().isBookmarked())
+				.bookmarkedAt(shortFormQuestionFeedback.getBookmark().getBookmarkedAt())
+				.build())
 			.replyList(shortFormQuestionFeedback.getReplyList())
 			.build();
 	}
@@ -112,6 +126,10 @@ public final class FeedbackDtoMapper {
 			.id(choiceFormQuestionFeedback.getId())
 			.questionId(choiceFormQuestionFeedback.getQuestionId())
 			.isRead(choiceFormQuestionFeedback.isRead())
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(choiceFormQuestionFeedback.getBookmark().isBookmarked())
+				.bookmarkedAt(choiceFormQuestionFeedback.getBookmark().getBookmarkedAt())
+				.build())
 			.selectedChoiceIdSet(choiceFormQuestionFeedback.getSelectedChoiceIdSet())
 			.build();
 	}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/survey/dto/TargetDto.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/survey/dto/TargetDto.java
@@ -13,5 +13,6 @@ public class TargetDto {
 
 	private final Long id;
 	private final String nickname;
+	private final String position;
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/common/survey/mapper/TargetDtoMapper.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/common/survey/mapper/TargetDtoMapper.java
@@ -20,6 +20,7 @@ public class TargetDtoMapper {
 		return TargetDto.builder()
 			.id(target.getId())
 			.nickname(target.getNickname())
+			.position(target.getPosition())
 			.build();
 	}
 }

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/RandomFeedbackDtoFixture.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/RandomFeedbackDtoFixture.java
@@ -1,7 +1,6 @@
 package me.nalab.survey.application;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -11,6 +10,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import lombok.Setter;
+import me.nalab.survey.application.common.feedback.dto.BookmarkDto;
 import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FormQuestionFeedbackDtoable;
@@ -71,7 +71,7 @@ public class RandomFeedbackDtoFixture {
 	private static List<FormQuestionFeedbackDtoable> getRandomQuestionFeedbackDtoListBySurvey(Survey survey) {
 		List<FormQuestionable> formQuestionableList = survey.getFormQuestionableList();
 		return formQuestionableList.stream().map(q -> {
-			if(q.getQuestionType() == QuestionType.CHOICE) {
+			if (q.getQuestionType() == QuestionType.CHOICE) {
 				return getRandomChoiceFormQuestionFeedbackDto((ChoiceFormQuestion)q);
 			}
 			return getRandomShortFormQuestionFeedbackDto((ShortFormQuestion)q);
@@ -81,11 +81,15 @@ public class RandomFeedbackDtoFixture {
 	private static ChoiceFormQuestionFeedbackDto getRandomChoiceFormQuestionFeedbackDto(
 		ChoiceFormQuestion choiceFormQuestion) {
 		Set<Long> selectedIdSet = new HashSet<>();
-		for(int i = 0; i < choiceFormQuestion.getMaxSelectableCount(); i++) {
+		for (int i = 0; i < choiceFormQuestion.getMaxSelectableCount(); i++) {
 			selectedIdSet.add(choiceFormQuestion.getChoiceList().get(i).getId());
 		}
 		return ChoiceFormQuestionFeedbackDto.builder()
 			.questionId(choiceFormQuestion.getId())
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(false)
+				.bookmarkedAt(Instant.now())
+				.build())
 			.isRead(RANDOM_BOOLEAN_SUPPLIER.getAsBoolean())
 			.selectedChoiceIdSet(selectedIdSet)
 			.build();
@@ -95,6 +99,10 @@ public class RandomFeedbackDtoFixture {
 		ShortFormQuestion shortFormQuestion) {
 		return ShortFormQuestionFeedbackDto.builder()
 			.questionId(shortFormQuestion.getId())
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(false)
+				.bookmarkedAt(Instant.now())
+				.build())
 			.isRead(RANDOM_BOOLEAN_SUPPLIER.getAsBoolean())
 			.replyList(List.of(RANDOM_STRING_SUPPLIER.get()))
 			.build();

--- a/survey/survey-domain/src/main/java/me/nalab/survey/domain/feedback/Bookmark.java
+++ b/survey/survey-domain/src/main/java/me/nalab/survey/domain/feedback/Bookmark.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.domain.feedback;
+
+import java.time.Instant;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@EqualsAndHashCode
+@ToString
+public class Bookmark {
+
+	private final boolean isBookmarked;
+	private final Instant bookmarkedAt;
+
+}

--- a/survey/survey-domain/src/main/java/me/nalab/survey/domain/feedback/FormQuestionFeedbackable.java
+++ b/survey/survey-domain/src/main/java/me/nalab/survey/domain/feedback/FormQuestionFeedbackable.java
@@ -19,6 +19,7 @@ public abstract class FormQuestionFeedbackable implements IdGeneratable, Questio
 	private Long id;
 	private Long questionId;
 	private boolean isRead;
+	private Bookmark bookmark;
 
 	public void setRead(boolean read) {
 		isRead = read;

--- a/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -20,6 +20,7 @@ public class Target implements IdGeneratable {
 	private Long id;
 	private final List<Survey> surveyList;
 	private final String nickname;
+	private final String position;
 
 	@Override
 	public void withId(LongSupplier idSupplier) {

--- a/survey/survey-domain/src/test/java/me/nalab/survey/domain/AbstractTargetSources.java
+++ b/survey/survey-domain/src/test/java/me/nalab/survey/domain/AbstractTargetSources.java
@@ -21,7 +21,7 @@ public abstract class AbstractTargetSources extends AbstractSurveySources {
 	protected static Stream<Arguments> targetCreateSuccessSources() {
 		return Stream.of(
 			of(
-				targetFunction(10L, "mike"),
+				targetFunction(10L, "mike", "designer"),
 				surveyFunction(1L, Instant.now(), Instant.now()),
 				(Supplier<List<FormQuestionable>>)() -> {
 					List<Choice> choiceList = new ArrayList<>();
@@ -42,10 +42,11 @@ public abstract class AbstractTargetSources extends AbstractSurveySources {
 	}
 
 	static Function<List<Survey>, Target> targetFunction(Long id,
-		String nickname) {
+		String nickname, String position) {
 		return T -> Target.builder()
 			.id(id)
 			.nickname(nickname)
+			.position(position)
 			.surveyList(T)
 			.build();
 	}

--- a/survey/survey-domain/src/test/java/me/nalab/survey/domain/feedback/FeedbackDomainTest.java
+++ b/survey/survey-domain/src/test/java/me/nalab/survey/domain/feedback/FeedbackDomainTest.java
@@ -209,6 +209,7 @@ class FeedbackDomainTest {
 		String position) {
 		ChoiceFormQuestionFeedback choiceFormQuestionFeedback = ChoiceFormQuestionFeedback.builder()
 			.questionId(1L)
+			.bookmark(getBookmark(false, Instant.now()))
 			.isRead(false)
 			.selectedChoiceIdSet(Set.of(-1L, -2L, -3L))
 			.build();
@@ -244,6 +245,7 @@ class FeedbackDomainTest {
 	private ShortFormQuestionFeedback getShortFormQuestionFeedback(ShortFormQuestion shortFormQuestion) {
 		return ShortFormQuestionFeedback.builder()
 			.questionId(shortFormQuestion.getId())
+			.bookmark(getBookmark(true, Instant.now()))
 			.isRead(false)
 			.replyList(List.of("hello world", "na lab"))
 			.build();
@@ -252,6 +254,7 @@ class FeedbackDomainTest {
 	private ChoiceFormQuestionFeedback getChoiceFormQuestionFeedback(ChoiceFormQuestion choiceFormQuestion) {
 		return ChoiceFormQuestionFeedback.builder()
 			.questionId(choiceFormQuestion.getId())
+			.bookmark(getBookmark(true, Instant.now()))
 			.isRead(false)
 			.selectedChoiceIdSet(getChoiceIdSet(choiceFormQuestion))
 			.build();
@@ -261,6 +264,13 @@ class FeedbackDomainTest {
 		return choiceFormQuestion.getChoiceList().stream()
 			.map(Choice::getId)
 			.collect(Collectors.toSet());
+	}
+
+	private Bookmark getBookmark(boolean isBookmarked, Instant bookmarkedAt) {
+		return Bookmark.builder()
+			.isBookmarked(isBookmarked)
+			.bookmarkedAt(bookmarkedAt)
+			.build();
 	}
 
 }

--- a/survey/survey-domain/src/test/java/me/nalab/survey/domain/target/TargetDomainTest.java
+++ b/survey/survey-domain/src/test/java/me/nalab/survey/domain/target/TargetDomainTest.java
@@ -61,6 +61,7 @@ class TargetDomainTest extends AbstractTargetSources {
 		LongSupplier longSupplier = () -> 119L;
 		Target target = Target.builder()
 			.nickname("xb")
+			.position("designer")
 			.build();
 
 		// when
@@ -77,6 +78,7 @@ class TargetDomainTest extends AbstractTargetSources {
 		LongSupplier longSupplier = () -> 119L;
 		Target target = Target.builder()
 			.nickname("xb")
+			.position("developer")
 			.build();
 
 		// when

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper.java
@@ -9,6 +9,7 @@ import me.nalab.core.data.feedback.FeedbackEntity;
 import me.nalab.core.data.feedback.FormFeedbackEntity;
 import me.nalab.core.data.feedback.ReviewerEntity;
 import me.nalab.core.data.feedback.ShortFormFeedbackEntity;
+import me.nalab.survey.domain.feedback.Bookmark;
 import me.nalab.survey.domain.feedback.ChoiceFormQuestionFeedback;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
@@ -44,7 +45,7 @@ public final class FeedbackEntityMapper {
 
 	private static List<FormQuestionFeedbackable> getFormQuestionFeedbackList(FeedbackEntity feedbackEntity) {
 		return feedbackEntity.getFormFeedbackEntityList().stream().map(q -> {
-			if(q instanceof ShortFormFeedbackEntity) {
+			if (q instanceof ShortFormFeedbackEntity) {
 				return getShortFormQuestionFeedback((ShortFormFeedbackEntity)q);
 			}
 			return getChoiceFormQuestionFeedback((ChoiceFormFeedbackEntity)q);
@@ -57,6 +58,10 @@ public final class FeedbackEntityMapper {
 			.id(shortFormFeedbackEntity.getId())
 			.questionId(shortFormFeedbackEntity.getQuestionId())
 			.isRead(shortFormFeedbackEntity.isRead())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(shortFormFeedbackEntity.isBookmarked())
+				.bookmarkedAt(shortFormFeedbackEntity.getBookmarkedAt())
+				.build())
 			.replyList(shortFormFeedbackEntity.getReplyList())
 			.build();
 	}
@@ -67,6 +72,10 @@ public final class FeedbackEntityMapper {
 			.id(choiceFormFeedbackEntity.getId())
 			.questionId(choiceFormFeedbackEntity.getQuestionId())
 			.isRead(choiceFormFeedbackEntity.isRead())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(choiceFormFeedbackEntity.isBookmarked())
+				.bookmarkedAt(choiceFormFeedbackEntity.getBookmarkedAt())
+				.build())
 			.selectedChoiceIdSet(choiceFormFeedbackEntity.getSelectSet())
 			.build();
 	}
@@ -97,7 +106,7 @@ public final class FeedbackEntityMapper {
 	private static List<FormFeedbackEntity> getFormFeedbackEntityList(Feedback feedback) {
 		return feedback.getFormQuestionFeedbackableList().stream()
 			.map(f -> {
-				if(f instanceof ShortFormQuestionFeedback) {
+				if (f instanceof ShortFormQuestionFeedback) {
 					return getShortFormFeedbackEntity((ShortFormQuestionFeedback)f);
 				}
 				return getChoiceFormFeedbackEntity((ChoiceFormQuestionFeedback)f);
@@ -110,6 +119,8 @@ public final class FeedbackEntityMapper {
 			.id(shortFormQuestionFeedback.getId())
 			.questionId(shortFormQuestionFeedback.getQuestionId())
 			.isRead(shortFormQuestionFeedback.isRead())
+			.isBookmarked(shortFormQuestionFeedback.getBookmark().isBookmarked())
+			.bookmarkedAt(shortFormQuestionFeedback.getBookmark().getBookmarkedAt())
 			.replyList(shortFormQuestionFeedback.getReplyList())
 			.build();
 	}
@@ -120,6 +131,8 @@ public final class FeedbackEntityMapper {
 			.id(choiceFormQuestionFeedback.getId())
 			.questionId(choiceFormQuestionFeedback.getQuestionId())
 			.isRead(choiceFormQuestionFeedback.isRead())
+			.isBookmarked(choiceFormQuestionFeedback.getBookmark().isBookmarked())
+			.bookmarkedAt(choiceFormQuestionFeedback.getBookmark().getBookmarkedAt())
 			.selectSet(choiceFormQuestionFeedback.getSelectedChoiceIdSet())
 			.build();
 	}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/TargetEntityMapper.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/TargetEntityMapper.java
@@ -13,6 +13,7 @@ public class TargetEntityMapper {
 		return TargetEntity.builder()
 			.id(target.getId())
 			.nickname(target.getNickname())
+			.position(target.getPosition())
 			.build();
 	}
 
@@ -20,6 +21,7 @@ public class TargetEntityMapper {
 		return Target.builder()
 			.id(targetEntity.getId())
 			.nickname(targetEntity.getNickname())
+			.position(targetEntity.getPosition())
 			.build();
 	}
 }

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/RandomFeedbackFixture.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/RandomFeedbackFixture.java
@@ -1,5 +1,6 @@
 package me.nalab.survey.jpa.adaptor;
 
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import lombok.Setter;
+import me.nalab.survey.domain.feedback.Bookmark;
 import me.nalab.survey.domain.feedback.ChoiceFormQuestionFeedback;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
@@ -86,7 +88,7 @@ public class RandomFeedbackFixture {
 	private static List<FormQuestionFeedbackable> getRandomQuestionFeedbackListBySurvey(Survey survey) {
 		List<FormQuestionable> formQuestionableList = survey.getFormQuestionableList();
 		return formQuestionableList.stream().map(q -> {
-			if(q.getQuestionType() == QuestionType.CHOICE) {
+			if (q.getQuestionType() == QuestionType.CHOICE) {
 				return getRandomChoiceFormQuestionFeedback((ChoiceFormQuestion)q);
 			}
 			return getRandomShortFormQuestionFeedback((ShortFormQuestion)q);
@@ -96,13 +98,17 @@ public class RandomFeedbackFixture {
 	private static ChoiceFormQuestionFeedback getRandomChoiceFormQuestionFeedback(
 		ChoiceFormQuestion choiceFormQuestion) {
 		Set<Long> selectedIdSet = new HashSet<>();
-		for(int i = 0; i < choiceFormQuestion.getMaxSelectableCount(); i++) {
+		for (int i = 0; i < choiceFormQuestion.getMaxSelectableCount(); i++) {
 			selectedIdSet.add(choiceFormQuestion.getChoiceList().get(i).getId());
 		}
 		return ChoiceFormQuestionFeedback.builder()
 			.id(choiceFormQuestion.getId())
 			.questionId(choiceFormQuestion.getId())
 			.isRead(randomBooleanGenerator.getAsBoolean())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(false)
+				.bookmarkedAt(Instant.now())
+				.build())
 			.selectedChoiceIdSet(selectedIdSet)
 			.build();
 	}
@@ -113,6 +119,10 @@ public class RandomFeedbackFixture {
 			.id(shortFormQuestion.getId())
 			.questionId(shortFormQuestion.getId())
 			.isRead(randomBooleanGenerator.getAsBoolean())
+			.bookmark(Bookmark.builder()
+				.isBookmarked(false)
+				.bookmarkedAt(Instant.now())
+				.build())
 			.replyList(List.of(randomStringGenerator.get()))
 			.build();
 	}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/authorization/TargetIdFindAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/authorization/TargetIdFindAdaptorTest.java
@@ -1,6 +1,6 @@
 package me.nalab.survey.jpa.adaptor.authorization;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.time.Instant;
 import java.util.List;

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/FeedbackCreateController.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/createfeedback/FeedbackCreateController.java
@@ -1,5 +1,6 @@
 package me.nalab.survey.web.adaptor.createfeedback;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import me.nalab.core.secure.xss.meta.Xss;
 import me.nalab.core.secure.xss.meta.XssFiltering;
+import me.nalab.survey.application.common.feedback.dto.BookmarkDto;
 import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
 import me.nalab.survey.application.common.feedback.dto.FormQuestionFeedbackDtoable;
@@ -63,7 +65,7 @@ public class FeedbackCreateController {
 		List<AbstractQuestionFeedbackRequest> abstractQuestionFeedbackRequestList) {
 		return abstractQuestionFeedbackRequestList.stream()
 			.map(r -> {
-				if(r instanceof ChoiceQuestionFeedbackRequest) {
+				if (r instanceof ChoiceQuestionFeedbackRequest) {
 					return toChoiceFormQuestionFeedbackDto((ChoiceQuestionFeedbackRequest)r);
 				}
 				return toShortFormQuestionFeedbackDto((ShortQuestionFeedbackRequest)r);
@@ -75,6 +77,11 @@ public class FeedbackCreateController {
 		ChoiceQuestionFeedbackRequest choiceQuestionFeedbackRequest) {
 		return ChoiceFormQuestionFeedbackDto.builder()
 			.questionId(Long.valueOf(choiceQuestionFeedbackRequest.getQuestionId()))
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(false)
+				// TODO
+				.bookmarkedAt(Instant.now())
+				.build())
 			.selectedChoiceIdSet(choiceQuestionFeedbackRequest.getChoiceSet().stream().map(Long::valueOf).collect(
 				Collectors.toSet()))
 			.build();
@@ -84,6 +91,11 @@ public class FeedbackCreateController {
 		ShortQuestionFeedbackRequest shortQuestionFeedbackRequest) {
 		return ShortFormQuestionFeedbackDto.builder()
 			.questionId(Long.valueOf(shortQuestionFeedbackRequest.getQuestionId()))
+			.bookmarkDto(BookmarkDto.builder()
+				.isBookmarked(false)
+				// TODO
+				.bookmarkedAt(Instant.now())
+				.build())
 			.replyList(shortQuestionFeedbackRequest.getReplyList())
 			.build();
 	}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
flyway v6 적용전에, bookmarked_at에 기본값 세팅을 위해, v4, v5 먼저 적용합니다~

## 어떻게 해결했나요?
- [x] #289 
- [x] #291 `flyway v4`
- [x] #296 `flyway v5` 
- [x] #297  

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
