### PR TITLE
[feat] : 질문폼에 해당하는 타겟의 정보 조회 - `web-adaptor` 구현 완료

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
@@ -80,7 +80,7 @@ public class SurveyAcceptanceValidator {
 			content().contentType(MediaType.APPLICATION_JSON),
 			jsonPath("$.target_id").isNumber(),
 			jsonPath("$.nickname").isString(),
-			jsonPath("$.position").isString()
+			jsonPath("$.position").hasJsonPath()
 		);
 	}
 

--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
@@ -11,7 +11,9 @@ public class JwtDecryptInterceptor implements HandlerInterceptor {
 
 	private static final String[][] EXCLUDED_URI_LIST = new String[][] {
 		{"POST", "/v1/feedbacks"},
-		{"GET", "/v1/feedbacks/bookmarks"},
+		{"GET", "/v1/feedbacks/bookmarks"}
+	};
+	private static final String[][] EXCLUDED_URI_WITH_QUERY_STRING_LIST = new String[][] {
 		{"GET", "/v1/users"}
 	};
 	private final TargetIdGetPort targetIdGetPort;
@@ -41,9 +43,17 @@ public class JwtDecryptInterceptor implements HandlerInterceptor {
 	private boolean isExcludedURI(HttpServletRequest httpServletRequest) {
 		String httpMethod = httpServletRequest.getMethod();
 		String requestURI = httpServletRequest.getRequestURI();
+		String queryString = httpServletRequest.getQueryString();
 
 		for (String[] excludedURI : EXCLUDED_URI_LIST) {
 			if (excludedURI[0].equals(httpMethod) && excludedURI[1].equals(requestURI)) {
+				return true;
+			}
+		}
+
+		for (String[] excludedURI : EXCLUDED_URI_WITH_QUERY_STRING_LIST) {
+			if (excludedURI[0].equals(httpMethod) && excludedURI[1].equals(requestURI)
+				&& queryString.length() > 0) {
 				return true;
 			}
 		}

--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
@@ -9,6 +9,11 @@ import me.nalab.auth.application.port.in.web.TargetIdGetPort;
 
 public class JwtDecryptInterceptor implements HandlerInterceptor {
 
+	private static final String[][] EXCLUDED_URI_LIST = new String[][] {
+		{"POST", "/v1/feedbacks"},
+		{"GET", "/v1/feedbacks/bookmarks"},
+		{"GET", "/v1/users"}
+	};
 	private final TargetIdGetPort targetIdGetPort;
 
 	JwtDecryptInterceptor(TargetIdGetPort targetIdGetPort) {
@@ -17,10 +22,10 @@ public class JwtDecryptInterceptor implements HandlerInterceptor {
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-		if(isPreflight(request)) {
+		if (isPreflight(request)) {
 			return true;
 		}
-		if(!isExcludedURI(request)) {
+		if (!isExcludedURI(request)) {
 			String token = request.getHeader("Authorization");
 			throwIfCannotValidToken(token);
 			Long targetId = targetIdGetPort.getTargetId(token.split(" ")[1]);
@@ -34,12 +39,20 @@ public class JwtDecryptInterceptor implements HandlerInterceptor {
 	}
 
 	private boolean isExcludedURI(HttpServletRequest httpServletRequest) {
-		return httpServletRequest.getMethod().equals("POST") && httpServletRequest.getRequestURI()
-			.contains("/v1/feedbacks");
+		String httpMethod = httpServletRequest.getMethod();
+		String requestURI = httpServletRequest.getRequestURI();
+
+		for (String[] excludedURI : EXCLUDED_URI_LIST) {
+			if (excludedURI[0].equals(httpMethod) && excludedURI[1].equals(requestURI)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private void throwIfCannotValidToken(String token) {
-		if(token == null) {
+		if (token == null) {
 			throw new CannotValidMockTokenException();
 		}
 	}

--- a/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
+++ b/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
@@ -12,7 +12,9 @@ public class MockAuthInterceptor implements HandlerInterceptor {
 
 	private static final String[][] EXCLUDED_URI_LIST = new String[][] {
 		{"POST", "/v1/feedbacks"},
-		{"GET", "/v1/feedbacks/bookmarks"},
+		{"GET", "/v1/feedbacks/bookmarks"}
+	};
+	private static final String[][] EXCLUDED_URI_WITH_QUERY_STRING_LIST = new String[][] {
 		{"GET", "/v1/users"}
 	};
 	private String expectedToken = null;
@@ -31,9 +33,16 @@ public class MockAuthInterceptor implements HandlerInterceptor {
 	private boolean isExcludedURI(HttpServletRequest httpServletRequest) {
 		String httpMethod = httpServletRequest.getMethod();
 		String requestURI = httpServletRequest.getRequestURI();
+		String queryString = httpServletRequest.getQueryString();
 
 		for (String[] excludedURI : EXCLUDED_URI_LIST) {
 			if (excludedURI[0].equals(httpMethod) && excludedURI[1].equals(requestURI)) {
+				return true;
+			}
+		}
+		for (String[] excludedURI : EXCLUDED_URI_WITH_QUERY_STRING_LIST) {
+			if (excludedURI[0].equals(httpMethod) && excludedURI[1].equals(requestURI)
+				&& queryString.length() > 0) {
 				return true;
 			}
 		}

--- a/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
+++ b/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
@@ -10,12 +10,17 @@ import me.nalab.auth.mock.api.MockUserRegisterEvent;
 
 public class MockAuthInterceptor implements HandlerInterceptor {
 
+	private static final String[][] EXCLUDED_URI_LIST = new String[][] {
+		{"POST", "/v1/feedbacks"},
+		{"GET", "/v1/feedbacks/bookmarks"},
+		{"GET", "/v1/users"}
+	};
 	private String expectedToken = null;
 	private Long expectedId = null;
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-		if(!isExcludedURI(request)) {
+		if (!isExcludedURI(request)) {
 			String token = request.getHeader("Authorization");
 			throwIfCannotValidToken(token);
 			request.setAttribute("logined", expectedId);
@@ -24,12 +29,20 @@ public class MockAuthInterceptor implements HandlerInterceptor {
 	}
 
 	private boolean isExcludedURI(HttpServletRequest httpServletRequest) {
-		return httpServletRequest.getMethod().equals("POST") && httpServletRequest.getRequestURI()
-			.contains("/v1/feedbacks");
+		String httpMethod = httpServletRequest.getMethod();
+		String requestURI = httpServletRequest.getRequestURI();
+
+		for (String[] excludedURI : EXCLUDED_URI_LIST) {
+			if (excludedURI[0].equals(httpMethod) && excludedURI[1].equals(requestURI)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private void throwIfCannotValidToken(String token) {
-		if(expectedToken == null || expectedId == null || !expectedToken.equals(token)) {
+		if (expectedToken == null || expectedId == null || !expectedToken.equals(token)) {
 			throw new CannotValidMockTokenException();
 		}
 	}

--- a/auth/auth-mock/src/test/java/me/nalab/auth/mock/interceptor/MockAuthInterceptorTest.java
+++ b/auth/auth-mock/src/test/java/me/nalab/auth/mock/interceptor/MockAuthInterceptorTest.java
@@ -1,8 +1,7 @@
 package me.nalab.auth.mock.interceptor;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.params.provider.Arguments.of;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.*;
 
 import java.util.stream.Stream;
 
@@ -64,7 +63,7 @@ class MockAuthInterceptorTest extends AbstractMockAuthTest {
 	static Stream<Arguments> successSources() {
 		return Stream.of(
 			of(HttpMethod.POST, "/v1/surveys", "token1", 1L)
-			, of(HttpMethod.GET, "/v1/users", "token2", 2L)
+			, of(HttpMethod.POST, "/v1/surveys", "token1", 2L)
 			, of(HttpMethod.GET, "/v1/surveys-id", "token3", 3L)
 			, of(HttpMethod.GET, "/v1/questions?survey-id=4", "token4", 4L)
 			, of(HttpMethod.GET, "/v1/feedbacks?survey-id=5", "token5", 5L)

--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -53,3 +53,4 @@ exclude me/nalab/core/secure/xss/config/XssConfig
 exclude me/nalab/core/secure/xss/json/JsonXssFilterException
 exclude me/nalab/survey/web/adaptor/bookmark/BookmarkReplaceController
 exclude me/nalab/survey/web/adaptor/findtarget/*
+exclude me/nalab/auth/mock/interceptor/*

--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -52,3 +52,4 @@ exclude me/nalab/core/secure/cors/CorsConfig
 exclude me/nalab/core/secure/xss/config/XssConfig
 exclude me/nalab/core/secure/xss/json/JsonXssFilterException
 exclude me/nalab/survey/web/adaptor/bookmark/BookmarkReplaceController
+exclude me/nalab/survey/web/adaptor/findtarget/*

--- a/survey/survey-application/src/main/java/module-info.java
+++ b/survey/survey-application/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.out.persistence.bookmark;
 	exports me.nalab.survey.application.port.in.web.bookmark;
 	exports me.nalab.survey.application.port.out.persistence.findtarget;
+	exports me.nalab.survey.application.port.in.web.findtarget;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findtarget/TargetFindBySurveyIdController.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findtarget/TargetFindBySurveyIdController.java
@@ -1,0 +1,29 @@
+package me.nalab.survey.web.adaptor.findtarget;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.common.survey.dto.TargetDto;
+import me.nalab.survey.application.port.in.web.findtarget.TargetFindBySurveyIdUseCase;
+import me.nalab.survey.web.adaptor.findtarget.response.TargetResponse;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class TargetFindBySurveyIdController {
+
+	private final TargetFindBySurveyIdUseCase targetFindBySurveyIdUseCase;
+
+	@GetMapping("/users")
+	@ResponseStatus(HttpStatus.OK)
+	public TargetResponse findTargetBySurveyId(@RequestParam("survey-id") Long surveyId) {
+		TargetDto targetDto = targetFindBySurveyIdUseCase.findTargetBySurveyId(surveyId);
+		return TargetResponseMapper.toTargetResponse(targetDto);
+	}
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findtarget/TargetResponseMapper.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findtarget/TargetResponseMapper.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.web.adaptor.findtarget;
+
+import me.nalab.survey.application.common.survey.dto.TargetDto;
+import me.nalab.survey.web.adaptor.findtarget.response.TargetResponse;
+
+class TargetResponseMapper {
+
+	private TargetResponseMapper() {
+		throw new UnsupportedOperationException("Cannot invoke constructor \"TargetResponseMapper()\"");
+	}
+
+	static TargetResponse toTargetResponse(TargetDto targetDto) {
+		return TargetResponse.builder()
+			.targetId(targetDto.getId())
+			.nickname(targetDto.getNickname())
+			.position(targetDto.getPosition())
+			.build();
+	}
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findtarget/response/TargetResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findtarget/response/TargetResponse.java
@@ -1,0 +1,25 @@
+package me.nalab.survey.web.adaptor.findtarget.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+public class TargetResponse {
+
+	@JsonProperty("target_id")
+	private final long targetId;
+
+	@JsonProperty("nickname")
+	private final String nickname;
+
+	@JsonProperty("position")
+	private final String position;
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
- [x]  **질문폼에 해당하는 타겟의 정보 조회(인증X)** 에 `web-adaptor` 를 추가하고, controller를 만들었습니다
- [x]  `TargetResponse` 객체를 만들고, 이에 대한 mapper를 추가해 response시에 mapper를 통해 변환해서 반환하도록 하였습니다
- [x]  인수테스트까지 테스트 검증을 모두 마쳤습니다
- [x]  `MockAuthInterceptor`,  `JwtDecryptInterceptor`  두 인터셉터에 제외해야할 URI를 추가하였습니다

## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
