### PR TITLE
feat: User 삭제 API 개발

### DIFF
--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/bookmark/BookmarkReplaceAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/bookmark/BookmarkReplaceAcceptanceTest.java
@@ -58,7 +58,7 @@ class BookmarkReplaceAcceptanceTest extends AbstractFeedbackTestSupporter {
 
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("target", Instant.now());
-		String token = "token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedId(targetId)
 			.expectedToken(token)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/FeedbackCreateAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/create/FeedbackCreateAcceptanceTest.java
@@ -66,7 +66,7 @@ class FeedbackCreateAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void CREATE_FEEDBACK_TO_SURVEY_SUCCESS() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("nalab", Instant.now());
-		String token = "nalab-token";
+		String token = "bearer nalab-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)
@@ -88,7 +88,7 @@ class FeedbackCreateAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void CREATE_MULTIPLE_FEEDBACK_TO_SURVEY_SUCCESS() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello", Instant.now());
-		String token = "hello-token";
+		String token = "bearer hello-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindAcceptanceTest.java
@@ -55,7 +55,7 @@ class FeedbackFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FIND_FEED_BACK_SUCCESS() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
-		String token = "mock token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedId(targetId)
 			.expectedToken(token)
@@ -79,7 +79,7 @@ class FeedbackFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FIND_FEED_BACK_SUCCESS_ANY_FEEDBACK() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
-		String token = "mock token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedId(targetId)
 			.expectedToken(token)
@@ -112,7 +112,7 @@ class FeedbackFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FIND_BOOKMARKED_FEED_BACK_SUCCESS_ANY_FEEDBACK() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
-		String token = "mock token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 																	.expectedId(targetId)
 																	.expectedToken(token)
@@ -130,7 +130,7 @@ class FeedbackFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	private Long setUpSurveyAndFeedbackAndBookmark() throws Exception {
 		// 유저 생성
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
-		String token = "mock token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 																	.expectedId(targetId)
 																	.expectedToken(token)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindByTypeAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/find/FeedbackFindByTypeAcceptanceTest.java
@@ -63,7 +63,7 @@ class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FIND_FEEDBACK_BY_FORM_TYPE_TENDENCY() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
-		String token = "mock token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedId(targetId)
 			.expectedToken(token)
@@ -86,7 +86,7 @@ class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FIND_FEEDBACK_BY_FORM_TYPE_CUSTOM() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
-		String token = "mock token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedId(targetId)
 			.expectedToken(token)
@@ -109,7 +109,7 @@ class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FIND_FEEDBACK_BY_TYPE_TENDENCY_WITH_NO_FEEDBACK() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
-		String token = "mock token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedId(targetId)
 			.expectedToken(token)
@@ -129,7 +129,7 @@ class FeedbackFindByTypeAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FIND_FEEDBACK_BY_TYPE_CUSTOM_WITH_NO_FEEDBACK() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("hello world", Instant.now());
-		String token = "mock token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedId(targetId)
 			.expectedToken(token)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findreviewers/ReviewersFindAcceptanceTest.java
@@ -64,7 +64,7 @@ class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FEEDBACKS_WITH_NO_REVIEWER_TEST() throws Exception {
 
 		// given
-		String token = "token";
+		String token = "bearer token";
 		Long targetId = targetInitializer.saveTargetAndGetId("sujin", Instant.now());
 		applicationEventPublisher.publishEvent(
 			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());
@@ -84,7 +84,7 @@ class ReviewersFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FEEDBACKS_WITH_REVIEWERS_TEST() throws Exception {
 
 		// given
-		String token = "token";
+		String token = "bearer token";
 		Long targetId = targetInitializer.saveTargetAndGetId("sujin", Instant.now());
 		applicationEventPublisher.publishEvent(
 			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findspecific/SpecificFindAcceptanceTest.java
@@ -63,7 +63,7 @@ public class SpecificFindAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FIND_SPECIFIC_FEEDBACK_SUCCESS_TEST() throws Exception {
 
 		// given
-		String token = "token";
+		String token = "bearer token";
 		Long targetId = targetInitializer.saveTargetAndGetId("sujin", Instant.now());
 		applicationEventPublisher.publishEvent(
 			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummary/FeedbackFindSummaryAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/findsummary/FeedbackFindSummaryAcceptanceTest.java
@@ -63,7 +63,7 @@ class FeedbackFindSummaryAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FEEFBACK_SUMMARY_FIND_SUCCESS_TEST_WITH_NO_FEEDBACK() throws Exception {
 
 		// given
-		String token = "token";
+		String token = "bearer token";
 		Long targetId = targetInitializer.saveTargetAndGetId("sujin", Instant.now());
 		applicationEventPublisher.publishEvent(
 			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());
@@ -81,7 +81,7 @@ class FeedbackFindSummaryAcceptanceTest extends AbstractFeedbackTestSupporter {
 	void FEEFBACK_SUMMARY_FIND_SUCCESS_TEST_WITH_FEEDBACK() throws Exception {
 
 		// given
-		String token = "token";
+		String token = "bearer token";
 		Long targetId = targetInitializer.saveTargetAndGetId("sujin", Instant.now());
 		applicationEventPublisher.publishEvent(
 			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/reviewer/summary/ReviewerSummarizeAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/feedback/reviewer/summary/ReviewerSummarizeAcceptanceTest.java
@@ -97,7 +97,7 @@ class ReviewerSummarizeAcceptanceTest extends AbstractFeedbackTestSupporter {
 
 	private String saveTargetAndGetToken(String name) {
 		Long targetId = targetInitializer.saveTargetAndGetId("nalab", Instant.now());
-		String token = "nalab-token";
+		String token = "bearer nalab-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/bookmark/SurveyBookmarkAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/bookmark/SurveyBookmarkAcceptanceTest.java
@@ -43,7 +43,7 @@ class SurveyBookmarkAcceptanceTest extends AbstractSurveyTestSupporter {
         // given
         var targetId = targetInitializer.saveTargetAndGetId("luffy",
             LocalDateTime.now().minusYears(24).toInstant(ZoneOffset.UTC));
-        var token = "luffy's-double-token";
+        var token = "bearer luffy's-double-token";
         applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
             .expectedToken(token)
             .expectedId(targetId)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/SurveyCreateAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/create/SurveyCreateAcceptanceTest.java
@@ -49,7 +49,7 @@ class SurveyCreateAcceptanceTest extends AbstractSurveyTestSupporter {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("luffy",
 			LocalDateTime.now().minusYears(24).toInstant(ZoneOffset.UTC));
-		String token = "luffy's-double-token";
+		String token = "bearer luffy's-double-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)
@@ -68,7 +68,7 @@ class SurveyCreateAcceptanceTest extends AbstractSurveyTestSupporter {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("luffy",
 			LocalDateTime.now().minusYears(24).toInstant(ZoneOffset.UTC));
-		String token = "luffy's-double-token";
+		String token = "bearer luffy's-double-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)
@@ -86,7 +86,7 @@ class SurveyCreateAcceptanceTest extends AbstractSurveyTestSupporter {
 	void CREATE_NEW_SURVEY_WITH_FAIL() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("luffy", LocalDateTime.now().minusYears(24).toInstant(ZoneOffset.UTC));
-		String token = "luffy's-double-token";
+		String token = "bearer luffy's-double-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/exists/SurveyExistsAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/exists/SurveyExistsAcceptanceTest.java
@@ -38,7 +38,7 @@ class SurveyExistsAcceptanceTest extends AbstractSurveyTestSupporter {
 	@DisplayName("token에 해당하는 survey가 존재한다면, true를 반환한다.")
 	void RETURN_TRUE_IF_SURVEY_EXISTS() throws Exception {
 		// given
-		String token = "luffy's-double-token";
+		String token = "bearer luffy's-double-token";
 		Long targetId = targetInitializer.saveTargetAndGetId("devxb", Instant.now());
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
@@ -59,7 +59,7 @@ class SurveyExistsAcceptanceTest extends AbstractSurveyTestSupporter {
 	@DisplayName("token에 해당하는 survey가 존재하지 않는다면, false를 반환한다.")
 	void RETURN_FALSE_IF_SURVEY_DOES_NOT_EXISTS() throws Exception {
 		// given
-		String token = "luffy's-double-token";
+		String token = "bearer luffy's-double-token";
 		Long targetId = targetInitializer.saveTargetAndGetId("devxb", Instant.now());
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/find/SurveyFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/find/SurveyFindAcceptanceTest.java
@@ -38,7 +38,7 @@ class SurveyFindAcceptanceTest extends AbstractSurveyTestSupporter {
 	@Test
 	void SURVEY_FIND_SUCCESS_TEST() throws Exception {
 
-		String token = "luffy's-double-token";
+		String token = "bearer luffy's-double-token";
 		Long targetId = targetInitializer.saveTargetAndGetId("sujin", Instant.now());
 		applicationEventPublisher.publishEvent(
 			MockUserRegisterEvent.builder().expectedToken(token).expectedId(targetId).build());

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/findid/SurveyFindidAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/findid/SurveyFindidAcceptanceTest.java
@@ -41,7 +41,7 @@ class SurveyFindidAcceptanceTest extends AbstractSurveyTestSupporter {
 	void GET_LOGINED_SURVEY_ID_SUCCESS() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("nalab", Instant.now());
-		String token = "nalab-token";
+		String token = "bearer nalab-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)
@@ -60,7 +60,7 @@ class SurveyFindidAcceptanceTest extends AbstractSurveyTestSupporter {
 	void GET_LOGINED_SURVEY_ID_FAIL_NO_SURVEY() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("nalab", Instant.now());
-		String token = "nalab-token";
+		String token = "bearer nalab-token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/findtarget/TargetFindAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/survey/findtarget/TargetFindAcceptanceTest.java
@@ -59,7 +59,7 @@ class TargetFindAcceptanceTest extends AbstractSurveyTestSupporter {
 	void FIND_TARGET_BY_SURVEY_ID_WITH_NO_AUTHORIZATION() throws Exception {
 		// given
 		Long targetId = targetInitializer.saveTargetAndGetId("target", Instant.now());
-		String token = "token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/UserAcceptanceTestSupporter.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/UserAcceptanceTestSupporter.java
@@ -33,6 +33,12 @@ public class UserAcceptanceTestSupporter {
 		);
 	}
 
+	protected ResultActions deleteUser(String token) throws Exception {
+		return mockMvc.perform(MockMvcRequestBuilders
+			.delete(API_VERSION + "/users")
+			.header(HttpHeaders.AUTHORIZATION, token));
+	}
+
 	@Autowired
 	final void setMockMvc(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/delete/UserDeleteAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/delete/UserDeleteAcceptanceTest.java
@@ -1,0 +1,73 @@
+package me.nalab.luffy.api.acceptance.test.user.delete;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.Set;
+import me.nalab.auth.application.common.dto.Payload;
+import me.nalab.auth.application.common.utils.JwtUtils;
+import me.nalab.auth.mock.api.MockUserRegisterEvent;
+import me.nalab.luffy.api.acceptance.test.TargetInitializer;
+import me.nalab.luffy.api.acceptance.test.UserInitializer;
+import me.nalab.luffy.api.acceptance.test.user.UserAcceptanceTestSupporter;
+import me.nalab.user.domain.user.Provider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource("classpath:h2.properties")
+@ComponentScan("me.nalab")
+@EnableJpaRepositories(basePackages = {"me.nalab"})
+@EntityScan(basePackages = {"me.nalab"})
+class UserDeleteAcceptanceTest extends UserAcceptanceTestSupporter {
+
+    @Autowired
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    private TargetInitializer targetInitializer;
+
+    @Autowired
+    private JwtUtils jwtUtils;
+
+    @Autowired
+    private UserInitializer userInitializer;
+
+    @Test
+    @DisplayName("DELETE /v1/users API는 token에 해당하는 유저가 삭제되면 200 OK를 반환한다.")
+    void DELETE_USER_SUCCESS() throws Exception {
+        // given
+        String nickname = "delete_user_success";
+        String email = "delete_user_success";
+
+        var token = "bearer " + createUserAndSetToken(nickname, email);
+
+        // when
+        var result = deleteUser(token);
+
+        // then
+        result.andExpect(status().isOk());
+    }
+
+    private String createUserAndSetToken(String nickname, String email) {
+        Long userId = userInitializer.saveUserWithOAuth(Provider.DEFAULT, nickname, email, Instant.now());
+        Long targetId = targetInitializer.saveTargetAndGetId(nickname, Instant.now());
+
+        var token = jwtUtils.createAccessToken(Set.of(new Payload(Payload.Key.USER_ID, String.valueOf(userId)),
+            new Payload(Payload.Key.TARGET_ID, String.valueOf(targetId))));
+
+        applicationEventPublisher.publishEvent(
+            MockUserRegisterEvent.builder().expectedToken("bearer " + token).expectedId(targetId).build());
+
+        return token;
+    }
+}

--- a/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/updatetarget/TargetPositionUpdateAcceptanceTest.java
+++ b/api/acceptance-test/src/test/java/me/nalab/luffy/api/acceptance/test/user/updatetarget/TargetPositionUpdateAcceptanceTest.java
@@ -41,7 +41,7 @@ class TargetPositionUpdateAcceptanceTest extends UserAcceptanceTestSupporter {
 		// given
 		String nickname = "nickname";
 		Long targetId = targetInitializer.saveTargetAndGetId(nickname, Instant.now());
-		String token = "token";
+		String token = "bearer token";
 		applicationEventPublisher.publishEvent(MockUserRegisterEvent.builder()
 			.expectedToken(token)
 			.expectedId(targetId)

--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/AuthenticateHeaderPrefix.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/AuthenticateHeaderPrefix.java
@@ -1,0 +1,7 @@
+package me.nalab.auth.interceptor;
+
+public enum AuthenticateHeaderPrefix {
+
+    BEARER,
+    ;
+}

--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
@@ -32,7 +32,7 @@ public class JwtDecryptInterceptor implements HandlerInterceptor {
 			throwIfCannotValidToken(token);
 			Long targetId = getTargetId(token);
 			request.setAttribute("logined", targetId);
-			request.setAttribute("tokenType", token.split(" ")[0]);
+			request.setAttribute("tokenType", AuthenticateHeaderPrefix.valueOf(token.split(" ")[0].toUpperCase()));
 			request.setAttribute("tokenValue", token.split(" ")[1]);
 		}
 		return true;

--- a/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
+++ b/auth/auth-interceptor/src/main/java/me/nalab/auth/interceptor/JwtDecryptInterceptor.java
@@ -32,6 +32,8 @@ public class JwtDecryptInterceptor implements HandlerInterceptor {
 			throwIfCannotValidToken(token);
 			Long targetId = getTargetId(token);
 			request.setAttribute("logined", targetId);
+			request.setAttribute("tokenType", token.split(" ")[0]);
+			request.setAttribute("tokenValue", token.split(" ")[1]);
 		}
 		return true;
 	}

--- a/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/AuthenticateHeaderPrefix.java
+++ b/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/AuthenticateHeaderPrefix.java
@@ -1,0 +1,7 @@
+package me.nalab.auth.mock.interceptor;
+
+public enum AuthenticateHeaderPrefix {
+
+    BEARER,
+    ;
+}

--- a/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
+++ b/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
@@ -26,6 +26,8 @@ public class MockAuthInterceptor implements HandlerInterceptor {
 			String token = request.getHeader("Authorization");
 			throwIfCannotValidToken(token);
 			request.setAttribute("logined", expectedId);
+			request.setAttribute("tokenType", token.split(" ")[0]);
+			request.setAttribute("tokenValue", token.split(" ")[1]);
 		}
 		return true;
 	}

--- a/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
+++ b/auth/auth-mock/src/main/java/me/nalab/auth/mock/interceptor/MockAuthInterceptor.java
@@ -26,7 +26,7 @@ public class MockAuthInterceptor implements HandlerInterceptor {
 			String token = request.getHeader("Authorization");
 			throwIfCannotValidToken(token);
 			request.setAttribute("logined", expectedId);
-			request.setAttribute("tokenType", token.split(" ")[0]);
+			request.setAttribute("tokenType", AuthenticateHeaderPrefix.valueOf(token.split(" ")[0].toUpperCase()));
 			request.setAttribute("tokenValue", token.split(" ")[1]);
 		}
 		return true;

--- a/auth/auth-mock/src/test/java/me/nalab/auth/mock/interceptor/MockAuthInterceptorTest.java
+++ b/auth/auth-mock/src/test/java/me/nalab/auth/mock/interceptor/MockAuthInterceptorTest.java
@@ -62,24 +62,24 @@ class MockAuthInterceptorTest extends AbstractMockAuthTest {
 
 	static Stream<Arguments> successSources() {
 		return Stream.of(
-			of(HttpMethod.POST, "/v1/surveys", "token1", 1L)
-			, of(HttpMethod.POST, "/v1/surveys", "token1", 2L)
-			, of(HttpMethod.GET, "/v1/surveys-id", "token3", 3L)
-			, of(HttpMethod.GET, "/v1/questions?survey-id=4", "token4", 4L)
-			, of(HttpMethod.GET, "/v1/feedbacks?survey-id=5", "token5", 5L)
-			, of(HttpMethod.GET, "/v1/feedbacks/6", "token6", 6L)
-			, of(HttpMethod.GET, "/v1/feedbacks/summary?survey-id=7", "token7", 7L)
-			, of(HttpMethod.GET, "/v1/feedbacks?question-id=8", "token8", 8L)
+			of(HttpMethod.POST, "/v1/surveys", "bearer token1", 1L)
+			, of(HttpMethod.POST, "/v1/surveys", "bearer token1", 2L)
+			, of(HttpMethod.GET, "/v1/surveys-id", "bearer token3", 3L)
+			, of(HttpMethod.GET, "/v1/questions?survey-id=4", "bearer token4", 4L)
+			, of(HttpMethod.GET, "/v1/feedbacks?survey-id=5", "bearer token5", 5L)
+			, of(HttpMethod.GET, "/v1/feedbacks/6", "bearer token6", 6L)
+			, of(HttpMethod.GET, "/v1/feedbacks/summary?survey-id=7", "bearer token7", 7L)
+			, of(HttpMethod.GET, "/v1/feedbacks?question-id=8", "bearer token8", 8L)
 		);
 	}
 
 	static Stream<Arguments> failSources() {
 		return Stream.of(
 			of(HttpMethod.POST, "/v1/surveys", null, null, null)
-			, of(HttpMethod.GET, "/v1/users", null, "token2", 2L)
-			, of(HttpMethod.GET, "/v1/users", "token3", null, 3L)
-			, of(HttpMethod.GET, "/v1/users", "token4", "4nekot", 4L)
-			, of(HttpMethod.GET, "/v1/users", "token4", "token4", null)
+			, of(HttpMethod.GET, "/v1/users", null, "bearer token2", 2L)
+			, of(HttpMethod.GET, "/v1/users", "bearer token3", null, 3L)
+			, of(HttpMethod.GET, "/v1/users", "bearer token4", "bearer 4nekot", 4L)
+			, of(HttpMethod.GET, "/v1/users", "bearer token4", "bearer token4", null)
 		);
 	}
 

--- a/user/user-application/src/main/java/me/nalab/user/application/port/in/UserDeleteUseCase.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/port/in/UserDeleteUseCase.java
@@ -1,0 +1,9 @@
+package me.nalab.user.application.port.in;
+
+public interface UserDeleteUseCase {
+
+    /*
+        토큰에 해당하는 유저를 삭제합니다.
+     */
+    void deleteByToken(String token);
+}

--- a/user/user-application/src/main/java/me/nalab/user/application/port/out/persistence/UserDeletePort.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/port/out/persistence/UserDeletePort.java
@@ -1,0 +1,9 @@
+package me.nalab.user.application.port.out.persistence;
+
+public interface UserDeletePort {
+
+    /*
+        user id에 해당하는 유저를 삭제합니다.
+     */
+    void deleteUserById(Long userId);
+}

--- a/user/user-application/src/main/java/me/nalab/user/application/service/UserDeleteService.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/service/UserDeleteService.java
@@ -17,11 +17,7 @@ public class UserDeleteService implements UserDeleteUseCase {
     @Override
     @Transactional
     public void deleteByToken(String token) {
-        var tokenInfo = loginedUserGetByTokenPort.decryptToken(getTokenValuePart(token));
+        var tokenInfo = loginedUserGetByTokenPort.decryptToken(token);
         userDeletePort.deleteUserById(tokenInfo.getUserId());
-    }
-
-    private String getTokenValuePart(String token) {
-        return token.split(" ")[1];
     }
 }

--- a/user/user-application/src/main/java/me/nalab/user/application/service/UserDeleteService.java
+++ b/user/user-application/src/main/java/me/nalab/user/application/service/UserDeleteService.java
@@ -1,0 +1,27 @@
+package me.nalab.user.application.service;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.user.application.port.in.UserDeleteUseCase;
+import me.nalab.user.application.port.out.persistence.LoginedUserGetByTokenPort;
+import me.nalab.user.application.port.out.persistence.UserDeletePort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserDeleteService implements UserDeleteUseCase {
+
+    private final LoginedUserGetByTokenPort loginedUserGetByTokenPort;
+    private final UserDeletePort userDeletePort;
+
+    @Override
+    @Transactional
+    public void deleteByToken(String token) {
+        var tokenInfo = loginedUserGetByTokenPort.decryptToken(getTokenValuePart(token));
+        userDeletePort.deleteUserById(tokenInfo.getUserId());
+    }
+
+    private String getTokenValuePart(String token) {
+        return token.split(" ")[1];
+    }
+}

--- a/user/user-jpa-adapter/src/main/java/me/nalab/user/jpa/adaptor/create/UserDeleteAdaptor.java
+++ b/user/user-jpa-adapter/src/main/java/me/nalab/user/jpa/adaptor/create/UserDeleteAdaptor.java
@@ -1,0 +1,21 @@
+package me.nalab.user.jpa.adaptor.create;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.user.application.port.out.persistence.UserDeletePort;
+import me.nalab.user.jpa.adaptor.create.repository.UserJpaRepository;
+import me.nalab.user.jpa.adaptor.create.repository.UserOAuthInfoJpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserDeleteAdaptor implements UserDeletePort {
+
+    private final UserJpaRepository userJpaRepository;
+    private final UserOAuthInfoJpaRepository userOAuthInfoJpaRepository;
+
+    @Override
+    public void deleteUserById(Long userId) {
+        userOAuthInfoJpaRepository.deleteByUserId(userId);
+        userJpaRepository.deleteById(userId);
+    }
+}

--- a/user/user-jpa-adapter/src/main/java/me/nalab/user/jpa/adaptor/create/UserDeleteAdaptor.java
+++ b/user/user-jpa-adapter/src/main/java/me/nalab/user/jpa/adaptor/create/UserDeleteAdaptor.java
@@ -15,7 +15,9 @@ public class UserDeleteAdaptor implements UserDeletePort {
 
     @Override
     public void deleteUserById(Long userId) {
-        userOAuthInfoJpaRepository.deleteByUserId(userId);
-        userJpaRepository.deleteById(userId);
+        var user = userJpaRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("Cannot find exist user"));
+        userOAuthInfoJpaRepository.deleteByUserId(user.getId());
+        userJpaRepository.deleteById(user.getId());
     }
 }

--- a/user/user-jpa-adapter/src/main/java/me/nalab/user/jpa/adaptor/create/UserGetAdaptor.java
+++ b/user/user-jpa-adapter/src/main/java/me/nalab/user/jpa/adaptor/create/UserGetAdaptor.java
@@ -5,9 +5,9 @@ import me.nalab.user.application.port.out.persistence.UserGetPort;
 import me.nalab.user.domain.user.User;
 import me.nalab.user.jpa.adaptor.create.common.mapper.UserObjectMapper;
 import me.nalab.user.jpa.adaptor.create.repository.UserJpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
 
-@Repository
+@Service
 @RequiredArgsConstructor
 public class UserGetAdaptor implements UserGetPort {
 

--- a/user/user-jpa-adapter/src/main/java/me/nalab/user/jpa/adaptor/create/repository/UserOAuthInfoJpaRepository.java
+++ b/user/user-jpa-adapter/src/main/java/me/nalab/user/jpa/adaptor/create/repository/UserOAuthInfoJpaRepository.java
@@ -2,6 +2,9 @@ package me.nalab.user.jpa.adaptor.create.repository;
 
 import me.nalab.core.data.user.UserOAuthInfoEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,4 +12,8 @@ import java.util.Optional;
 @Repository
 public interface UserOAuthInfoJpaRepository extends JpaRepository<UserOAuthInfoEntity, Long> {
     Optional<UserOAuthInfoEntity> findByProviderAndEmail(String provider, String email);
+
+    @Modifying
+    @Query("delete from UserOAuthInfoEntity u where u.userEntity.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/DeleteUserController.java
+++ b/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/DeleteUserController.java
@@ -1,0 +1,25 @@
+package me.nalab.user.web.adaptor.logined;
+
+import lombok.RequiredArgsConstructor;
+import me.nalab.user.application.port.in.UserDeleteUseCase;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class DeleteUserController {
+
+    private final UserDeleteUseCase userDeleteUseCase;
+
+    @DeleteMapping("/users")
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteUser(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+        userDeleteUseCase.deleteByToken(token);
+    }
+}

--- a/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/DeleteUserController.java
+++ b/user/user-web-adaptor/src/main/java/me/nalab/user/web/adaptor/logined/DeleteUserController.java
@@ -2,10 +2,9 @@ package me.nalab.user.web.adaptor.logined;
 
 import lombok.RequiredArgsConstructor;
 import me.nalab.user.application.port.in.UserDeleteUseCase;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +18,7 @@ public class DeleteUserController {
 
     @DeleteMapping("/users")
     @ResponseStatus(HttpStatus.OK)
-    public void deleteUser(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+    public void deleteUser(@RequestAttribute("tokenValue") String token) {
         userDeleteUseCase.deleteByToken(token);
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 : [행위] 도메인이 드러나는 설명 
-->

## 어떤 기능을 개발했나요?
token을 받아서 유저를 삭제하는 API를 개발했습니다.

## 어떻게 해결했나요?
- [x] token에 해당하는 유저 삭제 API 개발
- [x] UserOauthInfoEntity, UserEntity 삭제
	- (유저 삭제되면 다음 로그인 email, provider 를 받을때 새로운 유저로 가입되어서 중복조회 발생 x)
    - (target 찾을때, 위 이유 때문에 삭제되면 같은 타겟 안나옴)
- [x] 인수테스트 작성

## 이슈 넘버
- close #404 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
