### PR TITLE
[fix] : bookmark 카운트가 bookmark한 대상에게 증가하는 버그 수정

### DIFF
--- a/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
@@ -54,6 +54,6 @@ public class TargetEntity extends TimeBaseEntity {
 
     @Version
     @Column(name = "version")
-    private Long version = 0L;
+    private Long version;
 
 }

--- a/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
+++ b/core/data/src/main/java/me/nalab/core/data/target/TargetEntity.java
@@ -54,6 +54,6 @@ public class TargetEntity extends TimeBaseEntity {
 
     @Version
     @Column(name = "version")
-    private Long version;
+    private Long version = 0L;
 
 }

--- a/gallery/src/test/kotlin/me/nalab/gallery/domain/GalleryServiceTest.kt
+++ b/gallery/src/test/kotlin/me/nalab/gallery/domain/GalleryServiceTest.kt
@@ -65,6 +65,8 @@ internal class GalleryServiceTest(
 
     describe("getGalleries 메소드는") {
         beforeEach {
+            galleryRepository.deleteAll()
+
             galleryService.registerGallery(oldDesignerGallery)
             galleryService.registerGallery(midDeveloperGallery)
             galleryService.registerGallery(latestPmGallery)
@@ -150,6 +152,33 @@ internal class GalleryServiceTest(
             }
         }
     }
+
+    describe("increaseBookmarkCount 메소드는") {
+        context("targetId를 입력받으면,") {
+            galleryService.registerGallery(defaultGallery)
+            galleryService.increaseBookmarkCount(EXIST_TARGET_ID)
+
+            it("targetId에 해당하는 target gallery의 bookmarked count를 증가시킨다.") {
+                val gallery = galleryService.getGalleryByTargetId(EXIST_TARGET_ID)
+
+                gallery.getBookmarkedCount() shouldBeEqual 1
+            }
+        }
+    }
+
+    describe("decreaseBookmarkCount 메소드는") {
+        context("targetId를 입력받으면,") {
+            galleryService.registerGallery(defaultGallery)
+            galleryService.increaseBookmarkCount(EXIST_TARGET_ID)
+            galleryService.decreaseBookmarkCount(EXIST_TARGET_ID)
+
+            it("targetId에 해당하는 target gallery의 bookmarked count를 감소 시킨다.") {
+                val gallery = galleryService.getGalleryByTargetId(EXIST_TARGET_ID)
+
+                gallery.getBookmarkedCount() shouldBeEqual 0
+            }
+        }
+    }
 }) {
 
     companion object {
@@ -161,6 +190,15 @@ internal class GalleryServiceTest(
         val updatePage: PageRequest = PageRequest.of(0, 5, Sort.by("updateOrder").descending())
         val bookmarkPage: PageRequest =
             PageRequest.of(0, 5, Sort.by("survey.bookmarkedCount").descending())
+
+        val defaultGallery = gallery(
+            id = EXIST_GALLERY_ID,
+            targetId = EXIST_TARGET_ID,
+            surveyId = EXIST_SURVEY_ID,
+            job = Job.DESIGNER,
+            updateOrder = TimeUtil.toInstant().minus(1, ChronoUnit.DAYS),
+            bookmarkedCount = 0
+        )
 
         val oldDesignerGallery = gallery(
             id = 1,

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/bookmark/SurveyBookmarkService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/bookmark/SurveyBookmarkService.java
@@ -2,11 +2,13 @@ package me.nalab.survey.application.service.bookmark;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.survey.application.exception.SurveyDoesNotExistException;
+import me.nalab.survey.application.exception.TargetDoesNotHasSurveyException;
 import me.nalab.survey.application.port.in.web.bookmark.SurveyBookmarkUseCase;
 import me.nalab.survey.application.port.out.persistence.bookmark.SurveyBookmarkListenPort;
 import me.nalab.survey.application.port.out.persistence.bookmark.SurveyBookmarkPort;
 import me.nalab.survey.application.port.out.persistence.findfeedback.SurveyExistCheckPort;
 import me.nalab.survey.application.port.out.persistence.findtarget.TargetFindPort;
+import me.nalab.survey.application.port.out.persistence.findtarget.TargetIdFindPort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SurveyBookmarkService implements SurveyBookmarkUseCase {
 
     private final TargetFindPort targetFindPort;
+    private final TargetIdFindPort targetIdFindPort;
     private final SurveyExistCheckPort surveyExistCheckPort;
     private final SurveyBookmarkPort surveyBookmarkPort;
     private final SurveyBookmarkListenPort surveyBookmarkListener;
@@ -28,10 +31,13 @@ public class SurveyBookmarkService implements SurveyBookmarkUseCase {
             throw new SurveyDoesNotExistException(surveyId);
         }
 
-        target.bookmark(surveyId);
+        var bookmarkSuccess = target.bookmark(surveyId);
+        if (bookmarkSuccess) {
+            var bookmarkTargetId = targetIdFindPort.findTargetIdBySurveyId(surveyId)
+                .orElseThrow(() -> new TargetDoesNotHasSurveyException(surveyId));
+            surveyBookmarkListener.increaseBookmarked(bookmarkTargetId);
+        }
         surveyBookmarkPort.updateBookmark(target);
-
-        surveyBookmarkListener.increaseBookmarked(targetId);
     }
 
     @Override
@@ -43,9 +49,12 @@ public class SurveyBookmarkService implements SurveyBookmarkUseCase {
             throw new SurveyDoesNotExistException(surveyId);
         }
 
-        target.cancelBookmark(surveyId);
+        var cancelSuccess = target.cancelBookmark(surveyId);
+        if (cancelSuccess) {
+            var bookmarkTargetId = targetIdFindPort.findTargetIdBySurveyId(surveyId)
+                .orElseThrow(() -> new TargetDoesNotHasSurveyException(surveyId));
+            surveyBookmarkListener.decreaseBookmarked(bookmarkTargetId);
+        }
         surveyBookmarkPort.updateBookmark(target);
-
-        surveyBookmarkListener.decreaseBookmarked(targetId);
     }
 }

--- a/survey/survey-application/src/main/java/me/nalab/survey/application/service/bookmark/SurveyBookmarkService.java
+++ b/survey/survey-application/src/main/java/me/nalab/survey/application/service/bookmark/SurveyBookmarkService.java
@@ -36,8 +36,8 @@ public class SurveyBookmarkService implements SurveyBookmarkUseCase {
             var bookmarkTargetId = targetIdFindPort.findTargetIdBySurveyId(surveyId)
                 .orElseThrow(() -> new TargetDoesNotHasSurveyException(surveyId));
             surveyBookmarkListener.increaseBookmarked(bookmarkTargetId);
+            surveyBookmarkPort.updateBookmark(target);
         }
-        surveyBookmarkPort.updateBookmark(target);
     }
 
     @Override
@@ -54,7 +54,7 @@ public class SurveyBookmarkService implements SurveyBookmarkUseCase {
             var bookmarkTargetId = targetIdFindPort.findTargetIdBySurveyId(surveyId)
                 .orElseThrow(() -> new TargetDoesNotHasSurveyException(surveyId));
             surveyBookmarkListener.decreaseBookmarked(bookmarkTargetId);
+            surveyBookmarkPort.updateBookmark(target);
         }
-        surveyBookmarkPort.updateBookmark(target);
     }
 }

