### PR TITLE
[feat] : 질문폼에 해당하는 타겟의 정보 조회 - `인수테스트` 작성

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
@@ -1,6 +1,7 @@
 package me.nalab.luffy.api.acceptance.test.survey;
 
-import me.nalab.luffy.api.acceptance.test.DatabaseCleaner;
+import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -9,7 +10,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.util.Set;
+import me.nalab.luffy.api.acceptance.test.DatabaseCleaner;
 
 public abstract class AbstractSurveyTestSupporter {
 
@@ -39,6 +40,14 @@ public abstract class AbstractSurveyTestSupporter {
 	protected ResultActions findSurvey(Long survey_Id) throws Exception {
 		return mockMvc.perform(MockMvcRequestBuilders
 			.get(API_VERSION + "/surveys" + "/" + survey_Id)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+	}
+
+	protected ResultActions findTargetBySurveyId(Long survey_Id) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.get(API_VERSION + "/users?survey-id=" + survey_Id)
 			.accept(MediaType.APPLICATION_JSON)
 			.contentType(MediaType.APPLICATION_JSON)
 		);

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
@@ -1,8 +1,6 @@
 package me.nalab.luffy.api.acceptance.test.survey;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -52,7 +50,6 @@ public class SurveyAcceptanceValidator {
 			.andExpect(jsonPath("$.question[0].choices[2].order").value(3))
 			.andExpect(jsonPath("$.question[0].choices[3].order").value(4))
 
-
 			.andExpect(jsonPath("$.question[1].type").value("choice"))
 			.andExpect(jsonPath("$.question[1].title").value("예진님의 성향은 어떤 것이 돋보이나요?"))
 			.andExpect(jsonPath("$.question[1].order").value(4))
@@ -75,6 +72,16 @@ public class SurveyAcceptanceValidator {
 			.andExpect(jsonPath("$.question[3].form_type").isString())
 			.andExpect(jsonPath("$.question[3].title").value("당신이 생각하는 예진님의 직무적 약점은 무엇인가요?"))
 			.andExpect(jsonPath("$.question[3].order").value(6));
+	}
+
+	public static void assertIsTargetFound(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.target_id").isNumber(),
+			jsonPath("$.nickname").isString(),
+			jsonPath("$.position").isString()
+		);
 	}
 
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/findtarget/TargetFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/findtarget/TargetFindAcceptanceTest.java
@@ -1,0 +1,84 @@
+package me.nalab.luffy.api.acceptance.test.survey.findtarget;
+
+import static me.nalab.luffy.api.acceptance.test.survey.SurveyAcceptanceValidator.*;
+
+import java.time.Instant;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.survey.AbstractSurveyTestSupporter;
+import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+class TargetFindAcceptanceTest extends AbstractSurveyTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	private static final ObjectMapper OBJECT_MAPPER;
+
+	static {
+		OBJECT_MAPPER = new ObjectMapper();
+		OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+	}
+
+	@Test
+	@DisplayName("survey_id에 해당하는 타겟의 정보 조회")
+	void FIND_TARGET_BY_SURVEY_ID_WITH_NO_AUTHORIZATION() throws Exception {
+		// given
+		Long targetId = targetInitializer.saveTargetAndGetId("target", Instant.now());
+		String token = "token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedToken(token)
+			.expectedId(targetId)
+			.build());
+		Long surveyId = createAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+
+		// when
+		ResultActions resultActions = findTargetBySurveyId(surveyId);
+
+		// then
+		assertIsTargetFound(resultActions);
+	}
+
+	private Long createAndGetSurveyId(String token, String content) throws Exception {
+		ResultActions resultActions = createSurvey(token, content);
+		Map<String, Long> surveyIdMap = OBJECT_MAPPER.readValue(
+			resultActions.andReturn().getResponse().getContentAsString(), new TypeReference<>() {
+			});
+		return surveyIdMap.get("survey_id");
+	}
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
**질문폼에 해당하는 타겟의 정보 조회(인증X)** API에 대한 인수테스트를 작성했습니다

- [x]  find target 패키지를 추가하고, 해당 패키지에 **질문폼에 해당하는 타겟의 정보 조회** `인수테스트` 클래스를 생성했습니다
- [x] `AbstractSurveyTestSupporter` 에 요청로직을 추가했습니다 -> `findTargetBySurveyId`
- [x] `SurveyAcceptanceValidator` 에 요청로직에 대한 validation 로직을 추가했습니다 -> `assertIsTargetFound`


## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
