### PR TITLE
[feat] : 질문폼의 북마크된 피드백 교체 - `jpa-adaptor` 추가

### DIFF
--- a/survey/survey-application/src/main/java/module-info.java
+++ b/survey/survey-application/src/main/java/module-info.java
@@ -27,7 +27,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.out.persistence.authorization;
 	exports me.nalab.survey.application.common.target.dto;
 	exports me.nalab.survey.application.service.authorization;
-
+	exports me.nalab.survey.application.port.out.persistence.bookmark;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackFindAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackFindAdaptor.java
@@ -1,0 +1,30 @@
+package me.nalab.survey.jpa.adaptor.bookmark;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.data.feedback.FormFeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.bookmark.FormQuestionFeedbackFindPort;
+import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
+import me.nalab.survey.jpa.adaptor.bookmark.repository.FormQuestionFeedbackFindRepository;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+
+@Repository
+@RequiredArgsConstructor
+public class FormQuestionFeedbackFindAdaptor implements FormQuestionFeedbackFindPort {
+
+	private final FormQuestionFeedbackFindRepository formQuestionFeedbackFindRepository;
+
+	@Override
+	public Optional<FormQuestionFeedbackable> findFormQuestionFeedbackById(Long formQuestionFeedbackId) {
+		Optional<FormFeedbackEntity> formFeedbackEntity = formQuestionFeedbackFindRepository.findById(
+			formQuestionFeedbackId);
+		if (formFeedbackEntity.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(FeedbackEntityMapper.toFormQuestionFeedbackable(formFeedbackEntity.get()));
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackUpdateAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackUpdateAdaptor.java
@@ -1,0 +1,24 @@
+package me.nalab.survey.jpa.adaptor.bookmark;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.data.feedback.FormFeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.bookmark.FormQuestionFeedbackUpdatePort;
+import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
+import me.nalab.survey.jpa.adaptor.bookmark.repository.FormQuestionFeedbackUpdateRepository;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+
+@Repository
+@RequiredArgsConstructor
+public class FormQuestionFeedbackUpdateAdaptor implements FormQuestionFeedbackUpdatePort {
+
+	private final FormQuestionFeedbackUpdateRepository formQuestionFeedbackUpdateRepository;
+
+	@Override
+	public void updateFormQuestionFeedback(FormQuestionFeedbackable formQuestionFeedbackable) {
+		FormFeedbackEntity formFeedbackEntity = FeedbackEntityMapper.toFormFeedbackEntity(formQuestionFeedbackable);
+		formQuestionFeedbackUpdateRepository.save(formFeedbackEntity);
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/repository/FormQuestionFeedbackFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/repository/FormQuestionFeedbackFindRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.bookmark.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.feedback.FormFeedbackEntity;
+
+public interface FormQuestionFeedbackFindRepository extends JpaRepository<FormFeedbackEntity, Long> {
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/repository/FormQuestionFeedbackUpdateRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/repository/FormQuestionFeedbackUpdateRepository.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.jpa.adaptor.bookmark.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.feedback.FormFeedbackEntity;
+
+public interface FormQuestionFeedbackUpdateRepository extends JpaRepository<FormFeedbackEntity, Long> {
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/FeedbackEntityMapper.java
@@ -52,6 +52,13 @@ public final class FeedbackEntityMapper {
 		}).collect(Collectors.toList());
 	}
 
+	public static FormQuestionFeedbackable toFormQuestionFeedbackable(FormFeedbackEntity feedbackEntity) {
+		if (feedbackEntity instanceof ShortFormFeedbackEntity) {
+			return getShortFormQuestionFeedback((ShortFormFeedbackEntity)feedbackEntity);
+		}
+		return getChoiceFormQuestionFeedback((ChoiceFormFeedbackEntity)feedbackEntity);
+	}
+
 	private static ShortFormQuestionFeedback getShortFormQuestionFeedback(
 		ShortFormFeedbackEntity shortFormFeedbackEntity) {
 		return ShortFormQuestionFeedback.builder()
@@ -101,6 +108,13 @@ public final class FeedbackEntityMapper {
 			.createdAt(now)
 			.updatedAt(now)
 			.build();
+	}
+
+	public static FormFeedbackEntity toFormFeedbackEntity(FormQuestionFeedbackable formQuestionFeedbackable) {
+		if (formQuestionFeedbackable instanceof ShortFormQuestionFeedback) {
+			return getShortFormFeedbackEntity((ShortFormQuestionFeedback)formQuestionFeedbackable);
+		}
+		return getChoiceFormFeedbackEntity((ChoiceFormQuestionFeedback)formQuestionFeedbackable);
 	}
 
 	private static List<FormFeedbackEntity> getFormFeedbackEntityList(Feedback feedback) {

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackFindAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackFindAdaptorTest.java
@@ -1,0 +1,67 @@
+package me.nalab.survey.jpa.adaptor.bookmark;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.core.data.feedback.FormFeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.bookmark.FormQuestionFeedbackFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = FormQuestionFeedbackFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class FormQuestionFeedbackFindAdaptorTest {
+
+	@Autowired
+	private FormQuestionFeedbackFindPort formQuestionFeedbackFindPort;
+
+	@Autowired
+	private TestFeedbackSaveJpaRepository testFeedbackSaveJpaRepository;
+
+	@Test
+	void FIND_FORM_QUESTION_FEEDBACK_WITH_SUCCESS() {
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		Feedback feedback = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
+		FeedbackEntity feedbackEntity = FeedbackEntityMapper.toEntity(feedback);
+		FormFeedbackEntity formFeedbackEntity = feedbackEntity.getFormFeedbackEntityList().get(0);
+		FormQuestionFeedbackable formQuestionFeedbackable = FeedbackEntityMapper.toFormQuestionFeedbackable(
+			formFeedbackEntity);
+		Long formFeedbackEntityId = formFeedbackEntity.getId();
+		testFeedbackSaveJpaRepository.save(feedbackEntity);
+
+		Optional<FormQuestionFeedbackable> resultFormQuestionFeedbackable = formQuestionFeedbackFindPort.findFormQuestionFeedbackById(
+			formFeedbackEntityId);
+
+		assertTrue(resultFormQuestionFeedbackable.isPresent());
+		assertEquals(formQuestionFeedbackable, resultFormQuestionFeedbackable.get());
+	}
+
+	@Test
+	void FIND_FORM_QUESTION_FEEDBACK_WITH_FAIL() {
+
+		Long nonExistentFormFeedbackEntityId = 999L;
+
+		Optional<FormQuestionFeedbackable> formQuestionFeedbackable = formQuestionFeedbackFindPort.findFormQuestionFeedbackById(
+			nonExistentFormFeedbackEntityId);
+
+		assertTrue(formQuestionFeedbackable.isEmpty());
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackUpdateAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackUpdateAdaptorTest.java
@@ -1,0 +1,62 @@
+package me.nalab.survey.jpa.adaptor.bookmark;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.core.data.feedback.FormFeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.bookmark.FormQuestionFeedbackFindPort;
+import me.nalab.survey.application.port.out.persistence.bookmark.FormQuestionFeedbackUpdatePort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.feedback.FormQuestionFeedbackable;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = {FormQuestionFeedbackFindAdaptor.class, FormQuestionFeedbackUpdateAdaptor.class})
+@TestPropertySource("classpath:h2.properties")
+class FormQuestionFeedbackUpdateAdaptorTest {
+
+	@Autowired
+	private FormQuestionFeedbackFindPort formQuestionFeedbackFindPort;
+
+	@Autowired
+	private FormQuestionFeedbackUpdatePort formQuestionFeedbackUpdatePort;
+
+	@Autowired
+	private TestFeedbackSaveJpaRepository testFeedbackSaveJpaRepository;
+
+	@Test
+	void UPDATE_FORM_QUESTION_FEEDBACK_WITH_SUCCESS() {
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		Feedback feedback = RandomFeedbackFixture.getRandomFeedbackBySurvey(survey);
+		FeedbackEntity feedbackEntity = FeedbackEntityMapper.toEntity(feedback);
+		FormFeedbackEntity formFeedbackEntity = feedbackEntity.getFormFeedbackEntityList().get(0);
+		Long formFeedbackEntityId = FeedbackEntityMapper.toFormQuestionFeedbackable(formFeedbackEntity)
+			.getFormQuestionId();
+		testFeedbackSaveJpaRepository.save(feedbackEntity);
+
+		FormQuestionFeedbackable formQuestionFeedbackable = formQuestionFeedbackFindPort.findFormQuestionFeedbackById(
+			formFeedbackEntityId).get();
+		formQuestionFeedbackable.replaceBookmark();
+		formQuestionFeedbackUpdatePort.updateFormQuestionFeedback(formQuestionFeedbackable);
+
+		Optional<FormQuestionFeedbackable> resultFormQuestionFeedbackable = formQuestionFeedbackFindPort.findFormQuestionFeedbackById(
+			formFeedbackEntityId);
+		assertEquals(formQuestionFeedbackable, resultFormQuestionFeedbackable.get());
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/bookmark/TestFeedbackSaveJpaRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/bookmark/TestFeedbackSaveJpaRepository.java
@@ -1,0 +1,10 @@
+package me.nalab.survey.jpa.adaptor.bookmark;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+@Repository("bookmark.TestFeedbackSaveJpaRepository")
+public interface TestFeedbackSaveJpaRepository extends JpaRepository<FeedbackEntity, Long> {
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
질문폼의 북마크된 피드백 교체 API에 대한 jpa-adaptor 부분을 개발 완료했습니다

- [x] port의 구현체인 `FormQuestionFeedbackFindAdaptor`, `FormQuestionFeedbackUpdateAdaptor` 를 구현하고, 이를 이용하는 repository도 정의하였습니다
- [x] `FormQuestionFeedbackable` <-> `FormFeedbackEntity` 간의 변환 mapper를 만들었습니다
- [x] `FormQuestionFeedbackFindAdaptor`, `FormQuestionFeedbackUpdateAdaptor`각각에 대한 테스트를 작성하고, 예외에 대한 테스트도 추가하였습니다

## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
