### PR TITLE
[feat] : `formQuestionFeedbackId`로 Authorization 기능 추가

### DIFF
--- a/survey/survey-application/src/main/java/me/nalab/survey/application/exception/FormQuestionFeedbackNotExistException.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/exception/FormQuestionFeedbackNotExistException.java
@@ -8,7 +8,7 @@ public class FormQuestionFeedbackNotExistException extends RuntimeException {
 	private final Long formQuestionFeedbackId;
 
 	public FormQuestionFeedbackNotExistException(Long formQuestionFeedbackId) {
-		super("Cannot found any formQuestionFeedback id \"" + formQuestionFeedbackId);
+		super("Cannot found any formQuestionFeedback id \"" + formQuestionFeedbackId + "\"");
 		this.formQuestionFeedbackId = formQuestionFeedbackId;
 	}
 

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/authorization/TargetIdFindPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/authorization/TargetIdFindPort.java
@@ -8,21 +8,30 @@ import java.util.Optional;
 public interface TargetIdFindPort {
 
 	/**
-	 * surveyId를 인자로 받아, 해당 surveyId를 소유하고있는 target의 Id를 반환합니다.
-	 * 만약, target의 Id를 찾을 수 없다면, Optional.empty() 를 반환합니다.
+	 * surveyId 를 인자로 받아, 해당 surveyId를 소유하고있는 target 의 Id를 반환합니다.
+	 * 만약, target 의 Id를 찾을 수 없다면, Optional.empty() 를 반환합니다.
 	 *
-	 * @param surveyId survey의 id
-	 * @return 있다면, surveyId를 소유하고있는 target의 Id
+	 * @param surveyId survey 의 id
+	 * @return 있다면, surveyId를 소유하고있는 target 의 Id
 	 */
 	Optional<Long> findTargetIdBySurveyId(Long surveyId);
 
 	/**
-	 * feedbackId를 인자로 받아, 해당 surveyId를 소유하고있는 feedback의 Id를 반환합니다.
+	 * feedbackId를 인자로 받아, 해당 surveyId를 소유하고있는 target 의 Id를 반환합니다.
 	 * 만약, feedback의 Id를 찾을 수 없다면, Optional.empty() 를 반환합니다.
 	 *
-	 * @param feedbackId feedback의 id
-	 * @return 있다면, feedbackId를 소유하고있는 target의 Id
+	 * @param feedbackId feedback 의 id
+	 * @return 있다면, feedbackId 를 소유하고있는 target 의 Id
 	 */
 	Optional<Long> findTargetIdByFeedbackId(Long feedbackId);
+
+	/**
+	 * formQuestionFeedbackId 를 인자로 받아, 해당 surveyId를 소유하고있는 target 의 id를 반환합니다.
+	 * 만약, formQuestionFeedbackId 를 찾을 수 없다면, Optional.empty() 를 반환합니다.
+	 *
+	 * @param formQuestionFeedbackId formQuestionFeedback 의 id
+	 * @return formQuestionFeedbackId를 소유하고있는 target 의 id
+	 */
+	Optional<Long> findTargetIdByFormQuestionFeedbackId(Long formQuestionFeedbackId);
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/authorization/FormQuestionFeedbackIdValidator.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/authorization/FormQuestionFeedbackIdValidator.java
@@ -1,0 +1,39 @@
+package me.nalab.survey.application.service.authorization;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.authorization.spi.Validator;
+import me.nalab.survey.application.exception.FormQuestionFeedbackNotExistException;
+import me.nalab.survey.application.port.out.persistence.authorization.TargetIdFindPort;
+
+@Service
+@RequiredArgsConstructor
+public class FormQuestionFeedbackIdValidator implements Validator {
+
+	private final TargetIdFindPort targetIdFindPort;
+
+	@Override
+	@Transactional(readOnly = true)
+	public <T, S> boolean valid(T expected, S result) {
+		validType(expected, result);
+		Long expectedTargetId = (Long)expected;
+		Long requestFormQuestionFeedbackId = (Long)result;
+		Long resultTargetId = targetIdFindPort.findTargetIdByFormQuestionFeedbackId(requestFormQuestionFeedbackId)
+			.orElseThrow(() -> {
+				throw new FormQuestionFeedbackNotExistException(requestFormQuestionFeedbackId);
+			});
+		return expectedTargetId.equals(resultTargetId);
+	}
+
+	private <T, S> void validType(T expected, S result) {
+		if(expected instanceof Long && result instanceof Long) {
+			return;
+		}
+		throw new IllegalArgumentException(
+			"Expected \"expected\" type was Long \"" + expected.getClass() + "\"Expected \"result\" type was Long \""
+				+ result.getClass() + "\"");
+	}
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/authorization/FormQuestionFeedbackIdValidatorFactory.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/authorization/FormQuestionFeedbackIdValidatorFactory.java
@@ -1,0 +1,25 @@
+package me.nalab.survey.application.service.authorization;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.core.authorization.spi.ValidatorFactory;
+
+@Service
+@RequiredArgsConstructor
+public class FormQuestionFeedbackIdValidatorFactory
+	implements ValidatorFactory<LongParameterExtractor, FormQuestionFeedbackIdValidator> {
+
+	private final LongParameterExtractor longParameterExtractor;
+	private final FormQuestionFeedbackIdValidator formQuestionFeedbackIdValidator;
+
+	@Override
+	public LongParameterExtractor parameterExtractor() {
+		return longParameterExtractor;
+	}
+
+	@Override
+	public FormQuestionFeedbackIdValidator validator() {
+		return formQuestionFeedbackIdValidator;
+	}
+}

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/authorization/FormQuestionFeedbackIdValidatorTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/authorization/FormQuestionFeedbackIdValidatorTest.java
@@ -1,0 +1,112 @@
+package me.nalab.survey.application.service.authorization;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.survey.application.exception.FormQuestionFeedbackNotExistException;
+import me.nalab.survey.application.port.out.persistence.authorization.TargetIdFindPort;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {FormQuestionFeedbackIdValidator.class, LongParameterExtractor.class,
+	FormQuestionFeedbackIdValidatorFactory.class})
+class FormQuestionFeedbackIdValidatorTest {
+
+	@Autowired
+	private FormQuestionFeedbackIdValidatorFactory feedbackIdValidatorFactory;
+
+	@MockBean
+	private TargetIdFindPort targetIdFindPort;
+
+	@ParameterizedTest
+	@DisplayName("expectedTargetId와 requestFormQuestionFeedbackId가 같다면, true를 반환한다")
+	@MethodSource("authorizationSources")
+	void FORM_QUESTION_FEEDBACK_ID_AUTHORIZATION_TEST(Long expectedTargetId, Long requestFormQuestionFeedbackId,
+		Long realTargetId, boolean expectedResult) {
+		// given
+		FormQuestionFeedbackIdValidator formQuestionFeedbackIdValidator = feedbackIdValidatorFactory.validator();
+		feedbackIdValidatorFactory.parameterExtractor();
+
+		Mockito.when(targetIdFindPort.findTargetIdByFormQuestionFeedbackId(requestFormQuestionFeedbackId))
+			.thenReturn(Optional.of(realTargetId));
+
+		// when
+		boolean result = formQuestionFeedbackIdValidator.valid(expectedTargetId, requestFormQuestionFeedbackId);
+
+		// then
+		Assertions.assertThat(result).isEqualTo(expectedResult);
+	}
+
+	@Test
+	@DisplayName("requestFormQuestionFeedbackId에 해당하는 targetId가 없다면, FOrmQuestionFeedbackDoesNotExist 예외를 던진다")
+	void THROW_FORM_QUESTION_FEEDBACK_DOES_NOT_EXIST_EXCEPTION() {
+		// given
+		Long expectedTargetId = 1L;
+		Long requestFormQuestionFeedbackId = 1L;
+		FormQuestionFeedbackIdValidator formQuestionFeedbackIdValidator = feedbackIdValidatorFactory.validator();
+		feedbackIdValidatorFactory.parameterExtractor();
+
+		Mockito.when(targetIdFindPort.findTargetIdByFormQuestionFeedbackId(requestFormQuestionFeedbackId))
+			.thenReturn(Optional.empty());
+
+		// when
+		Throwable throwable = Assertions.catchThrowable(
+			() -> formQuestionFeedbackIdValidator.valid(expectedTargetId, requestFormQuestionFeedbackId));
+
+		// then
+		Assertions.assertThat(throwable.getClass()).isEqualTo(FormQuestionFeedbackNotExistException.class);
+	}
+
+	@Test
+	@DisplayName("expectedTargetId로 Long이 아닌 타입이 들어오면 IllegalArgumentException을 던진다")
+	void THROW_ILLEGAL_ARGUMENT_EXCEPTION_WHEN_WRONG_TYPE_ON_EXPECTED_TARGET_ID() {
+		// given
+		String expectedTargetId = "1L";
+		Long requestFormQuestionFeedbackId = 1L;
+		FormQuestionFeedbackIdValidator formQuestionFeedbackIdValidator = feedbackIdValidatorFactory.validator();
+		feedbackIdValidatorFactory.parameterExtractor();
+
+		// when
+		Throwable throwable = Assertions.catchThrowable(
+			() -> formQuestionFeedbackIdValidator.valid(expectedTargetId, requestFormQuestionFeedbackId));
+
+		// then
+		Assertions.assertThat(throwable.getClass()).isEqualTo(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("requestFormQuestionFeedbackId로 Long이 아닌 타입이 들어오면 IllegalArgumentException을 던진다")
+	void THROW_ILLEGAL_ARGUMENT_EXCEPTION_WHEN_WRONG_TYPE_ON_REQUEST_ID() {
+		// given
+		Long expectedTargetId = 1L;
+		String requestFormQuestionFeedbackId = "1L";
+		FormQuestionFeedbackIdValidator formQuestionFeedbackIdValidator = feedbackIdValidatorFactory.validator();
+
+		// when
+		Throwable throwable = Assertions.catchThrowable(
+			() -> formQuestionFeedbackIdValidator.valid(expectedTargetId, requestFormQuestionFeedbackId));
+
+		// then
+		Assertions.assertThat(throwable.getClass()).isEqualTo(IllegalArgumentException.class);
+	}
+
+	private static Stream<Arguments> authorizationSources() {
+		return Stream.of(
+			Arguments.of(1L, 1L, 1L, true),
+			Arguments.of(1L, 1L, 2L, false)
+		);
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/authorization/TargetIdFindAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/authorization/TargetIdFindAdaptor.java
@@ -24,4 +24,8 @@ public class TargetIdFindAdaptor implements TargetIdFindPort {
 		return targetIdFindJpaRepository.findTargetIdByFeedbackId(feedbackId);
 	}
 
+	@Override
+	public Optional<Long> findTargetIdByFormQuestionFeedbackId(Long formQuestionFeedbackId) {
+		return targetIdFindJpaRepository.findTargetIdByFormQuestionFeedbackId(formQuestionFeedbackId);
+	}
 }

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/authorization/repository/TargetIdFindJpaRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/authorization/repository/TargetIdFindJpaRepository.java
@@ -15,4 +15,7 @@ public interface TargetIdFindJpaRepository extends JpaRepository<TargetEntity, L
 
 	@Query("select t.id from TargetEntity as t join SurveyEntity as s on s.id = (select f.surveyId from FeedbackEntity as f where f.id = :feedbackId) and s.targetId = t.id")
 	Optional<Long> findTargetIdByFeedbackId(@Param("feedbackId") Long feedbackId);
+
+	@Query("select t.id from TargetEntity as t join SurveyEntity as s on s.id = (select ff.feedbackEntity.surveyId from FormFeedbackEntity as ff where ff.id = :formQuestionFeedbackId) and s.targetId = t.id")
+	Optional<Long> findTargetIdByFormQuestionFeedbackId(@Param("formQuestionFeedbackId") Long formQuestionFeedbackId);
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
formQuestionFeedbackId로 인증하는 기능을 추가했습니다.

## 어떻게 해결했나요?
- [x] formQuestionFeedbackId를 이용해 사용자 id와 비교하는 validator 추가
- [x] formQuestionFeedbackId를 받아, targetId를 반환하는 jpa-adaptor 추가

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
