### PR TITLE
[test] : survey 존재 유무 확인 인수테스트 추가

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
@@ -53,6 +53,15 @@ public abstract class AbstractSurveyTestSupporter {
 		);
 	}
 
+	protected ResultActions existsSurveyByToken(String token) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.get(API_VERSION + "/surveys/exists")
+			.header("Authorization", token)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+	}
+
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
@@ -84,4 +84,21 @@ public class SurveyAcceptanceValidator {
 		);
 	}
 
+
+	public static void assertIsSurveyExists(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.exists").value(true)
+		);
+	}
+
+	public static void assertIsSurveyDoesNotExists(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.exists").value(false)
+		);
+	}
+
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/exists/SurveyExistsAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/exists/SurveyExistsAcceptanceTest.java
@@ -1,0 +1,77 @@
+package me.nalab.luffy.api.acceptance.test.survey.exists;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.survey.AbstractSurveyTestSupporter;
+import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
+import me.nalab.luffy.api.acceptance.test.survey.SurveyAcceptanceValidator;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = "me.nalab")
+@EntityScan(basePackages = "me.nalab")
+class SurveyExistsAcceptanceTest extends AbstractSurveyTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	@Test
+	@DisplayName("token에 해당하는 survey가 존재한다면, true를 반환한다.")
+	void RETURN_TRUE_IF_SURVEY_EXISTS() throws Exception {
+		// given
+		String token = "luffy's-double-token";
+		Long targetId = targetInitializer.saveTargetAndGetId("devxb", Instant.now());
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedToken(token)
+			.expectedId(targetId)
+			.build()
+		);
+
+		createSurvey(token, RequestSample.DEFAULT_JSON);
+
+		// when
+		ResultActions result = existsSurveyByToken(token);
+
+		// then
+		SurveyAcceptanceValidator.assertIsSurveyExists(result);
+	}
+
+	@Test
+	@DisplayName("token에 해당하는 survey가 존재하지 않는다면, false를 반환한다.")
+	void RETURN_FALSE_IF_SURVEY_DOES_NOT_EXISTS() throws Exception {
+		// given
+		String token = "luffy's-double-token";
+		Long targetId = targetInitializer.saveTargetAndGetId("devxb", Instant.now());
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedToken(token)
+			.expectedId(targetId)
+			.build()
+		);
+
+		// when
+		ResultActions result = existsSurveyByToken(token);
+
+		// then
+		SurveyAcceptanceValidator.assertIsSurveyDoesNotExists(result);
+	}
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
jwt를 인자로 받아, survey가 존재하는지 확인하는 인수테스트를 추가했습니다.

## 어떻게 해결했나요?
- [x] `/v1/surveys/exists` 인수 테스트 추가
- [x] survey 존재 유무 확인 관련 Assert 메소드 추가

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
