### PR TITLE
[feat] : 로그인된 타겟의 정보 수정 - `jpa-adaptor` 구현 완료

### DIFF
--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetPositionUpdatePort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetPositionUpdatePort.java
@@ -10,9 +10,11 @@ import me.nalab.survey.domain.target.Target;
 public interface TargetPositionUpdatePort {
 
 	/**
+	 *
 	 * 이 메서드는 target의 position을 업데이트 합니다
 	 * @param target 업데이트할 target
+	 * @return
 	 */
-	void updateTargetPosition(Target target);
+	boolean updateTargetPosition(Target target);
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateService.java
@@ -24,7 +24,11 @@ public class TargetPositionUpdateService implements TargetPositionUpdateUseCase 
 			() -> new TargetDoesNotExistException(targetId)
 		);
 		target.setPosition(position);
-		targetPositionUpdatePort.updateTargetPosition(target);
+
+		boolean updatedResult = targetPositionUpdatePort.updateTargetPosition(target);
+		if (!updatedResult) {
+			throw new TargetDoesNotExistException(target.getId());
+		}
 	}
 
 }

--- a/survey/survey-application/src/main/java/module-info.java
+++ b/survey/survey-application/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.service.authorization;
 	exports me.nalab.survey.application.port.out.persistence.bookmark;
 	exports me.nalab.survey.application.port.in.web.bookmark;
+	exports me.nalab.survey.application.port.out.persistence.target.update;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateServiceTest.java
@@ -44,13 +44,33 @@ class TargetPositionUpdateServiceTest {
 			.build();
 
 		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+		when(targetPositionUpdatePort.updateTargetPosition(target)).thenReturn(true);
 
 		assertDoesNotThrow(() -> targetPositionUpdateService.updateTargetPosition(targetId, target.getPosition()));
 
 	}
 
 	@Test
