### PR TITLE
[feat] : 질문폼의 타입에 해당하는 피드백 조회 - `인수테스트` 작성

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
@@ -87,6 +87,15 @@ public abstract class AbstractFeedbackTestSupporter extends AbstractSurveyTestSu
 		);
 	}
 
+	protected ResultActions findFeedbackByType(Long surveyId, String formType) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.get("/v1/feedbacks?survey-id" + surveyId)
+			.queryParam("form-type", formType)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+	}
+
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -130,4 +130,21 @@ public final class FeedbackAcceptanceValidator {
 		resultActions.andExpectAll(status().isOk());
 	}
 
+	public static void assertIsFeedbackFoundByType(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+
+			jsonPath("$.question_feedback").isArray(),
+			jsonPath("$.question_feedback").isNotEmpty(),
+
+			jsonPath("$.question_feedback.[0].question_id").isString(),
+			jsonPath("$.question_feedback.[0].order").isNumber(),
+			jsonPath("$.question_feedback.[0].type").isString(),
+			jsonPath("$.question_feedback.[0].form_type").value("tendency"),
+			jsonPath("$.question_feedback.[0].title").isString(),
+			jsonPath("$.question_feedback.[0].choices").isArray()
+		);
+	}
+
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindByTypeAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindByTypeAcceptanceTest.java
@@ -1,0 +1,164 @@
+package me.nalab.luffy.api.acceptance.test.feedback.find;
+
+import static me.nalab.luffy.api.acceptance.test.feedback.FeedbackAcceptanceValidator.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.feedback.AbstractFeedbackTestSupporter;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.AbstractQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ChoiceQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.FeedbackCreateRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ReviewerRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.request.ShortQuestionFeedbackRequest;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.ChoiceFormQuestionResponse;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.ShortFormQuestionResponse;
+import me.nalab.luffy.api.acceptance.test.feedback.create.response.SurveyFindResponse;
+import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+public class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	private static final ObjectMapper OBJECT_MAPPER;
+
+	static {
+		OBJECT_MAPPER = new ObjectMapper();
+		OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+	}
+
+	@Test
+	@DisplayName("타입에 해당하는 피드백 조회 성공 인수테스트 - 피드백이 있을때")
+	void FIND_FEEDBACK_BY_TYPE_SUCCESS_TEST() throws Exception {
+		// given
+		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
+		String token = "mock token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedId(targetId)
+			.expectedToken(token)
+			.build());
+		Long surveyId = createAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+		SurveyFindResponse surveyFindResponse = getSurveyFindResponse(surveyId);
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "developer");
+		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
+
+		// when
+		ResultActions resultActions = findFeedbackByType(surveyId, "tendency");
+
+		// then
+		assertIsFeedbackFoundByType(resultActions);
+
+	}
+
+	@Test
+	@DisplayName("타입에 해당하는 피드백 조회 성공 인수테스트 - 피드백이 없을때")
+	void FIND_FEEDBACK_BY_TYPE_FAIL_TEST() throws Exception {
+		// given
+		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
+		String token = "mock token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedId(targetId)
+			.expectedToken(token)
+			.build());
+		Long surveyId = createAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+
+		// when
+		ResultActions resultActions = findFeedbackByType(surveyId, "tendency");
+
+		// then
+		assertIsFeedbackFoundByType(resultActions);
+
+	}
+
+	private Long createAndGetSurveyId(String token, String content) throws Exception {
+		ResultActions resultActions = createSurvey(token, content);
+		Map<String, Long> surveyIdMap = OBJECT_MAPPER.readValue(
+			resultActions.andReturn().getResponse().getContentAsString(), new TypeReference<>() {
+			});
+		return surveyIdMap.get("survey_id");
+	}
+
+	private SurveyFindResponse getSurveyFindResponse(Long surveyId) throws Exception {
+		ResultActions resultActions = findSurvey(surveyId);
+		return OBJECT_MAPPER.readValue(resultActions.andReturn().getResponse().getContentAsString(),
+			SurveyFindResponse.class);
+	}
+
+	public static FeedbackCreateRequest getFeedbackCreateRequest(SurveyFindResponse surveyFindResponse,
+		boolean collaborationExperience, String position) {
+		return FeedbackCreateRequest.builder()
+			.reviewerRequest(getReviewerRequest(collaborationExperience, position))
+			.abstractQuestionFeedbackRequests(getQuestionFeedbackRequestList(surveyFindResponse))
+			.build();
+	}
+
+	private static ReviewerRequest getReviewerRequest(boolean collaborationExperience, String position) {
+		return ReviewerRequest.builder()
+			.collaborationExperience(collaborationExperience)
+			.position(position)
+			.build();
+	}
+
+	private static List<AbstractQuestionFeedbackRequest> getQuestionFeedbackRequestList(
+		SurveyFindResponse surveyFindResponse) {
+
+		return surveyFindResponse.getQuestion().stream()
+			.map(q -> {
+				if (q instanceof ShortFormQuestionResponse) {
+					return getShortQuestionFeedbackRequest((ShortFormQuestionResponse)q);
+				}
+				return getChoiceQuestionFeedbackRequest((ChoiceFormQuestionResponse)q);
+			})
+			.collect(Collectors.toList());
+	}
+
+	private static ShortQuestionFeedbackRequest getShortQuestionFeedbackRequest(
+		ShortFormQuestionResponse shortFormQuestionResponse) {
+		return ShortQuestionFeedbackRequest.builder()
+			.questionId(shortFormQuestionResponse.getQuestionId())
+			.replyList(List.of("mocking", "words", "hello!"))
+			.type("short")
+			.build();
+	}
+
+	private static ChoiceQuestionFeedbackRequest getChoiceQuestionFeedbackRequest(
+		ChoiceFormQuestionResponse choiceFormQuestionResponse) {
+		return ChoiceQuestionFeedbackRequest.builder()
+			.type("choice")
+			.questionId(choiceFormQuestionResponse.getQuestionId())
+			.choiceList(List.of(choiceFormQuestionResponse.getChoices().get(0).getChoiceId()))
+			.build();
+	}
+
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindByTypeAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindByTypeAcceptanceTest.java
@@ -43,7 +43,7 @@ import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
 @ComponentScan("me.nalab")
 @EnableJpaRepositories(basePackages = {"me.nalab"})
 @EntityScan(basePackages = {"me.nalab"})
-public class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
+class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
 
 	@Autowired
 	private ApplicationEventPublisher applicationEventPublisher;
@@ -115,7 +115,7 @@ public class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSuppor
 			SurveyFindResponse.class);
 	}
 
-	public static FeedbackCreateRequest getFeedbackCreateRequest(SurveyFindResponse surveyFindResponse,
+	private static FeedbackCreateRequest getFeedbackCreateRequest(SurveyFindResponse surveyFindResponse,
 		boolean collaborationExperience, String position) {
 		return FeedbackCreateRequest.builder()
 			.reviewerRequest(getReviewerRequest(collaborationExperience, position))


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
**질문폼의 타입에 해당하는 피드백 조회(인증X)** API에 대한 인수테스트를 작성했습니다

- [x]  /feedback/find 패키지에 **질문폼의 타입에 해당하는 피드백 조회** `인수테스트` 클래스를 생성했습니다
- [x] `AbstractFeedbackTestSupporter` 에 요청로직을 추가했습니다 -> `findFeedbackByType`
- [x] `FeedbackAcceptanceValidator` 에 요청로직에 대한 validation 로직을 추가했습니다 -> `assertIsFeedbackFoundByType`


## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
