### PR TITLE
[fix] : SurveyBookmark 변경감지가 동작하지 않는 버그 수정

### DIFF
--- a/core/data/src/main/java/me/nalab/core/data/target/SurveyBookmarkEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/target/SurveyBookmarkEntity.java
@@ -3,8 +3,14 @@ package me.nalab.core.data.target;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
 public class SurveyBookmarkEntity {
 
     @Column(name = "bookmarked_survey_id")

--- a/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
@@ -1,5 +1,6 @@
 package me.nalab.core.data.target;
 
+import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -11,6 +12,7 @@ import javax.persistence.Table;
 
 import javax.persistence.Version;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -47,7 +49,8 @@ public class TargetEntity extends TimeBaseEntity {
         name = "bookmarked_survey",
         joinColumns = @JoinColumn(name = "target_id")
     )
-    private Set<SurveyBookmarkEntity> bookmarkedSurveys;
+    @Builder.Default
+    private Set<SurveyBookmarkEntity> bookmarkedSurveys = new HashSet<>();
 
     @Version
     @Column(name = "version")

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/bookmark/SurveyBookmarkUseCase.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/in/web/bookmark/SurveyBookmarkUseCase.java
@@ -2,7 +2,7 @@ package me.nalab.survey.application.port.in.web.bookmark;
 
 import me.nalab.survey.application.common.survey.dto.SurveyBookmarkDto;
 
-public interface SurveyBookmarkReplaceUseCase {
+public interface SurveyBookmarkUseCase {
 
     /**
      * targetId에 해당하는 유저에게 survey를 북마크합니다.

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/bookmark/SurveyBookmarkPort.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/port/out/persistence/bookmark/SurveyBookmarkPort.java
@@ -1,0 +1,8 @@
+package me.nalab.survey.application.port.out.persistence.bookmark;
+
+import me.nalab.survey.domain.target.Target;
+
+public interface SurveyBookmarkPort {
+
+    void bookmark(Target target);
+}

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/bookmark/SurveyBookmarkService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/bookmark/SurveyBookmarkService.java
@@ -3,7 +3,8 @@ package me.nalab.survey.application.service.bookmark;
 import lombok.RequiredArgsConstructor;
 import me.nalab.survey.application.common.survey.dto.SurveyBookmarkDto;
 import me.nalab.survey.application.exception.SurveyDoesNotExistException;
-import me.nalab.survey.application.port.in.web.bookmark.SurveyBookmarkReplaceUseCase;
+import me.nalab.survey.application.port.in.web.bookmark.SurveyBookmarkUseCase;
+import me.nalab.survey.application.port.out.persistence.bookmark.SurveyBookmarkPort;
 import me.nalab.survey.application.port.out.persistence.findfeedback.SurveyExistCheckPort;
 import me.nalab.survey.application.port.out.persistence.findtarget.TargetFindPort;
 import org.springframework.stereotype.Service;
@@ -11,10 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class SurveyBookmarkReplaceService implements SurveyBookmarkReplaceUseCase {
+public class SurveyBookmarkService implements SurveyBookmarkUseCase {
 
     private final TargetFindPort targetFindPort;
     private final SurveyExistCheckPort surveyExistCheckPort;
+    private final SurveyBookmarkPort surveyBookmarkPort;
 
     @Override
     @Transactional
@@ -26,6 +28,7 @@ public class SurveyBookmarkReplaceService implements SurveyBookmarkReplaceUseCas
         }
 
         target.bookmark(surveyId);
+        surveyBookmarkPort.bookmark(target);
 
         return SurveyBookmarkDto.from(surveyId, target);
     }

--- a/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -25,6 +25,7 @@ public class Target implements IdGeneratable {
     private final String nickname;
     private final String job;
     private final String imageUrl;
+    @Builder.Default
     private final Set<SurveyBookmark> bookmarkedSurveys = NONE_BOOKMARKED_SURVEYS;
     private String position;
 

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/SurveyBookmarkAdaptor.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/bookmark/SurveyBookmarkAdaptor.java
@@ -1,0 +1,24 @@
+package me.nalab.survey.jpa.adaptor.bookmark;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.survey.application.exception.TargetDoesNotExistException;
+import me.nalab.survey.application.port.out.persistence.bookmark.SurveyBookmarkPort;
+import me.nalab.survey.domain.target.Target;
+import me.nalab.survey.jpa.adaptor.common.mapper.TargetEntityMapper;
+import me.nalab.survey.jpa.adaptor.find.repository.TargetFindRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SurveyBookmarkAdaptor implements SurveyBookmarkPort {
+
+    private final TargetFindRepository targetFindRepository;
+
+    @Override
+    public void bookmark(Target target) {
+        var savedTarget = targetFindRepository.findById(target.getId())
+            .orElseThrow(() -> new TargetDoesNotExistException(target.getId()));
+
+        savedTarget.setBookmarkedSurveys(TargetEntityMapper.toSurveyBookmarkEntity(target.getBookmarkedSurveys()));
+    }
+}

--- a/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/TargetEntityMapper.java
+++ b/survey/survey-jpa-adaptor/src/main/java/me/nalab/survey/jpa/adaptor/common/mapper/TargetEntityMapper.java
@@ -1,6 +1,10 @@
 package me.nalab.survey.jpa.adaptor.common.mapper;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import me.nalab.core.data.target.SurveyBookmarkEntity;
 import me.nalab.core.data.target.TargetEntity;
+import me.nalab.survey.domain.target.SurveyBookmark;
 import me.nalab.survey.domain.target.Target;
 
 public class TargetEntityMapper {
@@ -16,8 +20,15 @@ public class TargetEntityMapper {
 			.position(target.getPosition())
 			.imageUrl(target.getImageUrl())
 			.job(target.getJob())
+			.bookmarkedSurveys(toSurveyBookmarkEntity(target.getBookmarkedSurveys()))
 			.build();
 	}
+
+    public static Set<SurveyBookmarkEntity> toSurveyBookmarkEntity(Set<SurveyBookmark> surveyBookmarks) {
+        return surveyBookmarks.stream()
+            .map(surveyBookmark -> new SurveyBookmarkEntity(surveyBookmark.surveyId()))
+            .collect(Collectors.toSet());
+    }
 
 	public static Target toTarget(TargetEntity targetEntity) {
 		return Target.builder()
@@ -25,6 +36,13 @@ public class TargetEntityMapper {
 			.nickname(targetEntity.getNickname())
 			.position(targetEntity.getPosition())
 			.job(targetEntity.getJob())
+            .bookmarkedSurveys(toSurveyBookmark(targetEntity.getBookmarkedSurveys()))
 			.build();
 	}
+
+    public static Set<SurveyBookmark> toSurveyBookmark(Set<SurveyBookmarkEntity> surveyBookmarkEntities) {
+        return surveyBookmarkEntities.stream()
+            .map(surveyBookmarkEntity -> new SurveyBookmark(surveyBookmarkEntity.getSurveyId()))
+            .collect(Collectors.toSet());
+    }
 }

--- a/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/bookmark/SurveyBookmarkReplaceController.java
+++ b/survey/survey-web-adaptor/src/main/java/me/nalab/survey/web/adaptor/bookmark/SurveyBookmarkReplaceController.java
@@ -1,7 +1,7 @@
 package me.nalab.survey.web.adaptor.bookmark;
 
 import lombok.RequiredArgsConstructor;
-import me.nalab.survey.application.port.in.web.bookmark.SurveyBookmarkReplaceUseCase;
+import me.nalab.survey.application.port.in.web.bookmark.SurveyBookmarkUseCase;
 import me.nalab.survey.web.adaptor.bookmark.response.SurveyBookmarkResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SurveyBookmarkReplaceController {
 
-    private final SurveyBookmarkReplaceUseCase surveyBookmarkReplaceUseCase;
+    private final SurveyBookmarkUseCase surveyBookmarkReplaceUseCase;
 
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/surveys/{survey_id}/bookmarks")


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Survey에 북마크를 해도 변경감지가 동작하지 않아서, 반영되지 않는 버그를 수정했습니다.

## 어떻게 해결했나요?
- [x] SurveyBookmarkPort 생성 및 구현
- [x] lombok의 Builder 사용시, `@Builder.Default` 가 없으면 다른값을 넣을 수 없어서, `@Builder.Default` 추가
- [x] EntityMapper에 bookmark 매핑 추가

## 이슈 넘버
- close #377 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
