### PR TITLE
[feat] : survey 존재 유무 확인 - `jpa-adaptor` 구현 완료

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/AbstractSurveyTestSupporter.java
@@ -53,6 +53,15 @@ public abstract class AbstractSurveyTestSupporter {
 		);
 	}
 
+	protected ResultActions existsSurveyByToken(String token) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.get(API_VERSION + "/surveys/exists")
+			.header("Authorization", token)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+	}
+
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/SurveyAcceptanceValidator.java
@@ -84,4 +84,21 @@ public class SurveyAcceptanceValidator {
 		);
 	}
 
+
+	public static void assertIsSurveyExists(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.exists").value(true)
+		);
+	}
+
+	public static void assertIsSurveyDoesNotExists(ResultActions resultActions) throws Exception {
+		resultActions.andExpectAll(
+			status().isOk(),
+			content().contentType(MediaType.APPLICATION_JSON),
+			jsonPath("$.exists").value(false)
+		);
+	}
+
 }

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/exists/SurveyExistsAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/exists/SurveyExistsAcceptanceTest.java
@@ -1,0 +1,77 @@
+package me.nalab.luffy.api.acceptance.test.survey.exists;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.ResultActions;
+
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.survey.AbstractSurveyTestSupporter;
+import me.nalab.luffy.api.acceptance.test.survey.RequestSample;
+import me.nalab.luffy.api.acceptance.test.survey.SurveyAcceptanceValidator;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = "me.nalab")
+@EntityScan(basePackages = "me.nalab")
+class SurveyExistsAcceptanceTest extends AbstractSurveyTestSupporter {
+
+	@Autowired
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	private TargetInitializer targetInitializer;
+
+	@Test
+	@DisplayName("token에 해당하는 survey가 존재한다면, true를 반환한다.")
+	void RETURN_TRUE_IF_SURVEY_EXISTS() throws Exception {
+		// given
+		String token = "luffy's-double-token";
+		Long targetId = targetInitializer.saveTargetAndGetId("devxb", Instant.now());
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedToken(token)
+			.expectedId(targetId)
+			.build()
+		);
+
+		createSurvey(token, RequestSample.DEFAULT_JSON);
+
+		// when
+		ResultActions result = existsSurveyByToken(token);
+
+		// then
+		SurveyAcceptanceValidator.assertIsSurveyExists(result);
+	}
+
+	@Test
+	@DisplayName("token에 해당하는 survey가 존재하지 않는다면, false를 반환한다.")
+	void RETURN_FALSE_IF_SURVEY_DOES_NOT_EXISTS() throws Exception {
+		// given
+		String token = "luffy's-double-token";
+		Long targetId = targetInitializer.saveTargetAndGetId("devxb", Instant.now());
+		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
+			.expectedToken(token)
+			.expectedId(targetId)
+			.build()
+		);
+
+		// when
+		ResultActions result = existsSurveyByToken(token);
+
+		// then
+		SurveyAcceptanceValidator.assertIsSurveyDoesNotExists(result);
+	}
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/existsurvey/SurveyExistUseCase.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/existsurvey/SurveyExistUseCase.java
@@ -1,0 +1,16 @@
+package me.nalab.survey.application.port.in.web.existsurvey;
+
+/**
+ * Survey의 존재 유무를 확인하는 인터페이스 입니다.
+ */
+public interface SurveyExistUseCase {
+
+	/**
+	 * targetId를 받아, survey의 존재유무를 반환합니다.
+	 *
+	 * @param targetId survey를 확인할 target의 id
+	 * @return boolean 존재한다면 true, 없다면 false
+	 */
+	boolean isSurveyExistByTargetId(Long targetId);
+
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/existsurvey/SurveyExistUseCase.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/existsurvey/SurveyExistUseCase.java
@@ -11,6 +11,6 @@ public interface SurveyExistUseCase {
 	 * @param targetId survey를 확인할 target의 id
 	 * @return boolean 존재한다면 true, 없다면 false
 	 */
-	boolean isSurveyExistByTargetId(Long targetId);
+	boolean existSurveyByTargetId(Long targetId);
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/existsurvey/SurveyExistPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/existsurvey/SurveyExistPort.java
@@ -1,0 +1,15 @@
+package me.nalab.survey.application.port.out.persistence.existsurvey;
+
+/**
+ * Survey가 존재하는지 확인하는 인터페이스 입니다.
+ */
+public interface SurveyExistPort {
+
+	/**
+	 * targetId 를 인자로 받아, survey가 저장되어 있다면 true, 아니라면 false를 반환하는 인터페이스 입니다.
+	 *
+	 * @param targetId 조회할 survey에 연결된 target-id 입니다.
+	 * @return boolean survey가 있다면 true, 없다면 false를 반환해야 합니다.
+	 */
+	boolean isSurveyExistByTargetId(Long targetId);
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/existsurvey/SurveyExistService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/existsurvey/SurveyExistService.java
@@ -1,0 +1,21 @@
+package me.nalab.survey.application.service.existsurvey;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.port.in.web.existsurvey.SurveyExistUseCase;
+import me.nalab.survey.application.port.out.persistence.existsurvey.SurveyExistPort;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyExistService implements SurveyExistUseCase {
+
+	private final SurveyExistPort surveyExistPort;
+
+	@Override
+	@Transactional(readOnly = true)
+	public boolean isSurveyExistByTargetId(Long targetId) {
+		return surveyExistPort.isSurveyExistByTargetId(targetId);
+	}
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/existsurvey/SurveyExistService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/existsurvey/SurveyExistService.java
@@ -15,7 +15,7 @@ public class SurveyExistService implements SurveyExistUseCase {
 
 	@Override
 	@Transactional(readOnly = true)
-	public boolean isSurveyExistByTargetId(Long targetId) {
+	public boolean existSurveyByTargetId(Long targetId) {
 		return surveyExistPort.isSurveyExistByTargetId(targetId);
 	}
 }

--- a/survey/survey-application/src/main/java/module-info.java
+++ b/survey/survey-application/src/main/java/module-info.java
@@ -36,6 +36,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.in.web.findtarget;
 	exports me.nalab.survey.application.port.in.web.findfeedback.formtype;
 	exports me.nalab.survey.application.port.out.persistence.findfeedback.formtype;
+	exports me.nalab.survey.application.port.out.persistence.existsurvey;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/existsurvey/SurveyExistServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/existsurvey/SurveyExistServiceTest.java
@@ -32,7 +32,7 @@ class SurveyExistServiceTest {
 		Mockito.when(surveyExistPort.isSurveyExistByTargetId(targetId)).thenReturn(true);
 
 		// when
-		boolean result = surveyExistUseCase.isSurveyExistByTargetId(targetId);
+		boolean result = surveyExistUseCase.existSurveyByTargetId(targetId);
 
 		// then
 		Assertions.assertThat(result).isTrue();
@@ -47,7 +47,7 @@ class SurveyExistServiceTest {
 		Mockito.when(surveyExistPort.isSurveyExistByTargetId(targetId)).thenReturn(false);
 
 		// when
-		boolean result = surveyExistUseCase.isSurveyExistByTargetId(targetId);
+		boolean result = surveyExistUseCase.existSurveyByTargetId(targetId);
 
 		// then
 		Assertions.assertThat(result).isFalse();

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/existsurvey/SurveyExistServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/existsurvey/SurveyExistServiceTest.java
@@ -1,0 +1,56 @@
+package me.nalab.survey.application.service.existsurvey;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import me.nalab.survey.application.port.in.web.existsurvey.SurveyExistUseCase;
+import me.nalab.survey.application.port.out.persistence.existsurvey.SurveyExistPort;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {SurveyExistService.class})
+class SurveyExistServiceTest {
+
+	@MockBean
+	private SurveyExistPort surveyExistPort;
+
+	@Autowired
+	private SurveyExistUseCase surveyExistUseCase;
+
+	@Test
+	@DisplayName("surveyExistsUseCase는 targetId에 해당하는 survey가 존재한다면, true를 반환한다.")
+	void RETURN_TRUE_IF_SURVEY_EXISTS() {
+		// given
+		Long targetId = 1L;
+
+		Mockito.when(surveyExistPort.isSurveyExistByTargetId(targetId)).thenReturn(true);
+
+		// when
+		boolean result = surveyExistUseCase.isSurveyExistByTargetId(targetId);
+
+		// then
+		Assertions.assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("surveyExistsUseCase는 targetId에 해당하는 survey가 존재하지 않는다면, false를 반환한다.")
+	void RETURN_FALSE_IF_SURVEY_DOES_NOT_EXISTS() {
+		// given
+		Long targetId = 1L;
+
+		Mockito.when(surveyExistPort.isSurveyExistByTargetId(targetId)).thenReturn(false);
+
+		// when
+		boolean result = surveyExistUseCase.isSurveyExistByTargetId(targetId);
+
+		// then
+		Assertions.assertThat(result).isFalse();
+	}
+
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/existsurvey/SurveyExistAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/existsurvey/SurveyExistAdaptor.java
@@ -1,0 +1,26 @@
+package me.nalab.survey.jpa.adaptor.existsurvey;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.survey.application.port.out.persistence.existsurvey.SurveyExistPort;
+import me.nalab.survey.jpa.adaptor.existsurvey.repository.SurveyFindRepository;
+
+@Repository("existsurvey.SurveyExistAdaptor")
+public class SurveyExistAdaptor implements SurveyExistPort {
+
+	private final SurveyFindRepository surveyFindRepository;
+
+	@Autowired
+	SurveyExistAdaptor(
+		@Qualifier("existsurvey.SurveyFindRepository") SurveyFindRepository surveyFindRepository) {
+		this.surveyFindRepository = surveyFindRepository;
+	}
+
+	@Override
+	public boolean isSurveyExistByTargetId(Long targetId) {
+		return surveyFindRepository.existsByTargetId(targetId);
+	}
+	
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/existsurvey/repository/SurveyFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/existsurvey/repository/SurveyFindRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.existsurvey.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+@Repository("existsurvey.SurveyFindRepository")
+public interface SurveyFindRepository extends JpaRepository<SurveyEntity, Long> {
+	boolean existsByTargetId(Long targetId);
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/SurveyExistAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/SurveyExistAdaptorTest.java
@@ -1,0 +1,80 @@
+package me.nalab.survey.jpa.adaptor.existsurvey;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = SurveyExistAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class SurveyExistAdaptorTest {
+
+	@Autowired
+	private SurveyExistAdaptor surveyExistAdaptor;
+
+	@Autowired
+	private TestSurveyFindRepository testSurveyFindRepository;
+
+	@Autowired
+	private TestTargetRepository testTargetRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("targetID에 해당하는 survey가 존재하는 경우")
+	void FIND_SURVEY_WITH_TARGET_ID_WITH_SURVEY() {
+
+		TargetEntity targetEntity = getTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		testTargetRepository.saveAndFlush(targetEntity);
+		testSurveyFindRepository.saveAndFlush(surveyEntity);
+		entityManager.clear();
+
+		boolean result = testSurveyFindRepository.existsByTargetId(targetEntity.getId());
+		assertTrue(result);
+	}
+
+	@Test
+	@DisplayName("targetID에 해당하는 survey가 존재하지 않는 경우")
+	void FIND_SURVEY_WITH_TARGET_ID_WITH_NO_SURVEY() {
+
+		TargetEntity targetEntity = getTargetEntity();
+
+		testTargetRepository.saveAndFlush(targetEntity);
+		entityManager.clear();
+
+		boolean result = testSurveyFindRepository.existsByTargetId(targetEntity.getId());
+		assertFalse(result);
+	}
+
+	private TargetEntity getTargetEntity() {
+		return TargetEntity.builder()
+			.id(1L)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("nalab")
+			.build();
+	}
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/TestSurveyFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/TestSurveyFindRepository.java
@@ -1,0 +1,10 @@
+package me.nalab.survey.jpa.adaptor.existsurvey;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyFindRepository extends JpaRepository<SurveyEntity, Long> {
+
+	boolean existsByTargetId(Long targetId);
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/TestTargetRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/TestTargetRepository.java
@@ -1,0 +1,9 @@
+package me.nalab.survey.jpa.adaptor.existsurvey;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TestTargetRepository extends JpaRepository<TargetEntity, Long> {
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
**survey 존재 유무 확인** API에 대한 `jpa-adaptor` 부분을 개발 완료했습니다

- [x] port의 구현체인 `SurveyExistAdaptor` 를 구현하고, 이를 이용하는 repository도 정의하였습니다
- [x] `SurveyExistAdaptor` 에 대한 테스트를 작성하고, 예외에 대한 테스트도 추가하였습니다



## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
