### PR TITLE
[test] : `질문폼의 타입에 해당하는 피드백 조회` e2e test 추가

### DIFF
--- a/support/e2e/v1_3_feedback_find.hurl
+++ b/support/e2e/v1_3_feedback_find.hurl
@@ -103,6 +103,10 @@ short_strength_question_id: jsonpath "$.question.[1].question_id"
 choice_custom_question_id: jsonpath "$.question.[2].question_id"
 choice_custom_choice_id: jsonpath "$.question.[2].choices.[0].choice_id"
 short_custom_question_id: jsonpath "$.question.[3].question_id"
+formtype_tendency: jsonpath "$.question.[0].form_type"
+formtype_strength: jsonpath "$.question.[1].form_type"
+formtype_custom: jsonpath "$.question.[2].form_type"
+
 
 ##########
 
@@ -314,3 +318,109 @@ header "Content-type" == "application/json"
 
 jsonpath "$.all_feedback_count" == 2
 jsonpath "$.new_feedback_count" == 1
+
+##########
+
+GET http://nalab-server:8080/v2/feedbacks # 생성된 survey와 feedback 2개를 바탕으로, 질문폼의 타입 "tendency"에 해당하는 피드백을 조회한다
+
+[QueryStringParams]
+survey-id: {{ survey_id }}
+form-type: {{ formtype_tendency }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.question_feedback" count == 1
+jsonpath "$.question_feedback.[0].question_id" exists
+jsonpath "$.question_feedback.[0].order" exists
+jsonpath "$.question_feedback.[0].type" matches "choice"
+jsonpath "$.question_feedback.[0].form_type" matches "tendency"
+jsonpath "$.question_feedback.[0].title" exists
+
+jsonpath "$.question_feedback.[0].choices" count == 4
+jsonpath "$.question_feedback.[0].choices.[0].order" exists
+jsonpath "$.question_feedback.[0].choices.[0].content" exists
+jsonpath "$.question_feedback.[0].choices.[0].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[0].selected_count" == 2
+jsonpath "$.question_feedback.[0].choices.[1].order" exists
+jsonpath "$.question_feedback.[0].choices.[1].content" exists
+jsonpath "$.question_feedback.[0].choices.[1].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[1].selected_count" == 0
+jsonpath "$.question_feedback.[0].choices.[2].order" exists
+jsonpath "$.question_feedback.[0].choices.[2].content" exists
+jsonpath "$.question_feedback.[0].choices.[2].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[2].selected_count" == 0
+jsonpath "$.question_feedback.[0].choices.[3].order" exists
+jsonpath "$.question_feedback.[0].choices.[3].content" exists
+jsonpath "$.question_feedback.[0].choices.[3].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[3].selected_count" == 0
+
+##########
+
+GET http://nalab-server:8080/v2/feedbacks # 생성된 survey와 feedback 2개를 바탕으로, 질문폼의 타입 "strength"에 해당하는 피드백을 조회한다
+
+[QueryStringParams]
+survey-id: {{ survey_id }}
+form-type: {{ formtype_strength }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.question_feedback" count == 1
+jsonpath "$.question_feedback.[0].question_id" exists
+jsonpath "$.question_feedback.[0].order" exists
+jsonpath "$.question_feedback.[0].type" matches "short"
+jsonpath "$.question_feedback.[0].form_type" matches "strength"
+jsonpath "$.question_feedback.[0].title" exists
+
+jsonpath "$.question_feedback.[0].feedbacks" count == 2
+jsonpath "$.question_feedback.[0].feedbacks.[0].feedback_id" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].created_at" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].reply" exists
+jsonpath "$.question_feedback.[0].feedbacks.[1].feedback_id" exists
+jsonpath "$.question_feedback.[0].feedbacks.[1].created_at" exists
+jsonpath "$.question_feedback.[0].feedbacks.[1].reply" exists
+
+##########
+
+GET http://nalab-server:8080/v2/feedbacks # 생성된 survey와 feedback 2개를 바탕으로, 질문폼의 타입 "custom"에 해당하는 피드백을 조회한다
+
+[QueryStringParams]
+survey-id: {{ survey_id }}
+form-type: {{ formtype_custom }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.question_feedback" count == 2
+
+jsonpath "$.question_feedback.[0].question_id" exists
+jsonpath "$.question_feedback.[0].order" exists
+jsonpath "$.question_feedback.[0].type" matches "choice"
+jsonpath "$.question_feedback.[0].form_type" matches "custom"
+jsonpath "$.question_feedback.[0].title" exists
+jsonpath "$.question_feedback.[0].choices" count == 2
+jsonpath "$.question_feedback.[0].choices.[0].order" exists
+jsonpath "$.question_feedback.[0].choices.[0].content" exists
+jsonpath "$.question_feedback.[0].choices.[0].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[0].selected_count" == 2
+jsonpath "$.question_feedback.[0].choices.[1].order" exists
+jsonpath "$.question_feedback.[0].choices.[1].content" exists
+jsonpath "$.question_feedback.[0].choices.[1].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[1].selected_count" == 0
+
+jsonpath "$.question_feedback.[1].question_id" exists
+jsonpath "$.question_feedback.[1].order" exists
+jsonpath "$.question_feedback.[1].type" matches "short"
+jsonpath "$.question_feedback.[1].form_type" matches "custom"
+jsonpath "$.question_feedback.[1].title" exists
+jsonpath "$.question_feedback.[1].feedbacks" count == 2
+jsonpath "$.question_feedback.[1].feedbacks.[0].feedback_id" exists
+jsonpath "$.question_feedback.[1].feedbacks.[0].created_at" exists
+jsonpath "$.question_feedback.[1].feedbacks.[0].reply" exists
+jsonpath "$.question_feedback.[1].feedbacks.[1].feedback_id" exists
+jsonpath "$.question_feedback.[1].feedbacks.[1].created_at" exists
+jsonpath "$.question_feedback.[1].feedbacks.[1].reply" exists

--- a/support/e2e/v2_3_feedback_find.hurl
+++ b/support/e2e/v2_3_feedback_find.hurl
@@ -103,6 +103,9 @@ short_strength_question_id: jsonpath "$.question.[1].question_id"
 choice_custom_question_id: jsonpath "$.question.[2].question_id"
 choice_custom_choice_id: jsonpath "$.question.[2].choices.[0].choice_id"
 short_custom_question_id: jsonpath "$.question.[3].question_id"
+formtype_tendency: jsonpath "$.question.[0].form_type"
+formtype_strength: jsonpath "$.question.[1].form_type"
+formtype_custom: jsonpath "$.question.[2].form_type"
 
 ##########
 
@@ -311,3 +314,109 @@ header "Content-type" == "application/json"
 
 jsonpath "$.all_feedback_count" == 2
 jsonpath "$.new_feedback_count" == 1
+
+##########
+
+GET http://nalab-server:8080/v2/feedbacks # 생성된 survey와 feedback 2개를 바탕으로, 질문폼의 타입 "tendency"에 해당하는 피드백을 조회한다
+
+[QueryStringParams]
+survey-id: {{ survey_id }}
+form-type: {{ formtype_tendency }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.question_feedback" count == 1
+jsonpath "$.question_feedback.[0].question_id" exists
+jsonpath "$.question_feedback.[0].order" exists
+jsonpath "$.question_feedback.[0].type" matches "choice"
+jsonpath "$.question_feedback.[0].form_type" matches "tendency"
+jsonpath "$.question_feedback.[0].title" exists
+
+jsonpath "$.question_feedback.[0].choices" count == 4
+jsonpath "$.question_feedback.[0].choices.[0].order" exists
+jsonpath "$.question_feedback.[0].choices.[0].content" exists
+jsonpath "$.question_feedback.[0].choices.[0].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[0].selected_count" == 2
+jsonpath "$.question_feedback.[0].choices.[1].order" exists
+jsonpath "$.question_feedback.[0].choices.[1].content" exists
+jsonpath "$.question_feedback.[0].choices.[1].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[1].selected_count" == 0
+jsonpath "$.question_feedback.[0].choices.[2].order" exists
+jsonpath "$.question_feedback.[0].choices.[2].content" exists
+jsonpath "$.question_feedback.[0].choices.[2].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[2].selected_count" == 0
+jsonpath "$.question_feedback.[0].choices.[3].order" exists
+jsonpath "$.question_feedback.[0].choices.[3].content" exists
+jsonpath "$.question_feedback.[0].choices.[3].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[3].selected_count" == 0
+
+##########
+
+GET http://nalab-server:8080/v2/feedbacks # 생성된 survey와 feedback 2개를 바탕으로, 질문폼의 타입 "strength"에 해당하는 피드백을 조회한다
+
+[QueryStringParams]
+survey-id: {{ survey_id }}
+form-type: {{ formtype_strength }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.question_feedback" count == 1
+jsonpath "$.question_feedback.[0].question_id" exists
+jsonpath "$.question_feedback.[0].order" exists
+jsonpath "$.question_feedback.[0].type" matches "short"
+jsonpath "$.question_feedback.[0].form_type" matches "strength"
+jsonpath "$.question_feedback.[0].title" exists
+
+jsonpath "$.question_feedback.[0].feedbacks" count == 2
+jsonpath "$.question_feedback.[0].feedbacks.[0].feedback_id" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].created_at" exists
+jsonpath "$.question_feedback.[0].feedbacks.[0].reply" exists
+jsonpath "$.question_feedback.[0].feedbacks.[1].feedback_id" exists
+jsonpath "$.question_feedback.[0].feedbacks.[1].created_at" exists
+jsonpath "$.question_feedback.[0].feedbacks.[1].reply" exists
+
+##########
+
+GET http://nalab-server:8080/v2/feedbacks # 생성된 survey와 feedback 2개를 바탕으로, 질문폼의 타입 "custom"에 해당하는 피드백을 조회한다
+
+[QueryStringParams]
+survey-id: {{ survey_id }}
+form-type: {{ formtype_custom }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.question_feedback" count == 2
+
+jsonpath "$.question_feedback.[0].question_id" exists
+jsonpath "$.question_feedback.[0].order" exists
+jsonpath "$.question_feedback.[0].type" matches "choice"
+jsonpath "$.question_feedback.[0].form_type" matches "custom"
+jsonpath "$.question_feedback.[0].title" exists
+jsonpath "$.question_feedback.[0].choices" count == 2
+jsonpath "$.question_feedback.[0].choices.[0].order" exists
+jsonpath "$.question_feedback.[0].choices.[0].content" exists
+jsonpath "$.question_feedback.[0].choices.[0].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[0].selected_count" == 2
+jsonpath "$.question_feedback.[0].choices.[1].order" exists
+jsonpath "$.question_feedback.[0].choices.[1].content" exists
+jsonpath "$.question_feedback.[0].choices.[1].choice_id" exists
+jsonpath "$.question_feedback.[0].choices.[1].selected_count" == 0
+
+jsonpath "$.question_feedback.[1].question_id" exists
+jsonpath "$.question_feedback.[1].order" exists
+jsonpath "$.question_feedback.[1].type" matches "short"
+jsonpath "$.question_feedback.[1].form_type" matches "custom"
+jsonpath "$.question_feedback.[1].title" exists
+jsonpath "$.question_feedback.[1].feedbacks" count == 2
+jsonpath "$.question_feedback.[1].feedbacks.[0].feedback_id" exists
+jsonpath "$.question_feedback.[1].feedbacks.[0].created_at" exists
+jsonpath "$.question_feedback.[1].feedbacks.[0].reply" exists
+jsonpath "$.question_feedback.[1].feedbacks.[1].feedback_id" exists
+jsonpath "$.question_feedback.[1].feedbacks.[1].created_at" exists
+jsonpath "$.question_feedback.[1].feedbacks.[1].reply" exists


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`질문폼의 타입에 해당하는 피드백 조회` 새로 추가된 API에 대한 e2e test를 추가하였습니다.

과정은 다음과 같이 진행됩니다.

- [x] 회원가입을 한다
- [x] 발급받은 토큰으로 survey를 생성한다 - [ choice-tendency, choice-custom, short-strength, short-custom ]
- [x] feedback 2개를 생성한다
- [x] 각 formType - [`tendency`, `strength`, `custom`] 에 해당하는 피드백 각각의 모든 케이스에 대해 테스트합니다
- [x] choice인 경우, 각 choiceSet에 대한 모든 개수를 counting 하고, short인 경우 해당 formQuestionId에 해당하는 모든 답변들을 보여주어야합니다

## 해당 경우의 수
* tendency - choice 만 가능
* strength - short 만 가능
* custom - choice, short 둘 다 가능

해당 3가지 모든 경우에 대한 테스트를 진행하였습니다


## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
