### PR TITLE
[feat] : 질문폼의 타입에 해당하는 피드백 조회 - `jpa-adaptor` , `web-adaptor` 구현 완료

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/AbstractFeedbackTestSupporter.java
@@ -89,7 +89,7 @@ public abstract class AbstractFeedbackTestSupporter extends AbstractSurveyTestSu
 
 	protected ResultActions findFeedbackByType(Long surveyId, String formType) throws Exception {
 		return mockMvc.perform(MockMvcRequestBuilders
-			.get("/v1/feedbacks?survey-id" + surveyId)
+			.get("/v2/feedbacks?survey-id=" + surveyId)
 			.queryParam("form-type", formType)
 			.accept(MediaType.APPLICATION_JSON)
 			.contentType(MediaType.APPLICATION_JSON)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/FeedbackAcceptanceValidator.java
@@ -130,7 +130,7 @@ public final class FeedbackAcceptanceValidator {
 		resultActions.andExpectAll(status().isOk());
 	}
 
-	public static void assertIsFeedbackFoundByType(ResultActions resultActions) throws Exception {
+	public static void assertIsFeedbackFoundByTendency(ResultActions resultActions) throws Exception {
 		resultActions.andExpectAll(
 			status().isOk(),
 			content().contentType(MediaType.APPLICATION_JSON),
@@ -144,6 +144,38 @@ public final class FeedbackAcceptanceValidator {
 			jsonPath("$.question_feedback.[0].form_type").value("tendency"),
 			jsonPath("$.question_feedback.[0].title").isString(),
 			jsonPath("$.question_feedback.[0].choices").isArray()
+		);
+	}
+
+	public static void assertIsFeedbackFoundByCustom(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+
+			jsonPath("$.question_feedback").isArray(),
+			jsonPath("$.question_feedback").isNotEmpty(),
+
+			jsonPath("$.question_feedback.[0].question_id").isString(),
+			jsonPath("$.question_feedback.[0].order").isNumber(),
+			jsonPath("$.question_feedback.[0].type").isString(),
+			jsonPath("$.question_feedback.[0].form_type").value("custom"),
+			jsonPath("$.question_feedback.[0].title").isString()
+		);
+	}
+
+	public static void assertIsFeedbackFoundByFormTypeWithNoFeedback(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+
+			jsonPath("$.question_feedback").isArray(),
+			jsonPath("$.question_feedback").isNotEmpty(),
+
+			jsonPath("$.question_feedback.[0].question_id").isString(),
+			jsonPath("$.question_feedback.[0].order").isNumber(),
+			jsonPath("$.question_feedback.[0].type").isString(),
+			jsonPath("$.question_feedback.[0].form_type").isString(),
+			jsonPath("$.question_feedback.[0].title").isString()
 		);
 	}
 

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindByTypeAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindByTypeAcceptanceTest.java
@@ -59,8 +59,8 @@ class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
 	}
 
 	@Test
-	@DisplayName("타입에 해당하는 피드백 조회 성공 인수테스트 - 피드백이 있을때")
-	void FIND_FEEDBACK_BY_TYPE_SUCCESS_TEST() throws Exception {
+	@DisplayName("타입에 해당하는 피드백 조회 성공 인수테스트 - formType이 tendency일 때")
+	void FIND_FEEDBACK_BY_FORM_TYPE_TENDENCY() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
 		String token = "mock token";
@@ -77,13 +77,36 @@ class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ResultActions resultActions = findFeedbackByType(surveyId, "tendency");
 
 		// then
-		assertIsFeedbackFoundByType(resultActions);
+		assertIsFeedbackFoundByTendency(resultActions);
+
+	}
+
+	@Test
+	@DisplayName("타입에 해당하는 피드백 조회 성공 인수테스트 - formType이 custom일 때")
+	void FIND_FEEDBACK_BY_FORM_TYPE_CUSTOM() throws Exception {
+		// given
+		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
+		String token = "mock token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedId(targetId)
+			.expectedToken(token)
+			.build());
+		Long surveyId = createAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+		SurveyFindResponse surveyFindResponse = getSurveyFindResponse(surveyId);
+		FeedbackCreateRequest feedbackCreateRequest = getFeedbackCreateRequest(surveyFindResponse, true, "developer");
+		createFeedback(surveyId, OBJECT_MAPPER.writeValueAsString(feedbackCreateRequest));
+
+		// when
+		ResultActions resultActions = findFeedbackByType(surveyId, "custom");
+
+		// then
+		assertIsFeedbackFoundByCustom(resultActions);
 
 	}
 
 	@Test
 	@DisplayName("타입에 해당하는 피드백 조회 성공 인수테스트 - 피드백이 없을때")
