### PR TITLE
fix: JWT decrypt 예외시 AuthException을 던지도록하고, 전역 Advice를 등록

### DIFF
--- a/auth/auth-application/src/main/java/me/nalab/auth/application/common/exception/AuthException.java
+++ b/auth/auth-application/src/main/java/me/nalab/auth/application/common/exception/AuthException.java
@@ -1,0 +1,8 @@
+package me.nalab.auth.application.common.exception;
+
+public class AuthException extends RuntimeException {
+
+    public AuthException(String message) {
+        super(message);
+    }
+}

--- a/auth/auth-application/src/main/java/me/nalab/auth/application/common/utils/JwtUtils.java
+++ b/auth/auth-application/src/main/java/me/nalab/auth/application/common/utils/JwtUtils.java
@@ -1,10 +1,16 @@
 package me.nalab.auth.application.common.utils;
 
+import com.auth0.jwt.exceptions.AlgorithmMismatchException;
+import com.auth0.jwt.exceptions.IncorrectClaimException;
+import com.auth0.jwt.exceptions.MissingClaimException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import me.nalab.auth.application.common.exception.AuthException;
 import org.springframework.stereotype.Component;
 
 import com.auth0.jwt.JWT;
@@ -33,7 +39,16 @@ public class JwtUtils {
 		var algorithm = getAlgorithm();
 		var verifier = getVerifier(algorithm);
 
-		return verifier.verify(jwt);
+		try {
+			return verifier.verify(jwt);
+		} catch (TokenExpiredException tokenExpiredException) {
+			throw new AuthException("Expired token");
+		} catch (IncorrectClaimException
+				 | MissingClaimException
+				 | SignatureVerificationException
+				 | AlgorithmMismatchException invalidTokenException) {
+			throw new AuthException("Invalid token");
+		}
 	}
 
 	private JWTVerifier getVerifier(Algorithm algorithm) {

--- a/auth/auth-application/src/main/java/module-info.java
+++ b/auth/auth-application/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module luffy.auth.auth.application.main {
 	exports me.nalab.auth.application.port.in.web;
 	exports me.nalab.auth.application.port.in;
 	exports me.nalab.auth.application.port.out;
+	exports me.nalab.auth.application.common.exception;
 
 	requires lombok;
 	requires com.fasterxml.jackson.annotation;

--- a/auth/auth-web-adaptor/build.gradle
+++ b/auth/auth-web-adaptor/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation project(':auth:auth-application')
     implementation project(':auth:oauth-application')
+    implementation project(':core:exception-handler')
     testImplementation project(':auth:auth-application')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/auth/auth-web-adaptor/src/main/java/me/nalab/auth/web/adaptor/advice/AuthControllerAdvice.java
+++ b/auth/auth-web-adaptor/src/main/java/me/nalab/auth/web/adaptor/advice/AuthControllerAdvice.java
@@ -1,0 +1,19 @@
+package me.nalab.auth.web.adaptor.advice;
+
+import me.nalab.auth.application.common.exception.AuthException;
+import me.nalab.core.exception.handler.ErrorTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class AuthControllerAdvice {
+
+    @ExceptionHandler(AuthException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorTemplate handleAuthException(AuthException authException) {
+        return ErrorTemplate.of(authException.getMessage());
+    }
+
+}

--- a/auth/auth-web-adaptor/src/main/java/module-info.java
+++ b/auth/auth-web-adaptor/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module luffy.auth.auth.web.adaptor.main {
 
     requires luffy.auth.auth.application.main;
     requires luffy.auth.oauth.application.main;
+    requires luffy.core.exception.handler.main;
 
     requires lombok;
     requires java.validation;

--- a/core/exception-handler/src/main/java/module-info.java
+++ b/core/exception-handler/src/main/java/module-info.java
@@ -1,4 +1,6 @@
 module luffy.core.exception.handler.main {
+	exports me.nalab.core.exception.handler;
+
 	requires spring.web;
 	requires lombok;
 	requires com.fasterxml.jackson.annotation;


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
Jwt decrypt 예외시 500 에러가 발생하고 있어서, 핸들링 로직을 추가했습니다.

## 어떻게 해결했나요?
- [x] JWT decrypt 과정에서 예외 발생시 AuthException 던지도록 수정
- [x] 전역 AuthExceptionHandler 추가


## 이슈 넘버
- close #402 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
