### PR TITLE
[feat]: 로그인한 유저의 gallery조회 기능 추가

### DIFF
--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptorConfigurer.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptorConfigurer.java
@@ -30,6 +30,7 @@ public class JwtDecryptInterceptorConfigurer implements WebMvcConfigurer {
 		"/v1/gallerys/previews",
 		"/v1/surveys/*/bookmarks",
 		"/v1/gallerys/logins",
+		"/v1/gallerys",
 	};
 
 	@Override

--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptorConfigurer.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptorConfigurer.java
@@ -29,7 +29,7 @@ public class JwtDecryptInterceptorConfigurer implements WebMvcConfigurer {
 		"/v1/users",
 		"/v1/gallerys/previews",
 		"/v1/surveys/*/bookmarks",
-		"/v1/gallerys",
+		"/v1/gallerys/logins",
 	};
 
 	@Override

--- a/gallery/src/main/kotlin/me/nalab/gallery/app/GalleryGetApp.kt
+++ b/gallery/src/main/kotlin/me/nalab/gallery/app/GalleryGetApp.kt
@@ -1,0 +1,24 @@
+package me.nalab.gallery.app
+
+import me.nalab.gallery.domain.GalleryService
+import me.nalab.gallery.domain.response.GalleryDto
+import me.nalab.survey.application.port.`in`.web.findfeedback.FeedbackFindUseCase
+import me.nalab.survey.application.port.`in`.web.survey.find.SurveyFindUseCase
+import me.nalab.survey.application.port.`in`.web.target.find.TargetFindUseCase
+
+class GalleryGetApp(
+    private val targetFindUseCase: TargetFindUseCase,
+    private val surveyFindUseCase: SurveyFindUseCase,
+    private val feedbackFindUseCase: FeedbackFindUseCase,
+    private val galleryService: GalleryService,
+) {
+
+    fun getGalleryByTargetId(targetId: Long): GalleryDto {
+        val gallery = galleryService.getGalleryByTargetId(targetId)
+        val target = targetFindUseCase.findTarget(targetId)
+        val survey = surveyFindUseCase.getSurveyByTargetId(targetId)
+        val feedbacks = feedbackFindUseCase.findAllFeedbackDtoBySurveyId(survey.id)
+
+        return toGalleryDto(gallery, target, survey, feedbacks)
+    }
+}

--- a/gallery/src/main/kotlin/me/nalab/gallery/app/GalleryGetApp.kt
+++ b/gallery/src/main/kotlin/me/nalab/gallery/app/GalleryGetApp.kt
@@ -5,7 +5,9 @@ import me.nalab.gallery.domain.response.GalleryDto
 import me.nalab.survey.application.port.`in`.web.findfeedback.FeedbackFindUseCase
 import me.nalab.survey.application.port.`in`.web.survey.find.SurveyFindUseCase
 import me.nalab.survey.application.port.`in`.web.target.find.TargetFindUseCase
+import org.springframework.stereotype.Service
 