-	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST() {
+	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST_CASE_1() {
+
+		Long targetId = 123L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+		String position = target.getPosition();
+
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+		when(targetPositionUpdatePort.updateTargetPosition(target)).thenReturn(false);
+
+		assertThrows(TargetDoesNotExistException.class,
+			() -> targetPositionUpdateService.updateTargetPosition(targetId, position)
+		);
+
+	}
+
+	@Test
+	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST_CASE_2() {
 
 		Long targetId = 123L;
 		Target target = Target.builder()
@@ -60,6 +80,26 @@ class TargetPositionUpdateServiceTest {
 		String position = target.getPosition();
 
 		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.empty());
+		when(targetPositionUpdatePort.updateTargetPosition(target)).thenReturn(true);
+
+		assertThrows(TargetDoesNotExistException.class,
+			() -> targetPositionUpdateService.updateTargetPosition(targetId, position)
+		);
+
+	}
+
+	@Test
+	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST_CASE_3() {
+
+		Long targetId = 123L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+		String position = target.getPosition();
+
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.empty());
+		when(targetPositionUpdatePort.updateTargetPosition(target)).thenReturn(false);
 
 		assertThrows(TargetDoesNotExistException.class,
 			() -> targetPositionUpdateService.updateTargetPosition(targetId, position)

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetFindAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetFindAdaptor.java
@@ -1,0 +1,35 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetFindPort;
+import me.nalab.survey.domain.target.Target;
+import me.nalab.survey.jpa.adaptor.common.mapper.TargetEntityMapper;
+import me.nalab.survey.jpa.adaptor.updatetarget.repository.TargetFindRepository;
+
+@Repository("updatetarget.TargetFindAdaptor")
+public class TargetFindAdaptor implements TargetFindPort {
+
+	private final TargetFindRepository targetFindRepository;
+
+	@Autowired
+	TargetFindAdaptor(
+		@Qualifier("updatetarget.TargetFindRepository") TargetFindRepository targetFindRepository) {
+		this.targetFindRepository = targetFindRepository;
+	}
+
+	@Override
+	public Optional<Target> findTarget(Long targetId) {
+		Optional<TargetEntity> targetEntity = targetFindRepository.findById(targetId);
+		if (targetEntity.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(TargetEntityMapper.toTarget(targetEntity.get()));
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptor.java
@@ -1,0 +1,33 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetPositionUpdatePort;
+import me.nalab.survey.domain.target.Target;
+import me.nalab.survey.jpa.adaptor.updatetarget.repository.TargetPositionUpdateRepository;
+
+@Repository("updatetarget.TargetPositionUpdateAdaptor")
+public class TargetPositionUpdateAdaptor implements TargetPositionUpdatePort {
+
+	private final TargetPositionUpdateRepository targetPositionUpdateRepository;
+
+	@Autowired
+	TargetPositionUpdateAdaptor(
+		@Qualifier("updatetarget.TargetPositionUpdateRepository") TargetPositionUpdateRepository targetPositionUpdateRepository) {
+		this.targetPositionUpdateRepository = targetPositionUpdateRepository;
+	}
+
+	@Override
+	public void updateTargetPosition(Target target) {
+		Optional<TargetEntity> targetEntity = targetPositionUpdateRepository.findById(target.getId());
+		if (targetEntity.isEmpty())
+			return;
+		targetEntity.get().setPosition(target.getPosition());
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptor.java
@@ -23,11 +23,13 @@ public class TargetPositionUpdateAdaptor implements TargetPositionUpdatePort {
 	}
 
 	@Override
-	public void updateTargetPosition(Target target) {
+	public boolean updateTargetPosition(Target target) {
 		Optional<TargetEntity> targetEntity = targetPositionUpdateRepository.findById(target.getId());
-		if (targetEntity.isEmpty())
-			return;
+		if (targetEntity.isEmpty()) {
+			return false;
+		}
 		targetEntity.get().setPosition(target.getPosition());
+		return true;
 	}
 
 }

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/repository/TargetFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/repository/TargetFindRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.updatetarget.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+@Repository("updatetarget.TargetFindRepository")
+public interface TargetFindRepository extends JpaRepository<TargetEntity, Long> {
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/repository/TargetPositionUpdateRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/repository/TargetPositionUpdateRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.updatetarget.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+@Repository("updatetarget.TargetPositionUpdateRepository")
+public interface TargetPositionUpdateRepository extends JpaRepository<TargetEntity, Long> {
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetFindAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetFindAdaptorTest.java
@@ -1,0 +1,69 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.target.Target;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = TargetFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class TargetFindAdaptorTest {
+
+	@Autowired
+	private TargetFindAdaptor targetFindAdaptor;
+
+	@Autowired
+	private TestTargetFindRepository testTargetFindRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("타겟 조회 성공 테스트")
+	void FIND_TARGET_BY_ID_SUCCESS() {
+
+		Long targetId = 1L;
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(targetId)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("sujin")
+			.build();
+
+		testTargetFindRepository.saveAndFlush(targetEntity);
+		entityManager.clear();
+		Optional<Target> resultTarget = targetFindAdaptor.findTarget(targetId);
+
+		assertTrue(resultTarget.isPresent());
+		assertEquals(targetEntity.getId(), resultTarget.get().getId());
+	}
+
+	@Test
+	@DisplayName("타겟 조회 실패 테스트")
+	void FIND_TARGET_BY_ID_FAIL() {
+
+		Long targetId = 1L;
+
+		Optional<Target> target = targetFindAdaptor.findTarget(targetId);
+
+		assertTrue(target.isEmpty());
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptorTest.java
@@ -54,11 +54,34 @@ class TargetPositionUpdateAdaptorTest {
 
 		String updatePosition = "developer";
 		target.setPosition(updatePosition);
-		targetPositionUpdateAdaptor.updateTargetPosition(target);
-
+		boolean updatedResult = targetPositionUpdateAdaptor.updateTargetPosition(target);
 		Optional<TargetEntity> resultTargetEntity = testTargetPositionUpdateRepository.findById(targetId);
+
+		assertTrue(updatedResult);
 		assertTrue(resultTargetEntity.isPresent());
 		assertEquals(updatePosition, resultTargetEntity.get().getPosition());
+
+	}
+
+	@Test
+	@DisplayName("타겟 position 수정 실패 테스트")
+	void UPDATE_TARGET_POSITION_FAIL() {
+
+		Long targetId = 1L;
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(targetId)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("sujin")
+			.position("designer")
+			.build();
+		Target target = TargetEntityMapper.toTarget(targetEntity);
+
+		String updatePosition = "developer";
+		target.setPosition(updatePosition);
+		boolean updatedResult = targetPositionUpdateAdaptor.updateTargetPosition(target);
+
+		assertFalse(updatedResult);
 
 	}
 

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptorTest.java
@@ -1,0 +1,65 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.target.Target;
+import me.nalab.survey.jpa.adaptor.common.mapper.TargetEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = TargetPositionUpdateAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class TargetPositionUpdateAdaptorTest {
+
+	@Autowired
+	private TargetPositionUpdateAdaptor targetPositionUpdateAdaptor;
+
+	@Autowired
+	private TestTargetPositionUpdateRepository testTargetPositionUpdateRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("타겟 position 수정 성공 테스트")
+	void UPDATE_TARGET_POSITION_SUCCESS() {
+
+		Long targetId = 1L;
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(targetId)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("sujin")
+			.position("designer")
+			.build();
+		Target target = TargetEntityMapper.toTarget(targetEntity);
+		testTargetPositionUpdateRepository.saveAndFlush(targetEntity);
+		entityManager.clear();
+
+		String updatePosition = "developer";
+		target.setPosition(updatePosition);
+		targetPositionUpdateAdaptor.updateTargetPosition(target);
+
+		Optional<TargetEntity> resultTargetEntity = testTargetPositionUpdateRepository.findById(targetId);
+		assertTrue(resultTargetEntity.isPresent());
+		assertEquals(updatePosition, resultTargetEntity.get().getPosition());
+
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TestTargetFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TestTargetFindRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+@Repository("updatetarget.TestTargetFindRepository")
+public interface TestTargetFindRepository extends JpaRepository<TargetEntity, Long> {
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TestTargetPositionUpdateRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TestTargetPositionUpdateRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+@Repository("updatetarget.TestTargetPositionUpdateRepository")
+public interface TestTargetPositionUpdateRepository extends JpaRepository<TargetEntity, Long> {
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
로그인된 타겟의 정보 수정 API에 대한 `jpa-adaptor` 부분을 개발 완료했습니다

- [x] port의 구현체인 `TargetFindAdaptor`, `TargetPositionUpdateAdaptor` 를 구현하고, 이를 이용하는 repository도 정의하였습니다
- [x] `TargetFindAdaptor`, `TargetPositionUpdateAdaptorr`각각에 대한 테스트를 작성하고, 예외에 대한 테스트도 추가하였습니다



## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
