### PR TITLE
[feat] : 질문폼에 해당하는 타겟의 정보 조회 - `application` 추가

### DIFF
--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/findtarget/TargetFindBySurveyIdUseCase.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/findtarget/TargetFindBySurveyIdUseCase.java
@@ -1,0 +1,18 @@
+package me.nalab.survey.application.port.in.web.findtarget;
+
+import me.nalab.survey.application.common.survey.dto.TargetDto;
+
+/**
+ * SurveyID를 이용해 Target을 조회하는 Usecase
+ * 이 인터페이스를 이용해서 Target을 조회할 수 있음
+ */
+public interface TargetFindBySurveyIdUseCase {
+
+	/**
+	 *
+	 * @param surveyId 질문폼의 id
+	 * @return 질문폼에 해당하는 타겟을 TargetDto 형식으로 반환해서 가져옴
+	 */
+	TargetDto findTargetBySurveyId(Long surveyId);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findtarget/TargetFindPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findtarget/TargetFindPort.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.application.port.out.persistence.findtarget;
+
+import java.util.Optional;
+
+import me.nalab.survey.domain.target.Target;
+
+/**
+ * targetId를 받아 Target을 반환하는 인터페이스입니다.
+ */
+public interface TargetFindPort {
+
+	/**
+	 * targetId에 해당하는 Target을 조회합니다
+	 *
+	 * @param targetId 조회할 Target의 ID
+	 * @return Optional 만약, 어떠한 targetId도 없을 경우, Optional.empty() 를 반환해야 합니다
+	 */
+	Optional<Target> findTarget(Long targetId);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findtarget/TargetFindPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findtarget/TargetFindPort.java
@@ -15,6 +15,6 @@ public interface TargetFindPort {
 	 * @param targetId 조회할 Target의 ID
 	 * @return Optional 만약, 어떠한 targetId도 없을 경우, Optional.empty() 를 반환해야 합니다
 	 */
-	Optional<Target> findTarget(Long targetId);
+	Optional<Target> findTargetById(Long targetId);
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findtarget/TargetIdFindPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findtarget/TargetIdFindPort.java
@@ -1,0 +1,17 @@
+package me.nalab.survey.application.port.out.persistence.findtarget;
+
+import java.util.Optional;
+
+/**
+ * surveyId를 받아 survey에 해당하는 target의 id를 반환하는 인터페이스입니다.
+ */
+public interface TargetIdFindPort {
+
+	/**
+	 *
+	 * @param surveyId survey를 조회할 survey의 ID
+	 * @return Optional 만약, 어떠한 targetId도 없을 경우, Optional.empty()
+	 */
+	Optional<Long> findTargetIdBySurveyId(Long surveyId);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/findtarget/TargetFindBySurveyIdService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/findtarget/TargetFindBySurveyIdService.java
@@ -1,0 +1,35 @@
+package me.nalab.survey.application.service.findtarget;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.common.survey.dto.TargetDto;
+import me.nalab.survey.application.common.survey.mapper.TargetDtoMapper;
+import me.nalab.survey.application.exception.SurveyDoesNotHasTargetException;
+import me.nalab.survey.application.exception.TargetDoesNotExistException;
+import me.nalab.survey.application.port.in.web.findtarget.TargetFindBySurveyIdUseCase;
+import me.nalab.survey.application.port.out.persistence.findtarget.TargetFindPort;
+import me.nalab.survey.application.port.out.persistence.findtarget.TargetIdFindPort;
+import me.nalab.survey.domain.target.Target;
+
+@Service
+@RequiredArgsConstructor
+public class TargetFindBySurveyIdService implements TargetFindBySurveyIdUseCase {
+
+	private final TargetFindPort targetFindPort;
+	private final TargetIdFindPort targetIdFindPort;
+
+	@Override
+	@Transactional
+	public TargetDto findTargetBySurveyId(Long surveyId) {
+		Long targetId = targetIdFindPort.findTargetIdBySurveyId(surveyId).orElseThrow(() -> {
+			throw new SurveyDoesNotHasTargetException(surveyId);
+		});
+		Target target = targetFindPort.findTarget(targetId).orElseThrow(() -> {
+			throw new TargetDoesNotExistException(targetId);
+		});
+		return TargetDtoMapper.toTargetDto(target);
+	}
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/findtarget/TargetFindBySurveyIdService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/findtarget/TargetFindBySurveyIdService.java
@@ -26,7 +26,7 @@ public class TargetFindBySurveyIdService implements TargetFindBySurveyIdUseCase 
 		Long targetId = targetIdFindPort.findTargetIdBySurveyId(surveyId).orElseThrow(() -> {
 			throw new SurveyDoesNotHasTargetException(surveyId);
 		});
-		Target target = targetFindPort.findTarget(targetId).orElseThrow(() -> {
+		Target target = targetFindPort.findTargetById(targetId).orElseThrow(() -> {
 			throw new TargetDoesNotExistException(targetId);
 		});
 		return TargetDtoMapper.toTargetDto(target);

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/findtarget/TargetFindBySurveyIdServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/findtarget/TargetFindBySurveyIdServiceTest.java
@@ -1,0 +1,93 @@
+package me.nalab.survey.application.service.findtarget;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.survey.application.common.survey.dto.TargetDto;
+import me.nalab.survey.application.common.survey.mapper.TargetDtoMapper;
+import me.nalab.survey.application.exception.SurveyDoesNotHasTargetException;
+import me.nalab.survey.application.exception.TargetDoesNotExistException;
+import me.nalab.survey.application.port.out.persistence.findtarget.TargetFindPort;
+import me.nalab.survey.application.port.out.persistence.findtarget.TargetIdFindPort;
+import me.nalab.survey.domain.target.Target;
+
+@ExtendWith(SpringExtension.class)
+class TargetFindBySurveyIdServiceTest {
+
+	private TargetFindBySurveyIdService targetFindBySurveyIdService;
+
+	@Mock
+	private TargetIdFindPort targetIdFindPort;
+
+	@Mock
+	private TargetFindPort targetFindPort;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		targetFindBySurveyIdService = new TargetFindBySurveyIdService(targetFindPort, targetIdFindPort);
+	}
+
+	@Test
+	void FIND_TARGET_BY_SURVEY_ID_SUCCESS_TEST() {
+
+		Long targetId = 123L;
+		Long surveyId = 12L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+
+		when(targetIdFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.of(targetId));
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+		TargetDto targetDto = targetFindBySurveyIdService.findTargetBySurveyId(surveyId);
+
+		assertEquals(TargetDtoMapper.toTarget(targetDto), target);
+	}
+
+	@Test
+	void FIND_TARGET_BY_SURVEY_ID_FAILED_TEST_WITH_NO_TARGET_ID() {
+
+		Long targetId = 123L;
+		Long surveyId = 12L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+
+		when(targetIdFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.empty());
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+
+		assertThrows(SurveyDoesNotHasTargetException.class,
+			() -> targetFindBySurveyIdService.findTargetBySurveyId(surveyId));
+
+	}
+
+	@Test
+	void FIND_TARGET_BY_SURVEY_ID_FAILED_TEST_WITH_NO_TARGET() {
+
+		Long targetId = 123L;
+		Long surveyId = 12L;
+		Target target = Target.builder()
+			.id(targetId)
+			.nickname("sujin")
+			.build();
+
+		when(targetIdFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.of(targetId));
+		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.empty());
+
+		assertThrows(TargetDoesNotExistException.class,
+			() -> targetFindBySurveyIdService.findTargetBySurveyId(surveyId));
+
+	}
+
+}

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/findtarget/TargetFindBySurveyIdServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/findtarget/TargetFindBySurveyIdServiceTest.java
@@ -48,7 +48,7 @@ class TargetFindBySurveyIdServiceTest {
 			.build();
 
 		when(targetIdFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.of(targetId));
-		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+		when(targetFindPort.findTargetById(targetId)).thenReturn(Optional.of(target));
 		TargetDto targetDto = targetFindBySurveyIdService.findTargetBySurveyId(surveyId);
 
 		assertEquals(TargetDtoMapper.toTarget(targetDto), target);
@@ -65,7 +65,7 @@ class TargetFindBySurveyIdServiceTest {
 			.build();
 
 		when(targetIdFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.empty());
-		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.of(target));
+		when(targetFindPort.findTargetById(targetId)).thenReturn(Optional.of(target));
 
 		assertThrows(SurveyDoesNotHasTargetException.class,
 			() -> targetFindBySurveyIdService.findTargetBySurveyId(surveyId));
@@ -83,7 +83,7 @@ class TargetFindBySurveyIdServiceTest {
 			.build();
 
 		when(targetIdFindPort.findTargetIdBySurveyId(surveyId)).thenReturn(Optional.of(targetId));
-		when(targetFindPort.findTarget(targetId)).thenReturn(Optional.empty());
+		when(targetFindPort.findTargetById(targetId)).thenReturn(Optional.empty());
 
 		assertThrows(TargetDoesNotExistException.class,
 			() -> targetFindBySurveyIdService.findTargetBySurveyId(surveyId));


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?

`질문폼에 해당하는 타겟의 정보 조회(인증X)` API에 대한 application 부분을 개발 완료했습니다

- [x] in port 에서 **질문폼에 해당하는 타겟의 정보 조회** 유즈케이스의 interface인 `TargetFindBySurveyIdUseCase` 정의하고, 이의 구현체 를 만들었습니다
- [x] out persistence 에서 port 인터페이스를 정의하였습니다 - `TargetFindPort,` `TargetIdFindPort`
- [x] 그리고 서비스 테스트를 추가하였습니다 - 테스트는 예외 케이스까지 모두 검증하였습니다


## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
