### PR TITLE
[fix] : `/v2 API` CORS 에러 수정

### DIFF
--- a/core/secure/src/main/java/me/nalab/core/secure/cors/CorsConfig.java
+++ b/core/secure/src/main/java/me/nalab/core/secure/cors/CorsConfig.java
@@ -1,6 +1,7 @@
 package me.nalab.core.secure.cors;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -11,16 +12,33 @@ class CorsConfig implements WebMvcConfigurer {
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/v1/**")
-			.allowedOrigins("*")
-			.allowedHeaders("*")
-			.allowedMethods(ALLOWED_METHOD_NAMES)
-			.maxAge(3600);
+		addCorsMappingsV1(registry);
+		addCorsMappingsV2(registry);
+		addCorsMappingsMock(registry);
+	}
 
-		registry.addMapping("/mock/**")
+	private void addCorsMappingsV1(CorsRegistry corsRegistry) {
+		corsRegistry.addMapping("/v1/**")
 			.allowedOrigins("*")
 			.allowedHeaders("*")
 			.allowedMethods(ALLOWED_METHOD_NAMES)
 			.maxAge(3600);
 	}
+
+	private CorsRegistration addCorsMappingsV2(CorsRegistry corsRegistry) {
+		return corsRegistry.addMapping("/v2/**")
+			.allowedOrigins("*")
+			.allowedHeaders("*")
+			.allowedMethods(ALLOWED_METHOD_NAMES)
+			.maxAge(3600);
+	}
+
+	private CorsRegistration addCorsMappingsMock(CorsRegistry corsRegistry) {
+		return corsRegistry.addMapping("/mock/**")
+			.allowedOrigins("*")
+			.allowedHeaders("*")
+			.allowedMethods(ALLOWED_METHOD_NAMES)
+			.maxAge(3600);
+	}
+
 }

--- a/core/secure/src/main/java/module-info.java
+++ b/core/secure/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module luffy.core.secure.main {
 	requires spring.context;
 	requires com.fasterxml.jackson.databind;
 	requires org.apache.commons.text;
+	requires spring.webmvc;
 
 	exports me.nalab.core.secure.xss.meta;
 


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
V2 API에서 CORS 에러가 발생하는 에러를 수정했습니다.

## 어떻게 해결했나요?
- [x] `/v2` url prefix에 대해 CORS 설정을 열었습니다.

## 이슈 넘버
- closes #335 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
