### PR TITLE
[test] : `survey 존재 유무 확인` e2e test 추가

### DIFF
--- a/support/e2e/v1_5_target.hurl
+++ b/support/e2e/v1_5_target.hurl
@@ -17,6 +17,17 @@ auth_token: jsonpath "$.access_token"
 
 ##########
 
+GET http://nalab-server:8080/v1/surveys/exists # 질문폼이 없는 상태에서 질문폼 존재 유무 확인 -> false
+Authorization: {{ token_type }} {{ auth_token }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.exists" == false
+
+##########
+
 POST http://nalab-server:8080/v1/surveys # 발급받은 토큰으로 survey를 생성한다
 Authorization: {{ token_type }} {{ auth_token }}
 {
@@ -60,6 +71,17 @@ jsonpath "$.survey_id" exists
 
 [Captures]
 survey_id: jsonpath "$.survey_id"
+
+##########
+
+GET http://nalab-server:8080/v1/surveys/exists # 질문폼이 있는 상태에서 질문폼 존재 유무 확인 -> true
+Authorization: {{ token_type }} {{ auth_token }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.exists" == true
 
 ##########
 


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
`survey 존재 유무 확인` 새로 추가된 API에 대한 e2e test를 추가하였습니다.

과정은 다음과 같이 진행됩니다.

- 회원가입을 한다
- 발급받은 토큰을 저장한다
- [x] **(survey가 없는 상태에서) survey 존재 유무를 확인한다 -> false 인지 확인**
- survey를 생성한다
- [x] **(survey가 있는 상태에서) survey 존재 유무를 확인한다 -> true 인지 확인**
-  ...

기존 v1_5_target 에 해당 api만 추가해서 만들었습니다

## 어떻게 해결했나요?

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
