### PR TITLE
[feat] : survey 존재 유무 확인 - `jpa-adaptor` 구현 완료

### DIFF
--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/existsurvey/SurveyExistUseCase.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/existsurvey/SurveyExistUseCase.java
@@ -11,6 +11,6 @@ public interface SurveyExistUseCase {
 	 * @param targetId survey를 확인할 target의 id
 	 * @return boolean 존재한다면 true, 없다면 false
 	 */
-	boolean isSurveyExistByTargetId(Long targetId);
+	boolean existSurveyByTargetId(Long targetId);
 
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/existsurvey/SurveyExistService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/existsurvey/SurveyExistService.java
@@ -15,7 +15,7 @@ public class SurveyExistService implements SurveyExistUseCase {
 
 	@Override
 	@Transactional(readOnly = true)
-	public boolean isSurveyExistByTargetId(Long targetId) {
+	public boolean existSurveyByTargetId(Long targetId) {
 		return surveyExistPort.isSurveyExistByTargetId(targetId);
 	}
 }

--- a/survey/survey-application/src/main/java/module-info.java
+++ b/survey/survey-application/src/main/java/module-info.java
@@ -36,6 +36,7 @@ module luffy.survey.application.main {
 	exports me.nalab.survey.application.port.in.web.findtarget;
 	exports me.nalab.survey.application.port.in.web.findfeedback.formtype;
 	exports me.nalab.survey.application.port.out.persistence.findfeedback.formtype;
+	exports me.nalab.survey.application.port.out.persistence.existsurvey;
 
 	requires luffy.survey.domain.main;
 	requires luffy.core.id.generator.id.generator.starter.main;

--- a/survey/survey-application/src/test/java/me/nalab/survey/application/service/existsurvey/SurveyExistServiceTest.java
+++ b/survey/survey-application/src/test/java/me/nalab/survey/application/service/existsurvey/SurveyExistServiceTest.java
@@ -32,7 +32,7 @@ class SurveyExistServiceTest {
 		Mockito.when(surveyExistPort.isSurveyExistByTargetId(targetId)).thenReturn(true);
 
 		// when
-		boolean result = surveyExistUseCase.isSurveyExistByTargetId(targetId);
+		boolean result = surveyExistUseCase.existSurveyByTargetId(targetId);
 
 		// then
 		Assertions.assertThat(result).isTrue();
@@ -47,7 +47,7 @@ class SurveyExistServiceTest {
 		Mockito.when(surveyExistPort.isSurveyExistByTargetId(targetId)).thenReturn(false);
 
 		// when
-		boolean result = surveyExistUseCase.isSurveyExistByTargetId(targetId);
+		boolean result = surveyExistUseCase.existSurveyByTargetId(targetId);
 
 		// then
 		Assertions.assertThat(result).isFalse();

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/existsurvey/SurveyExistAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/existsurvey/SurveyExistAdaptor.java
@@ -1,0 +1,26 @@
+package me.nalab.survey.jpa.adaptor.existsurvey;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.survey.application.port.out.persistence.existsurvey.SurveyExistPort;
+import me.nalab.survey.jpa.adaptor.existsurvey.repository.SurveyFindRepository;
+
+@Repository("existsurvey.SurveyExistAdaptor")
+public class SurveyExistAdaptor implements SurveyExistPort {
+
+	private final SurveyFindRepository surveyFindRepository;
+
+	@Autowired
+	SurveyExistAdaptor(
+		@Qualifier("existsurvey.SurveyFindRepository") SurveyFindRepository surveyFindRepository) {
+		this.surveyFindRepository = surveyFindRepository;
+	}
+
+	@Override
+	public boolean isSurveyExistByTargetId(Long targetId) {
+		return surveyFindRepository.existsByTargetId(targetId);
+	}
+	
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/existsurvey/repository/SurveyFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/existsurvey/repository/SurveyFindRepository.java
@@ -1,0 +1,11 @@
+package me.nalab.survey.jpa.adaptor.existsurvey.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+@Repository("existsurvey.SurveyFindRepository")
+public interface SurveyFindRepository extends JpaRepository<SurveyEntity, Long> {
+	boolean existsByTargetId(Long targetId);
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/SurveyExistAdaptorTest.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/SurveyExistAdaptorTest.java
@@ -1,0 +1,80 @@
+package me.nalab.survey.jpa.adaptor.existsurvey;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import me.nalab.core.data.survey.SurveyEntity;
+import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.survey.Survey;
+import me.nalab.survey.jpa.adaptor.RandomSurveyFixture;
+import me.nalab.survey.jpa.adaptor.common.mapper.SurveyEntityMapper;
+
+@DataJpaTest
+@EnableJpaRepositories
+@EntityScan("me.nalab.core.data")
+@ContextConfiguration(classes = SurveyExistAdaptor.class)
+@TestPropertySource("classpath:h2.properties")
+class SurveyExistAdaptorTest {
+
+	@Autowired
+	private SurveyExistAdaptor surveyExistAdaptor;
+
+	@Autowired
+	private TestSurveyFindRepository testSurveyFindRepository;
+
+	@Autowired
+	private TestTargetRepository testTargetRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("targetID에 해당하는 survey가 존재하는 경우")
+	void FIND_SURVEY_WITH_TARGET_ID_WITH_SURVEY() {
+
+		TargetEntity targetEntity = getTargetEntity();
+		Survey survey = RandomSurveyFixture.createRandomSurvey();
+		SurveyEntity surveyEntity = SurveyEntityMapper.toSurveyEntity(targetEntity.getId(), survey);
+
+		testTargetRepository.saveAndFlush(targetEntity);
+		testSurveyFindRepository.saveAndFlush(surveyEntity);
+		entityManager.clear();
+
+		boolean result = testSurveyFindRepository.existsByTargetId(targetEntity.getId());
+		assertTrue(result);
+	}
+
+	@Test
+	@DisplayName("targetID에 해당하는 survey가 존재하지 않는 경우")
+	void FIND_SURVEY_WITH_TARGET_ID_WITH_NO_SURVEY() {
+
+		TargetEntity targetEntity = getTargetEntity();
+
+		testTargetRepository.saveAndFlush(targetEntity);
+		entityManager.clear();
+
+		boolean result = testSurveyFindRepository.existsByTargetId(targetEntity.getId());
+		assertFalse(result);
+	}
+
+	private TargetEntity getTargetEntity() {
+		return TargetEntity.builder()
+			.id(1L)
+			.createdAt(Instant.now())
+			.updatedAt(Instant.now())
+			.nickname("nalab")
+			.build();
+	}
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/TestSurveyFindRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/TestSurveyFindRepository.java
@@ -1,0 +1,10 @@
+package me.nalab.survey.jpa.adaptor.existsurvey;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.survey.SurveyEntity;
+
+public interface TestSurveyFindRepository extends JpaRepository<SurveyEntity, Long> {
+
+	boolean existsByTargetId(Long targetId);
+}

--- a/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/TestTargetRepository.java
+++ b/survey/survey-jpa-adaptor/src/test/java/me/nalab/survey/jpa/adaptor/existsurvey/TestTargetRepository.java
@@ -1,0 +1,9 @@
+package me.nalab.survey.jpa.adaptor.existsurvey;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import me.nalab.core.data.target.TargetEntity;
+
+public interface TestTargetRepository extends JpaRepository<TargetEntity, Long> {
+
+}


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
**survey 존재 유무 확인** API에 대한 `jpa-adaptor` 부분을 개발 완료했습니다

- [x] port의 구현체인 `SurveyExistAdaptor` 를 구현하고, 이를 이용하는 repository도 정의하였습니다
- [x] `SurveyExistAdaptor` 에 대한 테스트를 작성하고, 예외에 대한 테스트도 추가하였습니다



## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
