### PR TITLE
[feat] : `로그인된 타겟의 정보 수정` 기능 개발 완료

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/UserAcceptanceTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/UserAcceptanceTestSupporter.java
@@ -23,6 +23,16 @@ public class UserAcceptanceTestSupporter {
 		);
 	}
 
+	protected ResultActions updateTargetPosition(String token, String content) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.patch(API_VERSION + "/users")
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header(HttpHeaders.AUTHORIZATION, token)
+			.content(content)
+		);
+	}
+
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/UserAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/UserAcceptanceValidator.java
@@ -1,16 +1,21 @@
 package me.nalab.luffy.api.acceptance.test.user;
 
-import org.springframework.test.web.servlet.ResultActions;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.springframework.test.web.servlet.ResultActions;
 
 public class UserAcceptanceValidator {
 
-	public static void assertIsLogined(ResultActions resultActions, Long targetId, String nickname) throws Exception{
+	public static void assertIsLogined(ResultActions resultActions, Long targetId, String nickname) throws Exception {
 		resultActions.andExpectAll(
 			status().isOk(),
 			jsonPath("$.target_id").value(targetId),
 			jsonPath("$.nickname").value(nickname)
 		);
+	}
+
+	public static void assertIsTargetPositionUpdated(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(status().isOk());
 	}
 
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/updatetarget/TargetPositionUpdateAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/updatetarget/TargetPositionUpdateAcceptanceTest.java
@@ -1,0 +1,57 @@
+package me.nalab.luffy.api.acceptance.test.user.updatetarget;
+
+import static me.nalab.luffy.api.acceptance.test.user.UserAcceptanceValidator.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.user.UserAcceptanceTestSupporter;
+import me.nalab.luffy.api.acceptance.test.user.updatetarget.request.RequestSample;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+class TargetPositionUpdateAcceptanceTest extends UserAcceptanceTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	@Test
+	@DisplayName("로그인된 타겟의 position 수정 성공 테스트")
+	void TARGET_POSITION_UPDATE_SUCCESS_TEST() throws Exception {
+		// given
+		String nickname = "nickname";
+		Long targetId = targetInitializer.saveTargetAndGetId(nickname, Instant.now());
+		String token = "token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedToken(token)
+			.expectedId(targetId)
+			.build());
+
+		// when
+		ResultActions resultActions = updateTargetPosition(token, RequestSample.DEFAULT_JSON);
+
+		// then
+		assertIsTargetPositionUpdated(resultActions);
+	}
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/updatetarget/request/RequestSample.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/updatetarget/request/RequestSample.java
@@ -1,0 +1,32 @@
+package me.nalab.luffy.api.acceptance.test.user.updatetarget.request;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public final class RequestSample {
+
+	private static final ObjectMapper OBJECT_MAPPER;
+	public static final String DEFAULT_JSON;
+
+	static {
+		OBJECT_MAPPER = new ObjectMapper();
+		OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+		DEFAULT_JSON = loadDefaultJson();
+	}
+
+	private static String loadDefaultJson() {
+
+		try {
+			return OBJECT_MAPPER.writeValueAsString(TargetPositionUpdateRequest.builder()
+				.position("BE developer")
+				.build()
+			);
+		} catch (JsonProcessingException jpe) {
+			throw new IllegalStateException(
+				"Cannot start acceptance test fail to load \"DEFAULT_JSON\" " + jpe.getMessage());
+		}
+	}
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/updatetarget/request/TargetPositionUpdateRequest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/updatetarget/request/TargetPositionUpdateRequest.java
@@ -1,0 +1,17 @@
+package me.nalab.luffy.api.acceptance.test.user.updatetarget.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TargetPositionUpdateRequest {
+
+	@JsonProperty("position")
+	private String position;
+
+}

--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptorConfigurer.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptorConfigurer.java
@@ -25,6 +25,7 @@ public class JwtDecryptInterceptorConfigurer implements WebMvcConfigurer {
 		"/v1/reviewers/summary*",
 		"/v2/surveys/*/feedbacks",
 		"/v1/feedbacks/bookmarks",
+		"/v1/users"
 	};
 
 	@Override

--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -52,3 +52,4 @@ exclude me/nalab/core/secure/cors/CorsConfig
 exclude me/nalab/core/secure/xss/config/XssConfig
 exclude me/nalab/core/secure/xss/json/JsonXssFilterException
 exclude me/nalab/survey/web/adaptor/bookmark/BookmarkReplaceController
+exclude me/nalab/survey/web/adaptor/updatetarget/*

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/target/update/TargetPositionUpdateUseCase.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/target/update/TargetPositionUpdateUseCase.java
@@ -1,0 +1,16 @@
+package me.nalab.survey.application.port.in.web.target.update;
+
+/**
+ *
+ * targetId에 해당하는 타겟의 position을 수정합니다.
+ */
+public interface TargetPositionUpdateUseCase {
+
+	/**
+	 *
+	 * @param targetId 해당 타겟의 id
+	 * @param position 변경할 position
+	 */
+	void updateTargetPosition(Long targetId, String position);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetFindPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetFindPort.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.application.port.out.persistence.target.update;
+
+import java.util.Optional;
+
+import me.nalab.survey.domain.target.Target;
+
+public interface TargetFindPort {
+
+	/**
+	 * targetId에 해당하는 Target을 조회합니다.
+	 *
+	 * @param targetId Target을 조회할 Target의 ID
+	 * @return Optional 만약, 어떠한 targetId도 없을 경우, Optional.empty() 를 반환해야 합니다.
+	 */
+	Optional<Target> findTarget(Long targetId);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetPositionUpdatePort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetPositionUpdatePort.java
@@ -10,9 +10,11 @@ import me.nalab.survey.domain.target.Target;
 public interface TargetPositionUpdatePort {
 
 	/**
+	 *
 	 * 이 메서드는 target의 position을 업데이트 합니다
 	 * @param target 업데이트할 target
+	 * @return
 	 */
-	void updateTargetPosition(Target target);
+	boolean updateTargetPosition(Target target);
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetPositionUpdatePort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/target/update/TargetPositionUpdatePort.java
@@ -1,0 +1,18 @@
+package me.nalab.survey.application.port.out.persistence.target.update;
+
+import me.nalab.survey.domain.target.Target;
+
+/**
+ * Target의 position 필드를 변경하는 역할을 하는 인터페이스
+ *
+ * 이 인터페이스의 구현체는 target의 position을 업데이트 합니다
+ */
+public interface TargetPositionUpdatePort {
+
+	/**
+	 * 이 메서드는 target의 position을 업데이트 합니다
+	 * @param target 업데이트할 target
+	 */
+	void updateTargetPosition(Target target);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateService.java
@@ -1,0 +1,30 @@
+package me.nalab.survey.application.service.updatetarget;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.exception.TargetDoesNotExistException;
+import me.nalab.survey.application.port.in.web.target.update.TargetPositionUpdateUseCase;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetFindPort;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetPositionUpdatePort;
+import me.nalab.survey.domain.target.Target;
+
+@Service
+@RequiredArgsConstructor
+public class TargetPositionUpdateService implements TargetPositionUpdateUseCase {
+
+	private final TargetFindPort targetFindPort;
+	private final TargetPositionUpdatePort targetPositionUpdatePort;
+
+	@Override
+	@Transactional
+	public void updateTargetPosition(Long targetId, String position) {
+		Target target = targetFindPort.findTarget(targetId).orElseThrow(
+			() -> new TargetDoesNotExistException(targetId)
+		);
+		target.setPosition(position);
+		targetPositionUpdatePort.updateTargetPosition(target);
+	}
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateService.java
@@ -24,7 +24,11 @@ public class TargetPositionUpdateService implements TargetPositionUpdateUseCase 
 			() -> new TargetDoesNotExistException(targetId)
 		);
 		target.setPosition(position);
-		targetPositionUpdatePort.updateTargetPosition(target);
+
+		boolean updatedResult = targetPositionUpdatePort.updateTargetPosition(target);
+		if (!updatedResult) {
+			throw new TargetDoesNotExistException(target.getId());
+		}
 	}
 
 }

--- a/survey/survey-application/src/main/java/module-info.java
+++ b/survey/survey-application/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.out.persistence.bookmark;
 	exports me.nalab.survey.application.port.in.web.bookmark;
 	exports me.nalab.survey.application.port.out.persistence.target.update;
+	exports me.nalab.survey.application.port.in.web.target.update;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/survey-application/src/main/java/module-info.java
+++ b/survey/survey-application/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.service.authorization;
 	exports me.nalab.survey.application.port.out.persistence.bookmark;
 	exports me.nalab.survey.application.port.in.web.bookmark;
+	exports me.nalab.survey.application.port.out.persistence.target.update;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateServiceTest.java
@@ -1,0 +1,70 @@
+package me.nalab.survey.application.service.updatetarget;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.survey.application.exception.TargetDoesNotExistException;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetFindPort;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetPositionUpdatePort;
+import me.nalab.survey.domain.target.Target;
+
+@ExtendWith(SpringExtension.class)
+class TargetPositionUpdateServiceTest {
+
+	private TargetPositionUpdateService targetPositionUpdateService;
+
+	@Mock
+	private TargetFindPort targetFindPort;
+
+	@Mock
+	private TargetPositionUpdatePort targetPositionUpdatePort;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		targetPositionUpdateService = new TargetPositionUpdateService(targetFindPort, targetPositionUpdatePort);
+	}
+
+	@Test
+	void UPDATE_TARGET_POSITION_SERVICE_SUCCESS_TEST() {
+
+		Long targetId = 123L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+
+		assertDoesNotThrow(() -> targetPositionUpdateService.updateTargetPosition(targetId, target.getPosition()));
+
+	}
+
+	@Test
+	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST() {
+
+		Long targetId = 123L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+		String position = target.getPosition();
+
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.empty());
+
+		assertThrows(TargetDoesNotExistException.class,
+			() -> targetPositionUpdateService.updateTargetPosition(targetId, position)
+		);
+
+	}
+
+}

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/updatetarget/TargetPositionUpdateServiceTest.java
@@ -44,13 +44,33 @@ class TargetPositionUpdateServiceTest {
 			.build();
 
 		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+		when(targetPositionUpdatePort.updateTargetPosition(target)).thenReturn(true);
 
 		assertDoesNotThrow(() -> targetPositionUpdateService.updateTargetPosition(targetId, target.getPosition()));
 
 	}
 
 	@Test
-	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST() {
+	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST_CASE_1() {
+
+		Long targetId = 123L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+		String position = target.getPosition();
+
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+		when(targetPositionUpdatePort.updateTargetPosition(target)).thenReturn(false);
+
+		assertThrows(TargetDoesNotExistException.class,
+			() -> targetPositionUpdateService.updateTargetPosition(targetId, position)
+		);
+
+	}
+
+	@Test
+	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST_CASE_2() {
 
 		Long targetId = 123L;
 		Target target = Target.builder()
@@ -60,6 +80,26 @@ class TargetPositionUpdateServiceTest {
 		String position = target.getPosition();
 
 		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.empty());
+		when(targetPositionUpdatePort.updateTargetPosition(target)).thenReturn(true);
+
+		assertThrows(TargetDoesNotExistException.class,
+			() -> targetPositionUpdateService.updateTargetPosition(targetId, position)
+		);
+
+	}
+
+	@Test
+	void UPDATE_TARGET_POSITION_SERVICE_FAIL_TEST_CASE_3() {
+
+		Long targetId = 123L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+		String position = target.getPosition();
+
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.empty());
+		when(targetPositionUpdatePort.updateTargetPosition(target)).thenReturn(false);
 
 		assertThrows(TargetDoesNotExistException.class,
 			() -> targetPositionUpdateService.updateTargetPosition(targetId, position)

--- a/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -20,14 +20,17 @@ public class Target implements IdGeneratable {
 	private Long id;
 	private final List<Survey> surveyList;
 	private final String nickname;
-	private final String position;
+	private String position;
 
 	@Override
 	public void withId(LongSupplier idSupplier) {
-		if(id != null) {
+		if (id != null) {
 			throw new IdAlreadyGeneratedException(this);
 		}
 		id = idSupplier.getAsLong();
 	}
 
+	public void setPosition(String position) {
+		this.position = position;
+	}
 }

--- a/survey/survey-domain/src/test/java/me/nalab/survey/domain/target/TargetDomainTest.java
+++ b/survey/survey-domain/src/test/java/me/nalab/survey/domain/target/TargetDomainTest.java
@@ -1,9 +1,6 @@
 package me.nalab.survey.domain.target;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.function.Function;
@@ -86,6 +83,22 @@ class TargetDomainTest extends AbstractTargetSources {
 
 		// then
 		assertThrows(IdAlreadyGeneratedException.class, () -> target.withId(longSupplier));
+	}
+
+	@Test
+	@DisplayName("Target position 수정 테스트")
+	void TARGET_POSITION_UPDATE_TEST() {
+
+		Target target = Target.builder()
+			.nickname("target")
+			.position("designer")
+			.build();
+		String newPosition = "developer";
+
+		target.setPosition(newPosition);
+
+		assertEquals(newPosition, target.getPosition());
+
 	}
 
 }

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetFindAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetFindAdaptor.java
@@ -1,0 +1,35 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetFindPort;
+import me.nalab.survey.domain.target.Target;
+import me.nalab.survey.jpa.adaptor.common.mapper.TargetEntityMapper;
+import me.nalab.survey.jpa.adaptor.updatetarget.repository.TargetFindRepository;
+
+@Repository("updatetarget.TargetFindAdaptor")
+public class TargetFindAdaptor implements TargetFindPort {
+
+	private final TargetFindRepository targetFindRepository;
+
+	@Autowired
+	TargetFindAdaptor(
+		@Qualifier("updatetarget.TargetFindRepository") TargetFindRepository targetFindRepository) {
+		this.targetFindRepository = targetFindRepository;
+	}
+
+	@Override
+	public Optional<Target> findTarget(Long targetId) {
+		Optional<TargetEntity> targetEntity = targetFindRepository.findById(targetId);
+		if (targetEntity.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(TargetEntityMapper.toTarget(targetEntity.get()));
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptor.java
@@ -1,0 +1,35 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.application.port.out.persistence.target.update.TargetPositionUpdatePort;
+import me.nalab.survey.domain.target.Target;
+import me.nalab.survey.jpa.adaptor.updatetarget.repository.TargetPositionUpdateRepository;
+
+@Repository("updatetarget.TargetPositionUpdateAdaptor")
+public class TargetPositionUpdateAdaptor implements TargetPositionUpdatePort {
+
+	private final TargetPositionUpdateRepository targetPositionUpdateRepository;
+
+	@Autowired
+	TargetPositionUpdateAdaptor(
+		@Qualifier("updatetarget.TargetPositionUpdateRepository") TargetPositionUpdateRepository targetPositionUpdateRepository) {
+		this.targetPositionUpdateRepository = targetPositionUpdateRepository;
+	}
+
+	@Override
+	public boolean updateTargetPosition(Target target) {
+		Optional<TargetEntity> targetEntity = targetPositionUpdateRepository.findById(target.getId());
+		if (targetEntity.isEmpty()) {
+			return false;
+		}
+		targetEntity.get().setPosition(target.getPosition());
+		return true;
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/repository/TargetFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/repository/TargetFindRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.updatetarget.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+@Repository("updatetarget.TargetFindRepository")
+public interface TargetFindRepository extends JpaRepository<TargetEntity, Long> {
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/repository/TargetPositionUpdateRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/updatetarget/repository/TargetPositionUpdateRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.updatetarget.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+@Repository("updatetarget.TargetPositionUpdateRepository")
+public interface TargetPositionUpdateRepository extends JpaRepository<TargetEntity, Long> {
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetFindAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetFindAdaptorTest.java
@@ -1,0 +1,69 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.target.Target;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = TargetFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class TargetFindAdaptorTest {
+
+	@Autowired
+	private TargetFindAdaptor targetFindAdaptor;
+
+	@Autowired
+	private TestTargetFindRepository testTargetFindRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("타겟 조회 성공 테스트")
+	void FIND_TARGET_BY_ID_SUCCESS() {
+
+		Long targetId = 1L;
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(targetId)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("sujin")
+			.build();
+
+		testTargetFindRepository.saveAndFlush(targetEntity);
+		entityManager.clear();
+		Optional<Target> resultTarget = targetFindAdaptor.findTarget(targetId);
+
+		assertTrue(resultTarget.isPresent());
+		assertEquals(targetEntity.getId(), resultTarget.get().getId());
+	}
+
+	@Test
+	@DisplayName("타겟 조회 실패 테스트")
+	void FIND_TARGET_BY_ID_FAIL() {
+
+		Long targetId = 1L;
+
+		Optional<Target> target = targetFindAdaptor.findTarget(targetId);
+
+		assertTrue(target.isEmpty());
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TargetPositionUpdateAdaptorTest.java
@@ -1,0 +1,88 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.target.Target;
+import me.nalab.survey.jpa.adaptor.common.mapper.TargetEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = TargetPositionUpdateAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class TargetPositionUpdateAdaptorTest {
+
+	@Autowired
+	private TargetPositionUpdateAdaptor targetPositionUpdateAdaptor;
+
+	@Autowired
+	private TestTargetPositionUpdateRepository testTargetPositionUpdateRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("타겟 position 수정 성공 테스트")
+	void UPDATE_TARGET_POSITION_SUCCESS() {
+
+		Long targetId = 1L;
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(targetId)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("sujin")
+			.position("designer")
+			.build();
+		Target target = TargetEntityMapper.toTarget(targetEntity);
+		testTargetPositionUpdateRepository.saveAndFlush(targetEntity);
+		entityManager.clear();
+
+		String updatePosition = "developer";
+		target.setPosition(updatePosition);
+		boolean updatedResult = targetPositionUpdateAdaptor.updateTargetPosition(target);
+		Optional<TargetEntity> resultTargetEntity = testTargetPositionUpdateRepository.findById(targetId);
+
+		assertTrue(updatedResult);
+		assertTrue(resultTargetEntity.isPresent());
+		assertEquals(updatePosition, resultTargetEntity.get().getPosition());
+
+	}
+
+	@Test
+	@DisplayName("타겟 position 수정 실패 테스트")
+	void UPDATE_TARGET_POSITION_FAIL() {
+
+		Long targetId = 1L;
+		TargetEntity targetEntity = TargetEntity.builder()
+			.id(targetId)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("sujin")
+			.position("designer")
+			.build();
+		Target target = TargetEntityMapper.toTarget(targetEntity);
+
+		String updatePosition = "developer";
+		target.setPosition(updatePosition);
+		boolean updatedResult = targetPositionUpdateAdaptor.updateTargetPosition(target);
+
+		assertFalse(updatedResult);
+
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TestTargetFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TestTargetFindRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+@Repository("updatetarget.TestTargetFindRepository")
+public interface TestTargetFindRepository extends JpaRepository<TargetEntity, Long> {
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TestTargetPositionUpdateRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/updatetarget/TestTargetPositionUpdateRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.updatetarget;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+@Repository("updatetarget.TestTargetPositionUpdateRepository")
+public interface TestTargetPositionUpdateRepository extends JpaRepository<TargetEntity, Long> {
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/updatetarget/TargetPositionUpdateController.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/updatetarget/TargetPositionUpdateController.java
@@ -1,0 +1,30 @@
+package me.nalab.survey.web.adaptor.updatetarget;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.port.in.web.target.update.TargetPositionUpdateUseCase;
+import me.nalab.survey.web.adaptor.updatetarget.request.TargetPositionUpdateRequest;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class TargetPositionUpdateController {
+
+	private final TargetPositionUpdateUseCase targetPositionUpdateUseCase;
+
+	@PatchMapping("/users")
+	public ResponseEntity<Void> updateTargetPosition(@RequestAttribute("logined") Long loginId,
+		@Valid @RequestBody TargetPositionUpdateRequest targetPositionUpdateRequest) {
+		targetPositionUpdateUseCase.updateTargetPosition(loginId, targetPositionUpdateRequest.getPosition());
+		return ResponseEntity.ok().build();
+	}
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/updatetarget/request/TargetPositionUpdateRequest.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/updatetarget/request/TargetPositionUpdateRequest.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.web.adaptor.updatetarget.request;
+
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class TargetPositionUpdateRequest {
+
+	@JsonProperty("position")
+	@Size(max = 16, message = "직군은 공백포함 최대 16자까지 입력가능합니다.")
+	private String position;
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`로그인된 타겟의 정보 수정` 기능 개발을 완료했습니다

- [x] #318 
- [x] #319 
- [x] #320 
- [x] #321 

## 어떻게 해결했나요?


## 이슈 넘버
- closes #317 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
