### PR TITLE
[refactor]: survey 도메인 kotlin 리팩토링

### DIFF
--- a/survey/build.gradle
+++ b/survey/build.gradle
@@ -1,0 +1,11 @@
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(":core:data")
+
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+
+    testRuntimeOnly "com.h2database:h2"
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Bookmark.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Bookmark.kt
@@ -1,0 +1,19 @@
+package me.nalab.survey.domain.feedback
+
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class Bookmark(
+    @Column(name = "is_bookmarked", nullable = false)
+    var isBookmarked: Boolean = BOOKMARK_DEFAULT_STATE,
+
+    @Column(name = "bookmarked_at", columnDefinition = "TIMESTAMP(6)", nullable = false)
+    var bookmarkedAt: Instant,
+) {
+
+    companion object {
+        private const val BOOKMARK_DEFAULT_STATE = false
+    }
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/ChoiceFormQuestionFeedback.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/ChoiceFormQuestionFeedback.kt
@@ -4,7 +4,7 @@ import javax.persistence.*
 
 @Entity
 class ChoiceFormQuestionFeedback(
-    id: Long? = null,
+    id: Long,
     formQuestionId: Long,
     isRead: Boolean = false,
     bookmark: Bookmark,

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/ChoiceFormQuestionFeedback.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/ChoiceFormQuestionFeedback.kt
@@ -1,0 +1,17 @@
+package me.nalab.survey.domain.feedback
+
+import javax.persistence.*
+
+@Entity
+class ChoiceFormQuestionFeedback(
+    id: Long? = null,
+    formQuestionId: Long,
+    isRead: Boolean = false,
+    bookmark: Bookmark,
+    feedback: Feedback,
+
+    @ElementCollection
+    @Column(name = "selects")
+    @CollectionTable(name = "selects", joinColumns = [JoinColumn(name = "form_feedback_id")])
+    private val selectedChoiceIds: MutableSet<Long>,
+) : FormQuestionFeedbackable(id, formQuestionId, isRead, bookmark, feedback)

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Feedback.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Feedback.kt
@@ -1,0 +1,50 @@
+package me.nalab.survey.domain.feedback
+
+import me.nalab.core.data.common.TimeBaseEntity
+import javax.persistence.*
+
+@Entity(name = "feedback")
+@Table(name = "feedback")
+class Feedback(
+    @Id
+    @Column(name = "feedback_id")
+    private var id: Long? = null,
+
+    @JoinColumn(name = "survey_id", nullable = false)
+    private val surveyId: Long,
+
+    @OneToMany(
+        mappedBy = "feedback",
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.PERSIST, CascadeType.MERGE]
+    )
+    private val allQuestionFeedbacks: MutableList<FormQuestionFeedbackable>,
+
+    @Column(name = "is_read", nullable = false)
+    private var isRead: Boolean = false,
+
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE])
+    private val reviewer: Reviewer,
+) : Comparable<Feedback>, TimeBaseEntity() {
+
+    fun read(read: Boolean) {
+        isRead = read
+    }
+
+    override fun compareTo(other: Feedback): Int {
+        if (updatedAt.isAfter(other.updatedAt)) {
+            return -1
+        }
+        if (updatedAt.isBefore(other.updatedAt)) {
+            return 1
+        }
+        if (createdAt.isAfter(other.createdAt)) {
+            return -1
+        }
+        if (createdAt.isBefore(other.createdAt)) {
+            return 1
+        }
+        return 0
+    }
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Feedback.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Feedback.kt
@@ -8,28 +8,47 @@ import javax.persistence.*
 class Feedback(
     @Id
     @Column(name = "feedback_id")
-    private var id: Long? = null,
+    val id: Long,
 
     @JoinColumn(name = "survey_id", nullable = false)
-    private val surveyId: Long,
+    val surveyId: Long,
 
     @OneToMany(
         mappedBy = "feedback",
         fetch = FetchType.LAZY,
         cascade = [CascadeType.PERSIST, CascadeType.MERGE]
     )
-    private val allQuestionFeedbacks: MutableList<FormQuestionFeedbackable>,
+    val allQuestionFeedbacks: MutableList<FormQuestionFeedbackable>,
 
     @Column(name = "is_read", nullable = false)
     private var isRead: Boolean = false,
 
     @JoinColumn(name = "reviewer_id", nullable = false)
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE])
-    private val reviewer: Reviewer,
+    val reviewer: Reviewer,
 ) : Comparable<Feedback>, TimeBaseEntity() {
 
     fun read(read: Boolean) {
         isRead = read
+    }
+
+    fun generateFirstReviewerNickName() {
+        reviewer.nickName = "A"
+    }
+
+    fun generateNickName(lastName: String) {
+        reviewer.nickName = getNextNickName(lastName)
+    }
+
+    private fun getNextNickName(lastName: String): String {
+        for (i in lastName.length - 1 downTo 0) {
+            if (lastName[i] != 'Z') {
+                return lastName.substring(0, i) + (lastName[i].code + 1).toChar() + "A".repeat(
+                    lastName.length - (i + 1)
+                )
+            }
+        }
+        return "A".repeat(Math.max(0, lastName.length + 1))
     }
 
     override fun compareTo(other: Feedback): Int {

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/FormQuestionFeedbackable.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/FormQuestionFeedbackable.kt
@@ -1,0 +1,37 @@
+package me.nalab.survey.domain.feedback
+
+import java.time.Instant
+import javax.persistence.*
+
+@Entity
+@Table(name = "form_feedback")
+abstract class FormQuestionFeedbackable(
+    @Id
+    @Column(name = "form_feedback_id")
+    protected open var id: Long? = null,
+
+    @Column(name = "form_question_id")
+    @JoinColumn(name = "form_question_id", nullable = false)
+    protected open val formQuestionId: Long,
+
+    @Column(name = "is_read")
+    protected open var isRead: Boolean = false,
+
+    @Embedded
+    protected open val bookmark: Bookmark,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feedback_id")
+    private var feedback: Feedback,
+) {
+
+    fun bookmark() {
+        bookmark.isBookmarked = true
+        bookmark.bookmarkedAt = Instant.now()
+    }
+
+    fun cancel() {
+        bookmark.isBookmarked = false
+        bookmark.bookmarkedAt = Instant.now()
+    }
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/FormQuestionFeedbackable.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/FormQuestionFeedbackable.kt
@@ -1,6 +1,5 @@
 package me.nalab.survey.domain.feedback
 
-import java.time.Instant
 import javax.persistence.*
 
 @Entity
@@ -8,30 +7,19 @@ import javax.persistence.*
 abstract class FormQuestionFeedbackable(
     @Id
     @Column(name = "form_feedback_id")
-    protected open var id: Long? = null,
+    open val id: Long,
 
     @Column(name = "form_question_id")
     @JoinColumn(name = "form_question_id", nullable = false)
-    protected open val formQuestionId: Long,
+    open val formQuestionId: Long,
 
     @Column(name = "is_read")
-    protected open var isRead: Boolean = false,
+    open var isRead: Boolean = false,
 
     @Embedded
-    protected open val bookmark: Bookmark,
+    open val bookmark: Bookmark,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feedback_id")
-    private var feedback: Feedback,
-) {
-
-    fun bookmark() {
-        bookmark.isBookmarked = true
-        bookmark.bookmarkedAt = Instant.now()
-    }
-
-    fun cancel() {
-        bookmark.isBookmarked = false
-        bookmark.bookmarkedAt = Instant.now()
-    }
-}
+    val feedback: Feedback,
+)

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Reviewer.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Reviewer.kt
@@ -1,0 +1,44 @@
+package me.nalab.survey.domain.feedback
+
+import me.nalab.core.data.common.TimeBaseEntity
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity(name = "reviewer")
+@Table(name = "reviewer")
+class Reviewer(
+    @Id
+    @Column(name = "reviewer_id")
+    private var id: Long? = null,
+
+    @Column(name = "nick_name", nullable = false)
+    private var nickName: String,
+
+    @Column(name = "collaboration_experience", nullable = false)
+    private val collaborationExperience: Boolean,
+
+    @Column(name = "position", nullable = false)
+    private var position: String? = null,
+) : TimeBaseEntity() {
+
+    fun generateFirstReviewerNickName() {
+        nickName = "A"
+    }
+
+    fun generateNickName(lastName: String) {
+        nickName = getNextNickName(lastName)
+    }
+
+    private fun getNextNickName(lastName: String): String {
+        for (i in lastName.length - 1 downTo 0) {
+            if (lastName[i] != 'Z') {
+                return lastName.substring(0, i) + (lastName[i].code + 1).toChar() + "A".repeat(
+                    lastName.length - (i + 1)
+                )
+            }
+        }
+        return "A".repeat(Math.max(0, lastName.length + 1))
+    }
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Reviewer.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/Reviewer.kt
@@ -11,34 +11,14 @@ import javax.persistence.Table
 class Reviewer(
     @Id
     @Column(name = "reviewer_id")
-    private var id: Long? = null,
+    val id: Long,
 
     @Column(name = "nick_name", nullable = false)
-    private var nickName: String,
+    var nickName: String,
 
     @Column(name = "collaboration_experience", nullable = false)
-    private val collaborationExperience: Boolean,
+    val collaborationExperience: Boolean,
 
     @Column(name = "position", nullable = false)
-    private var position: String? = null,
-) : TimeBaseEntity() {
-
-    fun generateFirstReviewerNickName() {
-        nickName = "A"
-    }
-
-    fun generateNickName(lastName: String) {
-        nickName = getNextNickName(lastName)
-    }
-
-    private fun getNextNickName(lastName: String): String {
-        for (i in lastName.length - 1 downTo 0) {
-            if (lastName[i] != 'Z') {
-                return lastName.substring(0, i) + (lastName[i].code + 1).toChar() + "A".repeat(
-                    lastName.length - (i + 1)
-                )
-            }
-        }
-        return "A".repeat(Math.max(0, lastName.length + 1))
-    }
-}
+    var position: String? = null,
+) : TimeBaseEntity()

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/ShortFormQuestionFeedback.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/ShortFormQuestionFeedback.kt
@@ -1,0 +1,17 @@
+package me.nalab.survey.domain.feedback
+
+import javax.persistence.*
+
+@Entity
+class ShortFormQuestionFeedback(
+    id: Long? = null,
+    formQuestionId: Long,
+    isRead: Boolean = false,
+    bookmark: Bookmark,
+    feedback: Feedback,
+
+    @ElementCollection
+    @CollectionTable(name = "reply", joinColumns = [JoinColumn(name = "form_feedback_id")])
+    @Column(name = "replies")
+    private val replies: MutableList<String>,
+) : FormQuestionFeedbackable(id, formQuestionId, isRead, bookmark, feedback)

--- a/survey/src/main/kotlin/me/nalab/survey/domain/feedback/ShortFormQuestionFeedback.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/feedback/ShortFormQuestionFeedback.kt
@@ -4,7 +4,7 @@ import javax.persistence.*
 
 @Entity
 class ShortFormQuestionFeedback(
-    id: Long? = null,
+    id: Long,
     formQuestionId: Long,
     isRead: Boolean = false,
     bookmark: Bookmark,
@@ -13,5 +13,5 @@ class ShortFormQuestionFeedback(
     @ElementCollection
     @CollectionTable(name = "reply", joinColumns = [JoinColumn(name = "form_feedback_id")])
     @Column(name = "replies")
-    private val replies: MutableList<String>,
+    val replies: MutableList<String>,
 ) : FormQuestionFeedbackable(id, formQuestionId, isRead, bookmark, feedback)

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/Choice.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/Choice.kt
@@ -1,0 +1,28 @@
+package me.nalab.survey.domain.survey
+
+import javax.persistence.*
+
+@Entity(name = "choice")
+@Table(name = "choice")
+class Choice(
+
+    @Id
+    @Column(name = "choice_id")
+    private var id: Long? = null,
+
+    @Column(name = "content", length = 18, nullable = false)
+    private val content: String,
+
+    @Column(name = "orders", nullable = false)
+    val order: Int,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "form_question_id", nullable = false)
+    private val choiceFormQuestion: ChoiceFormQuestion,
+) : Comparable<Choice> {
+
+    override fun compareTo(other: Choice): Int {
+        return Comparator.comparingInt { obj: Choice -> obj.order }
+            .compare(this, other)
+    }
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/Choice.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/Choice.kt
@@ -8,17 +8,17 @@ class Choice(
 
     @Id
     @Column(name = "choice_id")
-    private var id: Long? = null,
+    val id: Long,
 
     @Column(name = "content", length = 18, nullable = false)
-    private val content: String,
+    val content: String,
 
     @Column(name = "orders", nullable = false)
     val order: Int,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "form_question_id", nullable = false)
-    private val choiceFormQuestion: ChoiceFormQuestion,
+    val choiceFormQuestion: ChoiceFormQuestion,
 ) : Comparable<Choice> {
 
     override fun compareTo(other: Choice): Int {

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/ChoiceFormQuestion.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/ChoiceFormQuestion.kt
@@ -1,0 +1,44 @@
+package me.nalab.survey.domain.survey
+
+import me.nalab.survey.domain.survey.exception.DuplicatedOrderException
+import javax.persistence.*
+
+@Entity
+class ChoiceFormQuestion(
+    id: Long? = null,
+    title: String,
+    order: Int,
+    questionType: QuestionType,
+    survey: Survey,
+
+    @OneToMany(
+        mappedBy = "choiceFormQuestion",
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.PERSIST, CascadeType.MERGE],
+    )
+    private val choices: MutableList<Choice>,
+
+    @Column(name = "max_selection_count")
+    private val maxSelectableCount: Int,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "choice_question_type")
+    private val choiceFormQuestionType: ChoiceFormQuestionType,
+) : FormQuestionable(id, title, order, questionType, survey) {
+
+    init {
+        choices.sorted()
+        validNoDuplicatedChoiceOrder(choices)
+    }
+
+    private fun validNoDuplicatedChoiceOrder(choiceList: List<Choice>) {
+        val orders = HashSet<Int>()
+        choiceList.forEach { choice ->
+            val order: Int = choice.order
+            if (orders.contains(order)) {
+                throw DuplicatedOrderException(order, orders)
+            }
+            orders.add(order)
+        }
+    }
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/ChoiceFormQuestion.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/ChoiceFormQuestion.kt
@@ -5,7 +5,7 @@ import javax.persistence.*
 
 @Entity
 class ChoiceFormQuestion(
-    id: Long? = null,
+    id: Long,
     title: String,
     order: Int,
     questionType: QuestionType,
@@ -16,14 +16,14 @@ class ChoiceFormQuestion(
         fetch = FetchType.LAZY,
         cascade = [CascadeType.PERSIST, CascadeType.MERGE],
     )
-    private val choices: MutableList<Choice>,
+    val choices: MutableList<Choice>,
 
     @Column(name = "max_selection_count")
-    private val maxSelectableCount: Int,
+    val maxSelectableCount: Int,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "choice_question_type")
-    private val choiceFormQuestionType: ChoiceFormQuestionType,
+    val choiceFormQuestionType: ChoiceFormQuestionType,
 ) : FormQuestionable(id, title, order, questionType, survey) {
 
     init {

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/ChoiceFormQuestionType.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/ChoiceFormQuestionType.kt
@@ -1,0 +1,6 @@
+package me.nalab.survey.domain.survey
+
+enum class ChoiceFormQuestionType {
+    TENDENCY,
+    CUSTOM,
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/FormQuestionable.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/FormQuestionable.kt
@@ -1,7 +1,6 @@
 package me.nalab.survey.domain.survey
 
 import me.nalab.core.data.common.TimeBaseEntity
-import java.util.function.LongSupplier
 import javax.persistence.*
 
 @Entity
@@ -9,26 +8,22 @@ import javax.persistence.*
 abstract class FormQuestionable(
     @Id
     @Column(name = "form_question_id")
-    open var id: Long? = null,
+    open val id: Long,
 
     @Column(name = "title", nullable = false, length = 45)
-    protected open val title: String,
+    open val title: String,
 
     @Column(name = "orders", nullable = false)
     open val order: Int,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "question_type")
-    protected open val questionType: QuestionType,
+    open val questionType: QuestionType,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "survey_id", nullable = false)
     open val survey: Survey,
 ) : Comparable<FormQuestionable>, TimeBaseEntity() {
-
-    protected open fun cascadeId(idSupplier: LongSupplier) {
-        return
-    }
 
     override fun compareTo(other: FormQuestionable): Int {
         return Comparator.comparingInt { obj: FormQuestionable -> obj.order }

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/FormQuestionable.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/FormQuestionable.kt
@@ -1,0 +1,37 @@
+package me.nalab.survey.domain.survey
+
+import me.nalab.core.data.common.TimeBaseEntity
+import java.util.function.LongSupplier
+import javax.persistence.*
+
+@Entity
+@Table(name = "form_question")
+abstract class FormQuestionable(
+    @Id
+    @Column(name = "form_question_id")
+    open var id: Long? = null,
+
+    @Column(name = "title", nullable = false, length = 45)
+    protected open val title: String,
+
+    @Column(name = "orders", nullable = false)
+    open val order: Int,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "question_type")
+    protected open val questionType: QuestionType,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", nullable = false)
+    open val survey: Survey,
+) : Comparable<FormQuestionable>, TimeBaseEntity() {
+
+    protected open fun cascadeId(idSupplier: LongSupplier) {
+        return
+    }
+
+    override fun compareTo(other: FormQuestionable): Int {
+        return Comparator.comparingInt { obj: FormQuestionable -> obj.order }
+            .compare(this, other)
+    }
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/QuestionType.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/QuestionType.kt
@@ -1,0 +1,6 @@
+package me.nalab.survey.domain.survey
+
+enum class QuestionType {
+    CHOICE,
+    SHORT,
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/ShortFormQuestion.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/ShortFormQuestion.kt
@@ -4,7 +4,7 @@ import javax.persistence.*
 
 @Entity
 class ShortFormQuestion(
-    id: Long? = null,
+    id: Long,
     title: String,
     order: Int,
     questionType: QuestionType,
@@ -12,5 +12,5 @@ class ShortFormQuestion(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "short_form_question_type")
-    private val shortFormQuestionType: ShortFormQuestionType,
+    val shortFormQuestionType: ShortFormQuestionType,
 ) : FormQuestionable(id, title, order, questionType, survey)

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/ShortFormQuestion.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/ShortFormQuestion.kt
@@ -1,0 +1,16 @@
+package me.nalab.survey.domain.survey
+
+import javax.persistence.*
+
+@Entity
+class ShortFormQuestion(
+    id: Long? = null,
+    title: String,
+    order: Int,
+    questionType: QuestionType,
+    survey: Survey,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "short_form_question_type")
+    private val shortFormQuestionType: ShortFormQuestionType,
+) : FormQuestionable(id, title, order, questionType, survey)

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/ShortFormQuestionType.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/ShortFormQuestionType.kt
@@ -1,0 +1,7 @@
+package me.nalab.survey.domain.survey
+
+enum class ShortFormQuestionType {
+    STRENGTH,
+    WEAKNESS,
+    CUSTOM,
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/Survey.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/Survey.kt
@@ -9,18 +9,18 @@ import javax.persistence.*
 class Survey(
     @Id
     @Column(name = "gallery_id")
-    private var id: Long? = null,
+    val id: Long,
 
     @OneToMany(
         mappedBy = "survey",
         fetch = FetchType.LAZY,
         cascade = [CascadeType.PERSIST, CascadeType.MERGE]
     )
-    private val formQuestionables: MutableList<FormQuestionable>,
+    val formQuestionables: MutableList<FormQuestionable>,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "target_id")
-    private val target: Target,
+    val target: Target,
 ) : TimeBaseEntity() {
 
     init {

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/Survey.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/Survey.kt
@@ -1,0 +1,41 @@
+package me.nalab.survey.domain.survey
+
+import me.nalab.core.data.common.TimeBaseEntity
+import me.nalab.survey.domain.survey.exception.DuplicatedOrderException
+import javax.persistence.*
+
+@Table(name = "survey")
+@Entity(name = "survey")
+class Survey(
+    @Id
+    @Column(name = "gallery_id")
+    private var id: Long? = null,
+
+    @OneToMany(
+        mappedBy = "survey",
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.PERSIST, CascadeType.MERGE]
+    )
+    private val formQuestionables: MutableList<FormQuestionable>,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id")
+    private val target: Target,
+) : TimeBaseEntity() {
+
+    init {
+        formQuestionables.sorted()
+        validNoDuplicatedFormOrder()
+    }
+
+    private fun validNoDuplicatedFormOrder() {
+        val orders = HashSet<Int>()
+        this.formQuestionables.forEach { formQuestion ->
+            val order: Int = formQuestion.order
+            if (orders.contains(order)) {
+                throw DuplicatedOrderException(order, orders)
+            }
+            orders.add(order)
+        }
+    }
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/SurveyBookmark.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/SurveyBookmark.kt
@@ -1,0 +1,12 @@
+package me.nalab.survey.domain.survey
+
+import javax.persistence.Column
+import javax.persistence.Embeddable
+import javax.persistence.JoinColumn
+
+@Embeddable
+class SurveyBookmark(
+    @Column(name = "bookmarked_survey_id")
+    @JoinColumn(name = "survey_id", nullable = false)
+    val surveyId: Long
+)

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/SurveyRepository.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/SurveyRepository.kt
@@ -1,0 +1,5 @@
+package me.nalab.survey.domain.survey
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SurveyRepository : JpaRepository<Survey, Long>

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/Target.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/Target.kt
@@ -34,10 +34,6 @@ class Target(
     private var version: Long? = null
 ) : TimeBaseEntity() {
 
-    fun setPosition(position: String) {
-        this.position = position
-    }
-
     fun bookmark(surveyId: Long) {
         val bookmark = SurveyBookmark(surveyId)
         bookmarkedSurveys.add(bookmark)

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/Target.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/Target.kt
@@ -8,23 +8,26 @@ import javax.persistence.*
 class Target(
     @Id
     @Column(name = "target_id")
-    private var id: Long? = null,
+    val id: Long,
 
     @Column(name = "target_name", nullable = false)
-    private val nickname: String,
+    val nickname: String,
 
     @Column(name = "job", columnDefinition = "TEXT")
-    private val job: String,
+    val job: String,
 
     @Column(name = "image_url", columnDefinition = "TEXT")
-    private val imageUrl: String,
+    val imageUrl: String,
 
     @Column(name = "position")
-    private var position: String? = null,
+    var position: String? = null,
+
+    @OneToMany(mappedBy = "target", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+    val survey: Survey,
 
     @ElementCollection
     @CollectionTable(name = "bookmarked_survey", joinColumns = [JoinColumn(name = "target_id")])
-    private val bookmarkedSurveys: MutableSet<SurveyBookmark> = NONE_BOOKMARKED_SURVEYS,
+    val bookmarkedSurveys: MutableSet<SurveyBookmark> = NONE_BOOKMARKED_SURVEYS,
 
     @Version
     @Column(name = "version")

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/Target.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/Target.kt
@@ -1,0 +1,46 @@
+package me.nalab.survey.domain.survey
+
+import me.nalab.core.data.common.TimeBaseEntity
+import javax.persistence.*
+
+@Entity
+@Table(name = "target")
+class Target(
+    @Id
+    @Column(name = "target_id")
+    private var id: Long? = null,
+
+    @Column(name = "target_name", nullable = false)
+    private val nickname: String,
+
+    @Column(name = "job", columnDefinition = "TEXT")
+    private val job: String,
+
+    @Column(name = "image_url", columnDefinition = "TEXT")
+    private val imageUrl: String,
+
+    @Column(name = "position")
+    private var position: String? = null,
+
+    @ElementCollection
+    @CollectionTable(name = "bookmarked_survey", joinColumns = [JoinColumn(name = "target_id")])
+    private val bookmarkedSurveys: MutableSet<SurveyBookmark> = NONE_BOOKMARKED_SURVEYS,
+
+    @Version
+    @Column(name = "version")
+    private var version: Long? = null
+) : TimeBaseEntity() {
+
+    fun setPosition(position: String) {
+        this.position = position
+    }
+
+    fun bookmark(surveyId: Long) {
+        val bookmark = SurveyBookmark(surveyId)
+        bookmarkedSurveys.add(bookmark)
+    }
+
+    companion object {
+        private val NONE_BOOKMARKED_SURVEYS: MutableSet<SurveyBookmark> = HashSet()
+    }
+}

--- a/survey/src/main/kotlin/me/nalab/survey/domain/survey/exception/DuplicatedOrderException.kt
+++ b/survey/src/main/kotlin/me/nalab/survey/domain/survey/exception/DuplicatedOrderException.kt
@@ -1,0 +1,6 @@
+package me.nalab.survey.domain.survey.exception
+
+class DuplicatedOrderException internal constructor(duplicated: Int, orders: HashSet<Int>) :
+    RuntimeException(
+        "Duplicated order detected duplicated \"$duplicated\" ordinary \"$orders\""
+    )


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Survey 도메인을 kotlin으로 리팩토링 했습니다

## 어떻게 해결했나요?
- [x] Survey 어그리거트 루트 -> Target 
	기존 도메인 열어보니 Target하나에 여러개의 Survey가 되는거로 구성되어있어서 어그리거트 루트를 Target으로 지정했습니다.
- [x] Feedback 어그리거트 루트 -> Feedback
- [x] IdGenerator와 같은 복잡한 로직 삭제 (밖에서 넣어주는게 이해하기 편할듯) 했습니다. 

## 이슈 넘버
- close #384 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