--- a/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
+++ b/survey/survey-domain/src/main/java/me/nalab/survey/domain/target/Target.java
@@ -2,7 +2,6 @@ package me.nalab.survey.domain.target;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.LongSupplier;
 import lombok.Builder;
@@ -42,15 +41,21 @@ public class Target implements IdGeneratable {
         this.position = position;
     }
 
-    public void bookmark(Long surveyId) {
+    public boolean bookmark(Long surveyId) {
         var bookmark = new SurveyBookmark(surveyId);
+        if (bookmarkedSurveys.contains(bookmark)) {
+            return false;
+        }
         bookmarkedSurveys.add(bookmark);
+        return true;
     }
 
-    public void cancelBookmark(Long surveyId) {
-        bookmarkedSurveys.stream()
-            .filter(surveyBookmark -> Objects.equals(surveyBookmark.surveyId(), surveyId))
-            .findFirst()
-            .ifPresent(bookmarkedSurveys::remove);
+    public boolean cancelBookmark(Long surveyId) {
+        var canceledBookmark = new SurveyBookmark(surveyId);
+        if (bookmarkedSurveys.contains(canceledBookmark)) {
+            bookmarkedSurveys.remove(canceledBookmark);
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
북마크를 누른 대상의 북마크된 카운트 가 증가하는 버그를 수정했습니다.

## 어떻게 해결했나요?
- [x] 북마크 / 북마크 취소 여부에 상관없이 숫자가 감소 증가하는 버그 수정
- [x] `북마크 당한 대상`의 북마크 카운트 증가하도록 수정

<!--
## 이슈 넘버
-->

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