-	void FIND_FEEDBACK_BY_TYPE_FAIL_TEST() throws Exception {
+	void FIND_FEEDBACK_BY_TYPE_TENDENCY_WITH_NO_FEEDBACK() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
 		String token = "mock token";
@@ -97,7 +120,27 @@ class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
 		ResultActions resultActions = findFeedbackByType(surveyId, "tendency");
 
 		// then
-		assertIsFeedbackFoundByType(resultActions);
+		assertIsFeedbackFoundByFormTypeWithNoFeedback(resultActions);
+
+	}
+
+	@Test
+	@DisplayName("타입에 해당하는 피드백 조회 성공 인수테스트 - 피드백이 없을때")
+	void FIND_FEEDBACK_BY_TYPE_CUSTOM_WITH_NO_FEEDBACK() throws Exception {
+		// given
+		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
+		String token = "mock token";
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedId(targetId)
+			.expectedToken(token)
+			.build());
+		Long surveyId = createAndGetSurveyId(token, RequestSample.DEFAULT_JSON);
+
+		// when
+		ResultActions resultActions = findFeedbackByType(surveyId, "custom");
+
+		// then
+		assertIsFeedbackFoundByFormTypeWithNoFeedback(resultActions);
 
 	}
 

--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -55,3 +55,4 @@ exclude me/nalab/survey/web/adaptor/bookmark/BookmarkReplaceController
 exclude me/nalab/survey/web/adaptor/findtarget/*
 exclude me/nalab/auth/mock/interceptor/*
 exclude me/nalab/survey/web/adaptor/updatetarget/*
+exclude me/nalab/survey/web/adaptor/findfeedback/formtype/*

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/findfeedback/formtype/FeedbackFindByTypeUseCase.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/findfeedback/formtype/FeedbackFindByTypeUseCase.java
@@ -1,4 +1,4 @@
-package me.nalab.survey.application.port.in.web.findfeedback.type;
+package me.nalab.survey.application.port.in.web.findfeedback.formtype;
 
 import java.util.List;
 

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/formtype/FeedbackFindPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/formtype/FeedbackFindPort.java
@@ -1,4 +1,4 @@
-package me.nalab.survey.application.port.out.persistence.findfeedback.type;
+package me.nalab.survey.application.port.out.persistence.findfeedback.formtype;
 
 import java.util.List;
 

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/formtype/SurveyFindPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/formtype/SurveyFindPort.java
@@ -1,4 +1,4 @@
-package me.nalab.survey.application.port.out.persistence.findfeedback.type;
+package me.nalab.survey.application.port.out.persistence.findfeedback.formtype;
 
 import java.util.Optional;
 

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/formtype/TargetIdFindPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/findfeedback/formtype/TargetIdFindPort.java
@@ -1,4 +1,4 @@
-package me.nalab.survey.application.port.out.persistence.findfeedback.type;
+package me.nalab.survey.application.port.out.persistence.findfeedback.formtype;
 
 import java.util.Optional;
 

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/findfeedback/formtype/FeedbackFindByTypeService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/findfeedback/formtype/FeedbackFindByTypeService.java
@@ -1,4 +1,4 @@
-package me.nalab.survey.application.service.findfeedback.type;
+package me.nalab.survey.application.service.findfeedback.formtype;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,10 +17,10 @@ import me.nalab.survey.application.common.survey.dto.SurveyDto;
 import me.nalab.survey.application.common.survey.mapper.SurveyDtoMapper;
 import me.nalab.survey.application.exception.SurveyDoesNotExistException;
 import me.nalab.survey.application.exception.SurveyDoesNotHasTargetException;
-import me.nalab.survey.application.port.in.web.findfeedback.type.FeedbackFindByTypeUseCase;
-import me.nalab.survey.application.port.out.persistence.findfeedback.type.FeedbackFindPort;
-import me.nalab.survey.application.port.out.persistence.findfeedback.type.SurveyFindPort;
-import me.nalab.survey.application.port.out.persistence.findfeedback.type.TargetIdFindPort;
+import me.nalab.survey.application.port.in.web.findfeedback.formtype.FeedbackFindByTypeUseCase;
+import me.nalab.survey.application.port.out.persistence.findfeedback.formtype.FeedbackFindPort;
+import me.nalab.survey.application.port.out.persistence.findfeedback.formtype.SurveyFindPort;
+import me.nalab.survey.application.port.out.persistence.findfeedback.formtype.TargetIdFindPort;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.survey.Survey;
 

--- a/survey/survey-application/src/main/java/module-info.java
+++ b/survey/survey-application/src/main/java/module-info.java
@@ -34,7 +34,7 @@ module luffy.survey.application.main {
 
 	exports me.nalab.survey.application.port.out.persistence.findtarget;
 	exports me.nalab.survey.application.port.in.web.findtarget;
-	exports me.nalab.survey.application.port.in.web.findfeedback.type;
+	exports me.nalab.survey.application.port.in.web.findfeedback.formtype;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/survey-application/src/main/java/module-info.java
+++ b/survey/survey-application/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.out.persistence.findtarget;
 	exports me.nalab.survey.application.port.in.web.findtarget;
 	exports me.nalab.survey.application.port.in.web.findfeedback.formtype;
+	exports me.nalab.survey.application.port.out.persistence.findfeedback.formtype;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/findfeedback/formtype/FeedbackFindByTypeServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/findfeedback/formtype/FeedbackFindByTypeServiceTest.java
@@ -1,4 +1,4 @@
-package me.nalab.survey.application.service.findfeedback.type;
+package me.nalab.survey.application.service.findfeedback.formtype;
 
 import static me.nalab.survey.application.RandomSurveyDtoFixture.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -27,9 +27,9 @@ import me.nalab.survey.application.common.survey.dto.SurveyDto;
 import me.nalab.survey.application.common.survey.mapper.SurveyDtoMapper;
 import me.nalab.survey.application.exception.SurveyDoesNotExistException;
 import me.nalab.survey.application.exception.SurveyDoesNotHasTargetException;
-import me.nalab.survey.application.port.out.persistence.findfeedback.type.FeedbackFindPort;
-import me.nalab.survey.application.port.out.persistence.findfeedback.type.SurveyFindPort;
-import me.nalab.survey.application.port.out.persistence.findfeedback.type.TargetIdFindPort;
+import me.nalab.survey.application.port.out.persistence.findfeedback.formtype.FeedbackFindPort;
+import me.nalab.survey.application.port.out.persistence.findfeedback.formtype.SurveyFindPort;
+import me.nalab.survey.application.port.out.persistence.findfeedback.formtype.TargetIdFindPort;
 import me.nalab.survey.domain.feedback.Feedback;
 import me.nalab.survey.domain.survey.ChoiceFormQuestion;
 import me.nalab.survey.domain.survey.ShortFormQuestion;

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/FeedbackFindAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/FeedbackFindAdaptor.java
@@ -1,0 +1,35 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.survey.application.port.out.persistence.findfeedback.formtype.FeedbackFindPort;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.findfeedback.formtype.repository.FeedbackFindRepository;
+
+@Repository("findfeedback.formtype.FeedbackFindAdaptor")
+public class FeedbackFindAdaptor implements FeedbackFindPort {
+
+	private final FeedbackFindRepository feedbackFindRepository;
+
+	@Autowired
+	FeedbackFindAdaptor(
+		@Qualifier("findfeedback.formtype.FeedbackFindRepository") FeedbackFindRepository feedbackFindRepository) {
+		this.feedbackFindRepository = feedbackFindRepository;
+	}
+
+	@Override
+	public List<Feedback> findFeedbackBySurveyId(Long surveyId) {
+		List<FeedbackEntity> feedbackEntityList = feedbackFindRepository.findAllFeedbackEntityBySurveyId(surveyId);
+		return feedbackEntityList.stream()
+			.map(FeedbackEntityMapper::toDomain)
+			.collect(Collectors.toList());
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/SurveyFindAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/SurveyFindAdaptor.java
@@ -1,0 +1,35 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.survey.application.port.out.persistence.findfeedback.formtype.SurveyFindPort;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+import me.nalab.survey.jpa.adaptor.findfeedback.formtype.repository.SurveyFindRepository;
+
+@Repository("findfeedback.formtype.SurveyFindAdaptor")
+public class SurveyFindAdaptor implements SurveyFindPort {
+
+	private final SurveyFindRepository surveyFindRepository;
+
+	@Autowired
+	SurveyFindAdaptor(
+		@Qualifier("findfeedback.formtype.SurveyFindRepository") SurveyFindRepository surveyFindRepository) {
+		this.surveyFindRepository = surveyFindRepository;
+	}
+
+	@Override
+	public Optional<Survey> findSurveyById(Long surveyId) {
+		Optional<SurveyEntity> surveyEntity = surveyFindRepository.findById(surveyId);
+		if (surveyEntity.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(SurveyEntityMapper.toSurvey(surveyEntity.get()));
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TargetIdFindAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TargetIdFindAdaptor.java
@@ -1,0 +1,33 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.survey.application.port.out.persistence.findfeedback.formtype.TargetIdFindPort;
+import me.nalab.survey.jpa.adaptor.findfeedback.formtype.repository.SurveyFindRepository;
+
+@Repository("findfeedback.formtype.TargetIdFindAdaptor")
+public class TargetIdFindAdaptor implements TargetIdFindPort {
+
+	private final SurveyFindRepository surveyFindRepository;
+
+	@Autowired
+	TargetIdFindAdaptor(
+		@Qualifier("findfeedback.formtype.SurveyFindRepository") SurveyFindRepository surveyFindRepository) {
+		this.surveyFindRepository = surveyFindRepository;
+	}
+
+	@Override
+	public Optional<Long> findTargetIdBySurveyId(Long surveyId) {
+		Optional<SurveyEntity> surveyEntity = surveyFindRepository.findById(surveyId);
+		if (surveyEntity.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(surveyEntity.get().getTargetId());
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/repository/FeedbackFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/repository/FeedbackFindRepository.java
@@ -1,0 +1,18 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+@Repository("findfeedback.formtype.FeedbackFindRepository")
+public interface FeedbackFindRepository extends JpaRepository<FeedbackEntity, Long> {
+
+	@Query("select f from FeedbackEntity as f where f.surveyId = :surveyId")
+	List<FeedbackEntity> findAllFeedbackEntityBySurveyId(@Param("surveyId") Long surveyId);
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/repository/SurveyFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/repository/SurveyFindRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+@Repository("findfeedback.formtype.SurveyFindRepository")
+public interface SurveyFindRepository extends JpaRepository<SurveyEntity, Long> {
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/FeedbackFindAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/FeedbackFindAdaptorTest.java
@@ -1,0 +1,97 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.feedback.Feedback;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomFeedbackFixture;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.FeedbackEntityMapper;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = FeedbackFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class FeedbackFindAdaptorTest {
+
+	@Autowired
+	private FeedbackFindAdaptor feedbackFindAdaptor;
+
+	@Autowired
+	private TestTargetRepository testTargetRepository;
+
+	@Autowired
+	private TestSurveyFindRepository testSurveyFindRepository;
+
+	@Autowired
+	private TestFeedbackFindRepository testFeedbackFindRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("surveyId에 해당하는 모든 feedback 조회 - 피드백이 있는 경우")
+	void FIND_ALL_FEEDBACK_WITH_SURVEY_ID_WITH_FEEDBACK() {
+
+		TargetEntity targetEntity = getTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+		FeedbackEntity feedbackEntity = FeedbackEntityMapper.toEntity(
+			RandomFeedbackFixture.getRandomFeedbackBySurvey(survey));
+		Feedback feedback = FeedbackEntityMapper.toDomain(feedbackEntity);
+
+		testTargetRepository.saveAndFlush(targetEntity);
+		testSurveyFindRepository.saveAndFlush(surveyEntity);
+		testFeedbackFindRepository.saveAndFlush(feedbackEntity);
+		entityManager.clear();
+
+		List<Feedback> feedbackList = feedbackFindAdaptor.findFeedbackBySurveyId(survey.getId());
+
+		assertIterableEquals(List.of(feedback), feedbackList);
+	}
+
+	@Test
+	@DisplayName("surveyId에 해당하는 모든 feedback 조회 - 피드백이 없는 경우")
+	void FIND_ALL_FEEDBACK_WITH_SURVEY_ID_WITH_NO_FEEDBACK() {
+
+		TargetEntity targetEntity = getTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		testTargetRepository.saveAndFlush(targetEntity);
+		testSurveyFindRepository.saveAndFlush(surveyEntity);
+		entityManager.clear();
+
+		List<Feedback> feedbackList = feedbackFindAdaptor.findFeedbackBySurveyId(survey.getId());
+
+		assertEquals(List.of(), feedbackList);
+	}
+
+	private TargetEntity getTargetEntity() {
+		return TargetEntity.builder()
+			.id(1L)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("nalab")
+			.build();
+	}
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/SurveyFindAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/SurveyFindAdaptorTest.java
@@ -1,0 +1,83 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = SurveyFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class SurveyFindAdaptorTest {
+
+	@Autowired
+	private SurveyFindAdaptor surveyFindAdaptor;
+
+	@Autowired
+	private TestTargetRepository testTargetRepository;
+
+	@Autowired
+	private TestSurveyFindRepository testSurveyFindRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("surveyId에 해당하는 survey 조회 - survey가 존재하는 경우")
+	void FIND_SURVEY_WITH_SURVEY_ID_WITH_SURVEY() {
+
+		TargetEntity targetEntity = getTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		testTargetRepository.saveAndFlush(targetEntity);
+		testSurveyFindRepository.saveAndFlush(surveyEntity);
+		entityManager.clear();
+
+		Optional<Survey> resultSurvey = surveyFindAdaptor.findSurveyById(survey.getId());
+
+		assertFalse(resultSurvey.isEmpty());
+		assertEquals(survey, resultSurvey.get());
+	}
+
+	@Test
+	@DisplayName("surveyId에 해당하는 survey 조회 - survey가 존재하지 않는 경우")
+	void FIND_SURVEY_WITH_SURVEY_ID_WITH_NO_SURVEY() {
+
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+
+		Optional<Survey> resultSurvey = surveyFindAdaptor.findSurveyById(survey.getId());
+
+		assertTrue(resultSurvey.isEmpty());
+
+	}
+
+	private TargetEntity getTargetEntity() {
+		return TargetEntity.builder()
+			.id(1L)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("nalab")
+			.build();
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TargetIdFindAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TargetIdFindAdaptorTest.java
@@ -1,0 +1,83 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = TargetIdFindAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class TargetIdFindAdaptorTest {
+
+	@Autowired
+	private TargetIdFindAdaptor targetIdFindAdaptor;
+
+	@Autowired
+	private TestTargetRepository testTargetRepository;
+
+	@Autowired
+	private TestSurveyFindRepository testSurveyFindRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("surveyId에 해당하는 targetId 조회 - targetId가 존재하는 경우")
+	void FIND_TARGET_ID_WITH_SURVEY_ID_WITH_TARGETID() {
+
+		TargetEntity targetEntity = getTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		testTargetRepository.saveAndFlush(targetEntity);
+		testSurveyFindRepository.saveAndFlush(surveyEntity);
+		entityManager.clear();
+
+		Optional<Long> targetIdBySurveyId = targetIdFindAdaptor.findTargetIdBySurveyId(survey.getId());
+
+		assertFalse(targetIdBySurveyId.isEmpty());
+		assertEquals(targetEntity.getId(), targetIdBySurveyId.get());
+	}
+
+	@Test
+	@DisplayName("surveyId에 해당하는 targetId 조회 - targetId가 존재하지 않는 경우")
+	void FIND_TARGET_ID_WITH_SURVEY_ID_WITH_NO_TARGETID() {
+
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+
+		Optional<Long> targetIdBySurveyId = targetIdFindAdaptor.findTargetIdBySurveyId(survey.getId());
+
+		assertTrue(targetIdBySurveyId.isEmpty());
+
+	}
+
+	private TargetEntity getTargetEntity() {
+		return TargetEntity.builder()
+			.id(1L)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("nalab")
+			.build();
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TestFeedbackFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TestFeedbackFindRepository.java
@@ -1,0 +1,9 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.feedback.FeedbackEntity;
+
+public interface TestFeedbackFindRepository extends JpaRepository<FeedbackEntity, Long> {
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TestSurveyFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TestSurveyFindRepository.java
@@ -1,0 +1,9 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyFindRepository extends JpaRepository<SurveyEntity, Long> {
+
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TestTargetRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/findfeedback/formtype/TestTargetRepository.java
@@ -1,0 +1,9 @@
+package me.nalab.survey.jpa.adaptor.findfeedback.formtype;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TestTargetRepository extends JpaRepository<TargetEntity, Long> {
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/FeedbackFindByFormTypeController.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/FeedbackFindByFormTypeController.java
@@ -1,0 +1,37 @@
+package me.nalab.survey.web.adaptor.findfeedback.formtype;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.survey.dto.FormQuestionDtoable;
+import me.nalab.survey.application.port.in.web.findfeedback.formtype.FeedbackFindByTypeUseCase;
+import me.nalab.survey.web.adaptor.findfeedback.formtype.response.QuestionFeedbackResponse;
+
+@RestController
+@RequestMapping("/v2")
+@RequiredArgsConstructor
+public class FeedbackFindByFormTypeController {
+
+	private final FeedbackFindByTypeUseCase feedbackFindByTypeUseCase;
+
+	@GetMapping("/feedbacks")
+	@ResponseStatus(HttpStatus.OK)
+	public QuestionFeedbackResponse findFeedbackByFormType(
+		@RequestParam("survey-id") Long surveyId,
+		@RequestParam("form-type") String formType) {
+		List<FormQuestionDtoable> formQuestionDtoableList = feedbackFindByTypeUseCase.formQuestionMatchingWithType(
+			surveyId, formType);
+		List<FeedbackDto> feedbackDtoList = feedbackFindByTypeUseCase.findFeedbackBySurveyId(surveyId);
+		return QuestionFeedbackResponseMapper.toFeedbackQuestionResponse(
+			formQuestionDtoableList, feedbackDtoList);
+	}
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/QuestionFeedbackResponseMapper.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/QuestionFeedbackResponseMapper.java
@@ -1,0 +1,128 @@
+package me.nalab.survey.web.adaptor.findfeedback.formtype;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import me.nalab.survey.application.common.feedback.dto.ChoiceFormQuestionFeedbackDto;
+import me.nalab.survey.application.common.feedback.dto.FeedbackDto;
+import me.nalab.survey.application.common.feedback.dto.ShortFormQuestionFeedbackDto;
+import me.nalab.survey.application.common.survey.dto.ChoiceDto;
+import me.nalab.survey.application.common.survey.dto.ChoiceFormQuestionDto;
+import me.nalab.survey.application.common.survey.dto.FormQuestionDtoable;
+import me.nalab.survey.application.common.survey.dto.QuestionDtoType;
+import me.nalab.survey.application.common.survey.dto.ShortFormQuestionDto;
+import me.nalab.survey.web.adaptor.findfeedback.formtype.response.QuestionFeedbackResponse;
+import me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion.ChoiceFormQuestionResponse;
+import me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion.ChoiceResponse;
+import me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion.ShortFormQuestionResponse;
+import me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion.ShortResponse;
+
+final class QuestionFeedbackResponseMapper {
+
+	private QuestionFeedbackResponseMapper() {
+		throw new UnsupportedOperationException("Cannot invoke constructor \"QuestionFeedbackResponseMapper()\"");
+	}
+
+	static QuestionFeedbackResponse toFeedbackQuestionResponse(List<FormQuestionDtoable> formQuestionDtoableList,
+		List<FeedbackDto> feedbackDtoList) {
+		return QuestionFeedbackResponse.builder()
+			.abstractFormQuestionResponseList(formQuestionDtoableList.stream()
+				.map(q -> {
+						if (q.getQuestionDtoType() == QuestionDtoType.CHOICE) {
+							return toChoiceFormQuestionResponse((ChoiceFormQuestionDto)q, feedbackDtoList);
+						}
+						return toShortFormQuestionResponse((ShortFormQuestionDto)q, feedbackDtoList);
+					}
+				).collect(Collectors.toList())).build();
+	}
+
+	private static ChoiceFormQuestionResponse toChoiceFormQuestionResponse(ChoiceFormQuestionDto choiceFormQuestionDto,
+		List<FeedbackDto> feedbackDtoList) {
+		ChoiceFormQuestionResponse choiceFormQuestionResponse = ChoiceFormQuestionResponse.builder()
+			.questionId(String.valueOf(choiceFormQuestionDto.getId()))
+			.order(choiceFormQuestionDto.getOrder())
+			.type(choiceFormQuestionDto.getQuestionDtoType().name().toLowerCase())
+			.title(choiceFormQuestionDto.getQuestionDtoType().name().toLowerCase())
+			.formType(choiceFormQuestionDto.getChoiceFormQuestionDtoType().name().toLowerCase())
+			.title(choiceFormQuestionDto.getTitle())
+			.choiceResponseList(toChoiceResponseList(choiceFormQuestionDto.getChoiceDtoList()))
+			.build();
+		updateSelectedCount(choiceFormQuestionResponse, feedbackDtoList);
+		return choiceFormQuestionResponse;
+	}
+
+	private static void updateSelectedCount(ChoiceFormQuestionResponse choiceFormQuestionResponse,
+		List<FeedbackDto> feedbackDtoList) {
+		Long questionId = Long.valueOf(choiceFormQuestionResponse.getQuestionId());
+
+		feedbackDtoList
+			.forEach(c -> c.getFormQuestionFeedbackDtoableList()
+				.forEach(q -> {
+					if (Objects.equals(q.getQuestionId(), questionId)) {
+						Set<Long> selectedChoiceIdSet = ((ChoiceFormQuestionFeedbackDto)q).getSelectedChoiceIdSet();
+						selectedChoiceIdSet
+							.forEach(sc -> {
+								choiceFormQuestionResponse.getChoiceResponseList()
+									.forEach(cq -> {
+										if (Objects.equals(sc, Long.valueOf(cq.getChoiceId())))
+											cq.updateSelectedCount();
+									});
+							});
+					}
+				})
+			);
+	}
+
+	private static List<ChoiceResponse> toChoiceResponseList(List<ChoiceDto> choiceDtoList) {
+		return choiceDtoList.stream()
+			.map(c -> ChoiceResponse.builder()
+				.choiceId(String.valueOf(c.getId()))
+				.order(c.getOrder())
+				.selectedCount(0)
+				.content(c.getContent())
+				.build())
+			.collect(Collectors.toList());
+	}
+
+	private static ShortFormQuestionResponse toShortFormQuestionResponse(ShortFormQuestionDto shortFormQuestionDto,
+		List<FeedbackDto> feedbackDtoList) {
+		List<ShortResponse> shortResponseList = new ArrayList<>();
+		ShortFormQuestionResponse shortFormQuestionResponse = ShortFormQuestionResponse.builder()
+			.questionId(String.valueOf(shortFormQuestionDto.getId()))
+			.order(shortFormQuestionDto.getOrder())
+			.type(shortFormQuestionDto.getQuestionDtoType().name().toLowerCase())
+			.title(shortFormQuestionDto.getQuestionDtoType().name().toLowerCase())
+			.formType(shortFormQuestionDto.getShortFormQuestionDtoType().name().toLowerCase())
+			.title(shortFormQuestionDto.getTitle())
+			.shortResponseList(shortResponseList)
+			.build();
+		toShortResponseList(shortFormQuestionResponse, feedbackDtoList);
+		return shortFormQuestionResponse;
+	}
+
+	private static void toShortResponseList(ShortFormQuestionResponse shortFormQuestionResponse,
+		List<FeedbackDto> feedbackDtoList) {
+		feedbackDtoList
+			.forEach(f -> {
+				f.getFormQuestionFeedbackDtoableList().stream()
+					.filter(q -> Objects.equals(q.getQuestionId(),
+						Long.valueOf(shortFormQuestionResponse.getQuestionId())))
+					.forEach(sq -> shortFormQuestionResponse.getShortResponseList().add(
+						ShortResponse.builder()
+							.feedbackId(String.valueOf(f.getId()))
+							.createdAt(
+								ZonedDateTime.ofInstant(f.getCreatedAt(), ZoneId.of("Asia/Seoul")).toLocalDateTime())
+							.replyList(((ShortFormQuestionFeedbackDto)sq).getReplyList())
+							.build()
+
+					));
+			});
+
+	}
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/QuestionFeedbackResponseMapper.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/QuestionFeedbackResponseMapper.java
@@ -66,13 +66,11 @@ final class QuestionFeedbackResponseMapper {
 					if (Objects.equals(q.getQuestionId(), questionId)) {
 						Set<Long> selectedChoiceIdSet = ((ChoiceFormQuestionFeedbackDto)q).getSelectedChoiceIdSet();
 						selectedChoiceIdSet
-							.forEach(sc -> {
-								choiceFormQuestionResponse.getChoiceResponseList()
-									.forEach(cq -> {
-										if (Objects.equals(sc, Long.valueOf(cq.getChoiceId())))
-											cq.updateSelectedCount();
-									});
-							});
+							.forEach(sc -> choiceFormQuestionResponse.getChoiceResponseList()
+								.forEach(cq -> {
+									if (Objects.equals(sc, Long.valueOf(cq.getChoiceId())))
+										cq.updateSelectedCount();
+								}));
 					}
 				})
 			);
@@ -108,20 +106,18 @@ final class QuestionFeedbackResponseMapper {
 	private static void toShortResponseList(ShortFormQuestionResponse shortFormQuestionResponse,
 		List<FeedbackDto> feedbackDtoList) {
 		feedbackDtoList
-			.forEach(f -> {
-				f.getFormQuestionFeedbackDtoableList().stream()
-					.filter(q -> Objects.equals(q.getQuestionId(),
-						Long.valueOf(shortFormQuestionResponse.getQuestionId())))
-					.forEach(sq -> shortFormQuestionResponse.getShortResponseList().add(
-						ShortResponse.builder()
-							.feedbackId(String.valueOf(f.getId()))
-							.createdAt(
-								ZonedDateTime.ofInstant(f.getCreatedAt(), ZoneId.of("Asia/Seoul")).toLocalDateTime())
-							.replyList(((ShortFormQuestionFeedbackDto)sq).getReplyList())
-							.build()
+			.forEach(f -> f.getFormQuestionFeedbackDtoableList().stream()
+				.filter(q -> Objects.equals(q.getQuestionId(),
+					Long.valueOf(shortFormQuestionResponse.getQuestionId())))
+				.forEach(sq -> shortFormQuestionResponse.getShortResponseList().add(
+					ShortResponse.builder()
+						.feedbackId(String.valueOf(f.getId()))
+						.createdAt(
+							ZonedDateTime.ofInstant(f.getCreatedAt(), ZoneId.of("Asia/Seoul")).toLocalDateTime())
+						.replyList(((ShortFormQuestionFeedbackDto)sq).getReplyList())
+						.build()
 
-					));
-			});
+				)));
 
 	}
 

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/QuestionFeedbackResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/QuestionFeedbackResponse.java
@@ -1,0 +1,20 @@
+package me.nalab.survey.web.adaptor.findfeedback.formtype.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion.AbstractFormQuestionResponse;
+
+@Getter
+@ToString
+@SuperBuilder
+public class QuestionFeedbackResponse {
+
+	@JsonProperty("question_feedback")
+	private List<AbstractFormQuestionResponse> abstractFormQuestionResponseList;
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/AbstractFormQuestionResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/AbstractFormQuestionResponse.java
@@ -1,0 +1,26 @@
+package me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@ToString
+@SuperBuilder
+public abstract class AbstractFormQuestionResponse {
+
+	@JsonProperty("question_id")
+	private final String questionId;
+
+	private final Integer order;
+
+	private final String type;
+
+	@JsonProperty("form_type")
+	private final String formType;
+
+	private final String title;
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/ChoiceFormQuestionResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/ChoiceFormQuestionResponse.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@ToString
+@SuperBuilder
+public class ChoiceFormQuestionResponse extends AbstractFormQuestionResponse {
+
+	@JsonProperty("choices")
+	private final List<ChoiceResponse> choiceResponseList;
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/ChoiceResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/ChoiceResponse.java
@@ -1,0 +1,28 @@
+package me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class ChoiceResponse {
+
+	@JsonProperty("choice_id")
+	private final String choiceId;
+
+	private final int order;
+
+	@JsonProperty("selected_count")
+	private int selectedCount;
+
+	private final String content;
+
+	public void updateSelectedCount() {
+		this.selectedCount++;
+	}
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/ShortFormQuestionResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/ShortFormQuestionResponse.java
@@ -1,0 +1,19 @@
+package me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@ToString
+@SuperBuilder
+public class ShortFormQuestionResponse extends AbstractFormQuestionResponse {
+
+	@JsonProperty("feedbacks")
+	private final List<ShortResponse> shortResponseList;
+
+}

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/ShortResponse.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/findfeedback/formtype/response/formquestion/ShortResponse.java
@@ -1,0 +1,26 @@
+package me.nalab.survey.web.adaptor.findfeedback.formtype.response.formquestion;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class ShortResponse {
+
+	@JsonProperty("feedback_id")
+	private final String feedbackId;
+
+	@JsonProperty("created_at")
+	private final LocalDateTime createdAt;
+
+	@JsonProperty("reply")
+	List<String> replyList;
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
**질문폼의 타입에 해당하는 피드백 조회** API에 대한 `jpa-adaptor` 부분을 개발 완료했습니다

- [x] port의 구현체인 `FeedbackFindAdaptor`, `SurveyFindAdaptor`, `TargetIdFindAdaptor` 를 구현하고, 이를 이용하는 repository도 정의하였습니다
- [x] `FeedbackFindAdaptor`, `SurveyFindAdaptor`, `TargetIdFindAdaptor` 각각에 대한 테스트를 작성하고, 예외에 대한 테스트도 추가하였습니다

**질문폼의 타입에 해당하는 피드백 조회** API에 대한 `web-adaptor` 부분을 개발 완료했습니다

- [x]  **질문폼의 타입에 해당하는 피드백 조회(인증X)** 에 `web-adaptor` 를 추가하고, controller를 만들었습니다
- [x]  response 객체를 만들고, 이에 대한 mapper를 추가해 response시에 mapper를 통해 변환해서 반환하도록 하였습니다
- [x]  인수테스트 테스트케이스를 추가해 추가적인 테스트 검증을 모두 마쳤습니다 [formtype: tendency, custom] 그리고 객관식, 주관식에 맞게 제대로 반환하는지 검증을 완료했습니다


## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