+@Service
 class GalleryGetApp(
     private val targetFindUseCase: TargetFindUseCase,
     private val surveyFindUseCase: SurveyFindUseCase,

--- a/gallery/src/main/kotlin/me/nalab/gallery/controller/GalleryController.kt
+++ b/gallery/src/main/kotlin/me/nalab/gallery/controller/GalleryController.kt
@@ -1,5 +1,6 @@
 package me.nalab.gallery.controller
 
+import me.nalab.gallery.app.GalleryGetApp
 import me.nalab.gallery.app.GalleryPreviewApp
 import me.nalab.gallery.app.GalleryRegisterApp
 import me.nalab.gallery.controller.request.GalleryRegisterRequest
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/v1/gallerys")
 class GalleryController(
+    private val galleryGetApp: GalleryGetApp,
     private val galleryPreviewApp: GalleryPreviewApp,
     private val galleryRegisterApp: GalleryRegisterApp,
 ) {
@@ -28,5 +30,10 @@ class GalleryController(
     ): GalleryDto {
         return galleryRegisterApp.registerGalleryByTargetId(targetId, request.job)
     }
+
+    @GetMapping("/logins")
+    @ResponseStatus(HttpStatus.OK)
+    fun getGallery(@RequestAttribute("logined") targetId: Long): GalleryDto =
+        galleryGetApp.getGalleryByTargetId(targetId)
 
 }

--- a/gallery/src/main/kotlin/me/nalab/gallery/domain/GalleryService.kt
+++ b/gallery/src/main/kotlin/me/nalab/gallery/domain/GalleryService.kt
@@ -4,9 +4,15 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional(readOnly = true)
 class GalleryService(
     private val galleryRepository: GalleryRepository,
 ) {
+
+    fun getGalleryByTargetId(targetId: Long): Gallery {
+        return galleryRepository.findByTargetIdOrNull(targetId)
+            ?: throw IllegalArgumentException("targetId \"$targetId\" 에 해당하는 Gallery를 찾을 수 없습니다.")
+    }
 
     @Transactional
     fun registerGallery(gallery: Gallery): Gallery {

--- a/support/e2e/v1_10_get_logined_gallery.hurl
+++ b/support/e2e/v1_10_get_logined_gallery.hurl
@@ -1,0 +1,220 @@
+POST http://nalab-server:8080/v1/oauth/default # Default provider를 통해서 로그인 진행
+{
+    "nickname": "logined_gallery",
+    "email": "loginedgallery@123456"
+}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.access_token" exists
+jsonpath "$.token_type" exists
+
+[Captures]
+token_type: jsonpath "$.token_type"
+auth_token: jsonpath "$.access_token"
+
+##########
+
+POST http://nalab-server:8080/v1/surveys # 발급받은 토큰으로 survey를 생성한다.
+Authorization: {{ token_type }} {{ auth_token }}
+{
+    "question_count": 2,
+    "question": [
+        {
+            "type": "choice",
+            "form_type": "tendency",
+            "title": "저는 UI, UI, GUI 중에 어떤 분야를 가장 잘하는 것 같나요?",
+            "choices": [
+                {
+                    "content": "UI",
+                    "order": 1
+                },
+                {
+                    "content": "UX",
+                    "order": 2
+                },
+                {
+                    "content": "GUI",
+                    "order": 3
+                }
+            ],
+            "max_selectable_count": 1,
+            "order": 1
+        },
+        {
+            "type": "short",
+            "form_type": "strength",
+            "title": "저는 UX, UI, GUI 중에 어떤 분야에 더 강점이 있나요?",
+            "order": 2
+        }
+    ]
+}
+
+HTTP 201
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.survey_id" exists
+
+[Captures]
+survey_id: jsonpath "$.survey_id"
+
+##########
+
+GET http://nalab-server:8080/v1/surveys/{{ survey_id }} # 생성된 survey를 조회한다.
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.survey_id" exists
+
+jsonpath "$.target.id" exists
+jsonpath "$.target.nickname" == "logined_gallery"
+
+jsonpath "$.question_count" == 2
+jsonpath "$.question.[0].question_id" exists
+jsonpath "$.question.[0].type" == "choice"
+jsonpath "$.question.[0].form_type" == "tendency"
+jsonpath "$.question.[0].title" == "저는 UI, UI, GUI 중에 어떤 분야를 가장 잘하는 것 같나요?"
+jsonpath "$.question.[0].order" == 1
+jsonpath "$.question.[0].max_selectable_count" == 1
+jsonpath "$.question.[0].choices.[0].choice_id" exists
+jsonpath "$.question.[0].choices.[0].content" == "UI"
+jsonpath "$.question.[0].choices.[0].order" == 1
+jsonpath "$.question.[0].choices.[1].choice_id" exists
+jsonpath "$.question.[0].choices.[1].content" == "UX"
+jsonpath "$.question.[0].choices.[1].order" == 2
+jsonpath "$.question.[0].choices.[2].choice_id" exists
+jsonpath "$.question.[0].choices.[2].content" == "GUI"
+jsonpath "$.question.[0].choices.[2].order" == 3
+jsonpath "$.question.[1].question_id" exists
+jsonpath "$.question.[1].type" == "short"
+jsonpath "$.question.[1].form_type" == "strength"
+jsonpath "$.question.[1].title" == "저는 UX, UI, GUI 중에 어떤 분야에 더 강점이 있나요?"
+jsonpath "$.question.[1].order" == 2
+
+[Captures]
+target_id: jsonpath "$.target.id"
+tendency_question_id: jsonpath "$.question.[0].question_id"
+tendency_question_choice_id: jsonpath "$.question.[0].choices.[0].choice_id"
+strength_question_id: jsonpath "$.question.[1].question_id"
+
+
+##########
+
+POST http://nalab-server:8080/v1/surveys/{{ survey_id }}/bookmarks # survey_id를 북마크한다.
+Authorization: {{ token_type }} {{ auth_token }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.target_id" == {{ target_id }}
+jsonpath "$.survey_id" == {{ survey_id }}
+jsonpath "$.nickname" == "logined_gallery"
+
+##########
+
+POST http://nalab-server:8080/v1/feedbacks # 생성된 survey에 feedback을 남긴다.
+
+[QueryStringParams]
+survey-id: {{ survey_id }}
+
+{
+    "reviewer": {
+        "collaboration_experience": true,
+        "position": "pm"
+    },
+    "question_feedback": [
+        {
+            "question_id": {{ tendency_question_id }},
+            "type": "choice",
+            "choices": [
+                {{ tendency_question_choice_id }}
+            ]
+        },
+        {
+            "question_id": {{ strength_question_id }},
+            "type": "short",
+            "reply": [
+                "Hello world"
+            ]
+        }
+    ]
+}
+
+HTTP 201
+[Asserts]
+
+##########
+
+GET http://nalab-server:8080/v1/feedbacks # 북마크를 위해 feedback id 저장
+Authorization: {{ token_type }} {{ auth_token }}
+
+[QueryStringParams]
+survey-id: {{ survey_id }}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+[Captures]
+form_question_feedback_id: jsonpath "$.question_feedback.[0].feedbacks.[0].form_question_feedback_id"
+
+##########
+
+PATCH http://nalab-server:8080/v1/feedbacks/bookmarks # 북마크를 진행한다.
+Authorization: {{ token_type }} {{ auth_token }}
+
+[QueryStringParams]
+form-question-feedback-id: {{form_question_feedback_id}}
+
+##########
+
+POST http://nalab-server:8080/v1/gallerys # gallery를 등록한다
+Authorization: {{ token_type }} {{ auth_token }}
+{
+    "job": "designer"
+}
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.target.target_id" == {{ target_id }}
+jsonpath "$.target.nickname" == "logined_gallery"
+jsonpath "$.target.position" == null
+jsonpath "$.target.job" == "DESIGNER"
+jsonpath "$.target.image_url" == "empty_image"
+
+jsonpath "$.survey.survey_id" == {{ survey_id }}
+jsonpath "$.survey.feedback_count" == 1
+jsonpath "$.survey.bookmarked_count" == 1
+jsonpath "$.survey.feedbacks.[0]" == "Hello world"
+jsonpath "$.survey.tendencies.[0].name" == "UI"
+jsonpath "$.survey.tendencies.[0].count" == 1
+
+##########
+
+GET http://nalab-server:8080/v1/gallerys/logins # 내 gallery 를 조회한다
+
+HTTP 200
+[Asserts]
+header "Content-type" == "application/json"
+
+jsonpath "$.target.target_id" == {{ target_id }}
+jsonpath "$.target.nickname" == "logined_gallery"
+jsonpath "$.target.position" == null
+jsonpath "$.target.job" == "DESIGNER"
+jsonpath "$.target.image_url" == "empty_image"
+
+jsonpath "$.survey.survey_id" == {{ survey_id }}
+jsonpath "$.survey.feedback_count" == 1
+jsonpath "$.survey.bookmarked_count" == 1
+jsonpath "$.survey.feedbacks.[0]" == "Hello world"
+jsonpath "$.survey.tendencies.[0].name" == "UI"
+jsonpath "$.survey.tendencies.[0].count" == 1
+

--- a/support/e2e/v1_10_get_logined_gallery.hurl
+++ b/support/e2e/v1_10_get_logined_gallery.hurl
@@ -200,6 +200,7 @@ jsonpath "$.survey.tendencies.[0].count" == 1
 ##########
 
 GET http://nalab-server:8080/v1/gallerys/logins # 내 gallery 를 조회한다
+Authorization: {{ token_type }} {{ auth_token }}
 
 HTTP 200
 [Asserts]


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
로그인한 유저의 gallery 조회기능을 추가했습니다.

## 어떻게 해결했나요?
- [x] gallery 를 조회하고, 조회된 gallery의 targetId, surveyId로 targetDto, surveyDto 가져오도록 구성
- [x] e2e 테스트 작성

## 이슈 넘버
- close #360 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
