### PR TITLE
[chore] : HURL verison 4.0.0으로 업그레이드

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,19 +13,27 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+
       - name: docker setup
         uses: docker-practice/actions-setup-docker@master
+
       - name: docker network setup
         run: docker network create e2e-net
+
       - name: run dbms
         run: docker run --rm -it --name database --network e2e-net -e MYSQL_ROOT_PASSWORD=0000 -e MYSQL_DATABASE=luffy -d mysql:8.0.33
+
       - name: build nalab-server
         run: ./gradlew clean build
+
       - name: build nalab-server-docker-image
         run: docker build --tag luffy:e2e --build-arg DB_URL=jdbc:mysql://database:3306/luffy --build-arg DB_USERNAME=root --build-arg DB_PASSWORD=0000 --build-arg JWT_SECRET=fore2e .
+
       - name: run nalab-server
         run: docker run --rm -it --name nalab-server --network e2e-net -d luffy:e2e
+
       - name: build hurl image
         run: docker build --tag hurl:e2e support/e2e/
+
       - name: e2e test
         run: docker run --rm --network e2e-net hurl:e2e

--- a/support/e2e/Dockerfile
+++ b/support/e2e/Dockerfile
@@ -1,4 +1,3 @@
-FROM ghcr.io/orange-opensource/hurl:4.0.0
 FROM amd64/ubuntu:22.04
 
 ENV DOCKERIZE_VERSION v0.6.1
@@ -8,5 +7,10 @@ COPY *.hurl hurls/
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN apt-get install -y curl
+
+RUN curl -k --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/4.0.0/hurl_4.0.0_amd64.deb
+RUN apt-get update && apt-get install -y ./hurl_4.0.0_amd64.deb
 
 ENTRYPOINT dockerize -wait tcp://nalab-server:8080 -timeout 300s && hurl --very-verbose --color --test hurls/*.hurl

--- a/support/e2e/Dockerfile
+++ b/support/e2e/Dockerfile
@@ -1,3 +1,4 @@
+FROM ghcr.io/orange-opensource/hurl:4.0.0
 FROM amd64/ubuntu:22.04
 
 ENV DOCKERIZE_VERSION v0.6.1
@@ -7,10 +8,5 @@ COPY *.hurl hurls/
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
-RUN apt-get install -y curl
-
-RUN curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/4.0.0/hurl_4.0.0_amd64.deb
-RUN apt-get update && apt-get install -y ./hurl_4.0.0_amd64.deb
 
 ENTRYPOINT dockerize -wait tcp://nalab-server:8080 -timeout 300s && hurl --very-verbose --color --test hurls/*.hurl

--- a/support/e2e/Dockerfile
+++ b/support/e2e/Dockerfile
@@ -10,7 +10,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 
 RUN apt-get install -y curl
 
-RUN curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/3.0.1/hurl_3.0.1_amd64.deb
-RUN apt-get update && apt-get install -y ./hurl_3.0.1_amd64.deb
+RUN curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/4.0.0/hurl_4.0.0_amd64.deb
+RUN apt-get update && apt-get install -y ./hurl_4.0.0_amd64.deb
 
 ENTRYPOINT dockerize -wait tcp://nalab-server:8080 -timeout 300s && hurl --very-verbose --color --test hurls/*.hurl


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
HURL 3.0.1 을 사용하고 있었는데, curl중에 SSL 에러가 뜨면서 hurl 다운이 안되네요.
curl로 hurl image 받을때, 인증서 옵션을 꺼놨습니다. 보안 필요한 정보 함께 보내지 않아서, 크게 문제되지 않을거 같아요

_(마침, 3주전 HURL 4.0.0 나왔다고 해서 함께 버전업 PR 날립니다.)_

## 어떻게 해결했나요?
- [x] HURL `3.0.1` -> HURL `4.0.0`
- [x] curl로 이미지 받을때 -k 옵션 추가

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
