### PR TITLE
[fix] : coverage-exclude.luffy 개행 버그 수정

### DIFF
--- a/coverage-exclude.luffy
+++ b/coverage-exclude.luffy
@@ -56,5 +56,4 @@ exclude me/nalab/survey/web/adaptor/findtarget/*
 exclude me/nalab/auth/mock/interceptor/*
 exclude me/nalab/survey/web/adaptor/updatetarget/*
 exclude me/nalab/survey/web/adaptor/findfeedback/formtype/*
-
 exclude me/nalab/api/sentry/*


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
coverage-exclude.luffy 개행에 버그가 있어서 수정했습니다.

## 어떻게 해결했나요?
- [x] exclude 라인 사이의 잘못된 개행 제거

## 이슈 넘버
- closes #340 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
