### PR TITLE
[feat] : 로그인된 타겟의 정보 수정 - `application` 추가

### DIFF
--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/target/update/TargetPositionUpdateUseCase.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/target/update/TargetPositionUpdateUseCase.java
@@ -1,0 +1,16 @@
+package me.nalab.survey.application.port.in.web.target.update;
+
+/**
+ *
+ * targetId에 해당하는 타겟의 position을 수정합니다.
+ */
+public interface TargetPositionUpdateUseCase {
+
+	/**
+	 *
+	 * @param targetId 해당 타겟의 id
+	 * @param position 변경할 position
+	 */
+	void updateTargetPosition(Long targetId, String position);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetFindPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetFindPort.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.application.port.out.persistence.target.update;
+
+import java.util.Optional;
+
+import me.nalab.survey.domain.target.Target;
+
+public interface TargetFindPort {
+
+	/**
+	 * targetId에 해당하는 Target을 조회합니다.
+	 *
+	 * @param targetId Target을 조회할 Target의 ID
+	 * @return Optional 만약, 어떠한 targetId도 없을 경우, Optional.empty() 를 반환해야 합니다.
+	 */
+	Optional<Target> findTarget(Long targetId);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetPositionUpdatePort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetPositionUpdatePort.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.application.port.out.persistence.target.update;
+
+import me.nalab.survey.domain.target.Target;
+
+/**
+ * Target의 position 필드를 변경하는 역할을 하는 인터페이스
+ *
+ * 이 인터페이스의 구현체는 target의 position을 업데이트 합니다
+ */
+public interface TargetPositionUpdatePort {
+
+	/**
+	 * 이 메서드는 target의 position을 업데이트 합니다
+	 * @param targetId 업데이트할 target의 id
+	 * @param target 업데이트할 target
+	 */
+	void updateTargetPosition(Long targetId, Target target);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateService.java
@@ -1,0 +1,30 @@
+package me.nalab.survey.application.service.updatetarget;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.exception.TargetDoesNotExistException;
+import me.nalab.survey.application.port.in.web.target.update.TargetPositionUpdateUseCase;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetFindPort;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetPositionUpdatePort;
+import me.nalab.survey.domain.target.Target;
+
+@Service
+@RequiredArgsConstructor
+public class TargetPositionUpdateService implements TargetPositionUpdateUseCase {
+
+	private final TargetFindPort targetFindPort;
+	private final TargetPositionUpdatePort targetPositionUpdatePort;
+
+	@Override
+	@Transactional
+	public void updateTargetPosition(Long targetId, String position) {
+		Target target = targetFindPort.findTarget(targetId).orElseThrow(
+			() -> new TargetDoesNotExistException(targetId)
+		);
+		target.setPosition(position);
+		targetPositionUpdatePort.updateTargetPosition(targetId, target);
+	}
+
+}

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateServiceTest.java
@@ -1,0 +1,72 @@
+package me.nalab.survey.application.service.updatetarget;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.survey.application.TestIdGenerator;
+import me.nalab.survey.application.exception.TargetDoesNotExistException;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetFindPort;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetPositionUpdatePort;
+import me.nalab.survey.domain.target.Target;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {TestIdGenerator.class})
+class TargetPositionUpdateServiceTest {
+
+	private TargetPositionUpdateService targetPositionUpdateService;
+
+	@Mock
+	private TargetFindPort targetFindPort;
+
+	@Mock
+	private TargetPositionUpdatePort targetPositionUpdatePort;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		targetPositionUpdateService = new TargetPositionUpdateService(targetFindPort, targetPositionUpdatePort);
+	}
+
+	@Test
+	void UPDATE_TARGET_POSITION_SERVICE_SUCCESS_TEST() {
+
+		Long targetId = 123L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+
+		assertDoesNotThrow(() -> targetPositionUpdateService.updateTargetPosition(targetId, target.getPosition()));
+
+	}
+
+	@Test
+	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST() {
+
+		Long targetId = 123L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.empty());
+
+		assertThrows(TargetDoesNotExistException.class,
+			() -> targetPositionUpdateService.updateTargetPosition(targetId, target.getPosition())
+		);
+
+	}
+
+}

--- a/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -20,14 +20,17 @@ public class Target implements IdGeneratable {
 	private Long id;
 	private final List<Survey> surveyList;
 	private final String nickname;
-	private final String position;
+	private String position;
 
 	@Override
 	public void withId(LongSupplier idSupplier) {
-		if(id != null) {
+		if (id != null) {
 			throw new IdAlreadyGeneratedException(this);
 		}
 		id = idSupplier.getAsLong();
 	}
 
+	public void setPosition(String position) {
+		this.position = position;
+	}
 }

--- a/survey/survey-domain/src/test/java/me/nalab/survey/domain/target/TargetDomainTest.java
+++ b/survey/survey-domain/src/test/java/me/nalab/survey/domain/target/TargetDomainTest.java
@@ -1,9 +1,6 @@
 package me.nalab.survey.domain.target;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.function.Function;
@@ -86,6 +83,22 @@ class TargetDomainTest extends AbstractTargetSources {
 
 		// then
 		assertThrows(IdAlreadyGeneratedException.class, () -> target.withId(longSupplier));
+	}
+
+	@Test
+	@DisplayName("Target position 수정 테스트")
+	void TARGET_POSITION_UPDATE_TEST() {
+
+		Target target = Target.builder()
+			.nickname("target")
+			.position("designer")
+			.build();
+		String newPosition = "developer";
+
+		target.setPosition(newPosition);
+
+		assertEquals(newPosition, target.getPosition());
+
 	}
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?

`로그인된 타겟의 정보 수정` API에 대한 application 부분을 개발 완료했습니다

- [x] in port 에서 **로그인된 타겟의 정보 수정** 유즈케이스의 interface인 `TargetPositionUpdateUseCase` 정의하고, 이의 구현체 를 만들었습니다
- [x] target 도메인에 position을 수정하는 메서드를 추가하고, 도메인 단위 테스트를 추가하였습니다
- [x] out persistence 에서 port 인터페이스를 정의하였습니다
- [x] 그리고 서비스 테스트를 추가하였습니다 - 테스트는 예외 케이스까지 모두 검증하였습니다


## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
