### PR TITLE
[fix] : 북마크시 jpa 변경 감지 이용하도록 수정, 인증에 Auth 어노테이션 누락 수정

### DIFF
--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackUpdateAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/FormQuestionFeedbackUpdateAdaptor.java
@@ -18,7 +18,8 @@ public class FormQuestionFeedbackUpdateAdaptor implements FormQuestionFeedbackUp
 	@Override
 	public void updateFormQuestionFeedback(FormQuestionFeedbackable formQuestionFeedbackable) {
 		FormFeedbackEntity formFeedbackEntity = FeedbackEntityMapper.toFormFeedbackEntity(formQuestionFeedbackable);
-		formQuestionFeedbackUpdateRepository.save(formFeedbackEntity);
+		formFeedbackEntity.setBookmarked(formQuestionFeedbackable.getBookmark().isBookmarked());
+		formFeedbackEntity.setBookmarkedAt(formQuestionFeedbackable.getBookmark().getBookmarkedAt());
 	}
 
 }

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/bookmark/BookmarkReplaceController.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/bookmark/BookmarkReplaceController.java
@@ -1,12 +1,15 @@
 package me.nalab.survey.web.adaptor.bookmark;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import me.nalab.core.authorization.aop.meta.Auth;
 import me.nalab.core.authorization.aop.meta.Authorization;
 import me.nalab.survey.application.port.in.web.bookmark.BookmarkReplaceUseCase;
 import me.nalab.survey.application.service.authorization.FormQuestionFeedbackIdValidatorFactory;
@@ -20,10 +23,10 @@ public class BookmarkReplaceController {
 
 	@PatchMapping("/feedbacks/bookmarks")
 	@Authorization(factory = FormQuestionFeedbackIdValidatorFactory.class)
-	public ResponseEntity<Void> replaceBookmark(
-		@RequestParam("form-question-feedback-id") String formQuestionFeedbackId) {
-		bookmarkReplaceUseCase.replaceBookmark(Long.valueOf(formQuestionFeedbackId));
-		return ResponseEntity.ok().build();
+	@ResponseStatus(HttpStatus.OK)
+	public void replaceBookmark(
+		@Auth @RequestParam("form-question-feedback-id") Long formQuestionFeedbackId) {
+		bookmarkReplaceUseCase.replaceBookmark(formQuestionFeedbackId);
 	}
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
인수테스트가 깨지는 부분 수정했습니다

## 어떻게 해결했나요?
- [x] 북마크시, db에 쿼리를 날리는것이 아닌 변경감지를 이용해 북마크되도록 수정했습니다.
- [x] 인증때, `@Auth` 어노테이션이 누락되어있어 추가했습니다.
 
<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
